### PR TITLE
feat(dashboard): wire OnboardingChecklist into dashboard home (PLZ-032)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,10 +1,13 @@
 import { redirect } from 'next/navigation';
+import { Suspense } from 'react';
 import Link from 'next/link';
 import { ShoppingBag, Banknote, Clock, CheckCircle, ExternalLink } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { StatusBadge } from '@/components/ui/StatusBadge';
 import { PaymentBadge } from '@/components/ui/PaymentBadge';
 import { CopyButton } from './CopyButton';
+import { getOnboardingData } from '@/lib/db/onboarding';
+import { OnboardingChecklist, OnboardingChecklistSkeleton } from '@/components/onboarding/OnboardingChecklist';
 import type { Merchant, Order, OrderStatus, PaymentMethod } from '@/types/supabase';
 
 function formatPrice(centimes: number): string {
@@ -52,6 +55,8 @@ export default async function DashboardPage() {
     .maybeSingle<Pick<Merchant, 'id' | 'store_name' | 'store_slug'>>();
 
   if (!merchant) redirect('/onboarding');
+
+  const onboardingData = await getOnboardingData(user.id);
 
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
@@ -124,6 +129,13 @@ export default async function DashboardPage() {
           </h1>
           <p className="text-sm text-[#78716C] mt-1 capitalize">{formatDate()}</p>
         </div>
+
+        {/* Onboarding checklist — only shown when store is not yet live */}
+        {onboardingData !== null && !onboardingData.isOnline && (
+          <Suspense fallback={<OnboardingChecklistSkeleton />}>
+            <OnboardingChecklist data={onboardingData} />
+          </Suspense>
+        )}
 
         {/* Stats grid — 2 cols mobile, 4 cols desktop */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 mb-6 md:mb-8">


### PR DESCRIPTION
PLZ-032 — Wire OnboardingChecklist into dashboard home

## What this does

Wires Hamza's `OnboardingChecklist` component into `app/dashboard/page.tsx`. The checklist renders above the stats grid inside a `Suspense` boundary (skeleton shown during load). It is only displayed when `onboardingData` is non-null **and** `is_online = false` — merchants who are already live never see it.

**Depends on:** PR #20 (feat(onboarding): OnboardingChecklist widget — merged).

## Changes

- `app/dashboard/page.tsx` — sole file changed:
  - Imports `getOnboardingData` from `lib/db/onboarding`
  - Imports `OnboardingChecklist` + `OnboardingChecklistSkeleton` from `components/onboarding/OnboardingChecklist`
  - Calls `getOnboardingData(user.id)` in the server component
  - Renders `<OnboardingChecklist data={onboardingData} />` wrapped in `<Suspense fallback={<OnboardingChecklistSkeleton />}>` above the stats grid, guarded by `onboardingData !== null && !onboardingData.isOnline`

## How to test

1. Sign in as a merchant with `is_online = false` → dashboard shows OnboardingChecklist above the 4 stat cards
2. Sign in as a merchant with `is_online = true` → checklist is absent, stats grid renders at the top
3. Throttle network (slow 3G) → skeleton placeholder renders while data loads, then checklist appears
4. Complete all required steps and publish → checklist disappears (handled inside the component, no changes needed here)

## Checklist
- [x] TypeScript passes (`npx tsc --noEmit` — 0 errors)
- [x] Lint passes (`npm run lint` — 0 warnings, 0 errors)
- [x] Only `app/dashboard/page.tsx` modified — no cross-territory touches
- [x] Suspense + skeleton in place — no layout shift on load
- [x] Guard condition: `onboardingData !== null && !onboardingData.isOnline` — safe for live merchants
- [x] Rebased onto origin/main after PR #20 merge — no conflicts

## Notes for QA (Anas)
- Verify checklist position: it must sit **above** the 2×4 stats grid, not inside it
- Confirm skeleton matches `OnboardingChecklistSkeleton` height so there is no layout shift when data resolves
- Test the `is_online = true` path explicitly — checklist must be fully absent from the DOM
- No new i18n keys added in this PR — all strings live in Hamza's component

/cc @Anas for review