### PR TITLE
fix(auth): PLZ-035 — Auth flow end-to-end + desktop spacing fix

### DIFF
--- a/app/auth/login/actions.ts
+++ b/app/auth/login/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
 
 type LoginResult = { error: string | null };
 
@@ -21,4 +22,25 @@ export async function loginAction(formData: FormData): Promise<LoginResult> {
   }
 
   return { error: null };
+}
+
+/**
+ * Check whether a phone number is already registered as a merchant.
+ * Returns the merchant's store name so the PIN login screen can greet them.
+ */
+export async function checkPhoneAction(
+  phone: string,
+): Promise<{ exists: boolean; merchantName: string | null }> {
+  const service = createServiceClient();
+
+  const { data } = await service
+    .from('merchants')
+    .select('store_name')
+    .eq('phone', phone)
+    .maybeSingle();
+
+  return {
+    exists: data !== null,
+    merchantName: data?.store_name ?? null,
+  };
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { checkPhoneAction } from './actions';
 
 function formatPhoneDisplay(value: string): string {
   if (!value) return '';
@@ -30,7 +31,7 @@ export default function PhoneEntryPage() {
     }
   }
 
-  function handleSubmit() {
+  async function handleSubmit() {
     if (!validatePhone(phone)) {
       setError(true);
       return;
@@ -41,24 +42,36 @@ export default function PhoneEntryPage() {
     const fullPhone = `+212${phone}`;
     // TODO: [SMS stub — implement real OTP send via SMS provider]
 
-    // Navigate to OTP page with phone in search params
-    const params = new URLSearchParams({ phone: fullPhone });
-    router.push(`/auth/otp?${params.toString()}`);
+    // Check if phone is already registered → returning user goes to PIN login,
+    // new user goes through OTP → PIN setup flow.
+    try {
+      const { exists, merchantName } = await checkPhoneAction(fullPhone);
+      const params = new URLSearchParams({ phone: fullPhone });
+      if (exists) {
+        if (merchantName) params.set('name', merchantName);
+        router.push(`/auth/pin-login?${params.toString()}`);
+      } else {
+        router.push(`/auth/otp?${params.toString()}`);
+      }
+    } catch {
+      setLoading(false);
+      setError(true);
+    }
   }
 
   const isValid = validatePhone(phone);
 
   return (
-    <div className="min-h-screen bg-white flex flex-col md:items-center md:justify-center md:bg-[#FAFAF9]">
-      <div className="flex-1 flex flex-col md:flex-none md:w-full md:max-w-[420px] md:bg-white md:rounded-2xl md:shadow-lg md:p-8">
+    <main className="min-h-screen bg-[#FAFAF9] flex items-center justify-center">
+      <div className="w-full max-w-[420px] bg-white rounded-2xl shadow-lg p-8">
         {/* Logo area */}
-        <div className="flex-[0.3] flex flex-col items-center justify-center pt-12 md:pt-0">
+        <div className="flex flex-col items-center justify-center pb-8">
           <div className="text-[28px] font-bold text-[#2563EB]">{t('logo')}</div>
           <div className="text-sm text-[#78716C] text-center mt-2">{t('tagline')}</div>
         </div>
 
         {/* Phone input */}
-        <div className="flex-[0.4] px-4 mt-8">
+        <div className="mt-2">
           <label className="block text-[13px] font-medium text-[#78716C] mb-2">
             {t('phoneLabel')}
           </label>
@@ -87,7 +100,7 @@ export default function PhoneEntryPage() {
         </div>
 
         {/* CTA */}
-        <div className="flex-[0.3] px-4 pb-8 flex flex-col justify-end">
+        <div className="mt-8">
           <button
             onClick={handleSubmit}
             disabled={!isValid || loading}
@@ -104,6 +117,6 @@ export default function PhoneEntryPage() {
           </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/app/auth/otp/page.tsx
+++ b/app/auth/otp/page.tsx
@@ -35,7 +35,9 @@ function OTPContent() {
         const isCorrect = otp.join('') === '123456';
         if (isCorrect) {
           setIsSuccess(true);
-          setTimeout(() => router.push('/auth/pin-setup'), 1000);
+          // Pass phone through to pin-setup so it can create the Supabase user
+          const params = new URLSearchParams({ phone });
+          setTimeout(() => router.push(`/auth/pin-setup?${params.toString()}`), 1000);
         } else {
           const newAttempts = attempts - 1;
           setAttempts(newAttempts);
@@ -99,102 +101,100 @@ function OTPContent() {
   }
 
   return (
-    <div className="min-h-screen bg-white flex flex-col md:items-center md:justify-center md:bg-[#FAFAF9]">
-      <div className="flex-1 flex flex-col md:flex-none md:w-full md:max-w-[420px] md:bg-white md:rounded-2xl md:shadow-lg md:p-8">
+    <main className="min-h-screen bg-[#FAFAF9] flex items-center justify-center">
+      <div className="w-full max-w-[420px] bg-white rounded-2xl shadow-lg p-8">
         {/* TODO PLZ-033: migrate to i18n */}
         <button
           onClick={() => router.back()}
-          className="w-11 h-11 flex items-center justify-center hover:bg-[#F5F5F4] rounded-lg transition-colors mt-4 ms-4 md:mt-0 md:ms-0"
+          className="w-11 h-11 flex items-center justify-center hover:bg-[#F5F5F4] rounded-lg transition-colors -ms-2 mb-4"
           aria-label="Retour"
         >
           <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
         </button>
 
-        <div className="flex-1 px-4 mt-12">
-          <h1 className="text-2xl font-semibold text-[#1C1917]">{t('title')}</h1>
-          <p className="text-sm text-[#78716C] mt-2">
-            {t('subtitle')} <span className="text-[#1C1917]">{phone}</span>
-          </p>
+        <h1 className="text-2xl font-semibold text-[#1C1917]">{t('title')}</h1>
+        <p className="text-sm text-[#78716C] mt-2">
+          {t('subtitle')} <span className="text-[#1C1917]">{phone}</span>
+        </p>
 
-          {/* 6-box OTP input */}
-          <div className="flex justify-center gap-2 mt-8">
-            {otp.map((digit, index) => (
-              <input
-                key={index}
-                ref={(el) => { inputRefs.current[index] = el; }}
-                type="tel"
-                inputMode="numeric"
-                maxLength={6}
-                value={digit}
-                onChange={(e) => handleChange(index, e.target.value)}
-                onKeyDown={(e) => handleKeyDown(index, e)}
-                onPaste={(e) => {
-                  e.preventDefault();
-                  handleChange(index, e.clipboardData.getData('text'));
-                }}
-                disabled={isLocked || isChecking}
-                className={`w-12 h-14 text-xl font-semibold text-center rounded-xl transition-all outline-none ${
-                  isSuccess
-                    ? 'border-2 border-[#16A34A] bg-[#F0FDF4]'
-                    : error
-                    ? 'border border-[#DC2626] bg-[#FEF2F2]'
-                    : digit
-                    ? 'bg-[#F8FAFC] border border-[#E2E8F0]'
-                    : 'border-2 border-[#2563EB] ring-2 ring-[#2563EB]/20'
-                } ${isLocked ? 'bg-[#F5F5F4] text-[#A8A29E]' : 'text-[#1C1917]'}`}
-              />
-            ))}
-          </div>
-
-          {isChecking && (
-            <div className="flex items-center justify-center gap-2 mt-4 text-[13px] text-[#78716C]">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              {t('checking')}
-            </div>
-          )}
-
-          {isSuccess && (
-            <div className="flex items-center justify-center gap-2 mt-4 text-[13px] text-[#16A34A]">
-              <CheckCircle2 className="w-4 h-4" />
-              {t('success')}
-            </div>
-          )}
-
-          {error && !isLocked && (
-            <div className="text-[13px] text-[#DC2626] text-center mt-4">
-              {t('error', { attempts })}
-            </div>
-          )}
-
-          {isLocked && (
-            <div className="text-[13px] text-[#DC2626] text-center mt-4 font-medium">
-              {t('locked')}
-            </div>
-          )}
-
-          {!isLocked && (
-            <div className="mt-6 text-center">
-              {countdown > 0 ? (
-                <div className="text-[13px] text-[#A8A29E]">
-                  {t('resendCountdown', { time: formatCountdown(countdown) })}
-                </div>
-              ) : (
-                <button
-                  onClick={handleResend}
-                  className="text-[13px] text-[#2563EB] underline"
-                >
-                  {t('resend')}
-                </button>
-              )}
-            </div>
-          )}
-
-          <button className="text-[13px] text-[#78716C] text-center mt-4 w-full">
-            {t('wrongNumber')}
-          </button>
+        {/* 6-box OTP input */}
+        <div className="flex justify-center gap-2 mt-8">
+          {otp.map((digit, index) => (
+            <input
+              key={index}
+              ref={(el) => { inputRefs.current[index] = el; }}
+              type="tel"
+              inputMode="numeric"
+              maxLength={6}
+              value={digit}
+              onChange={(e) => handleChange(index, e.target.value)}
+              onKeyDown={(e) => handleKeyDown(index, e)}
+              onPaste={(e) => {
+                e.preventDefault();
+                handleChange(index, e.clipboardData.getData('text'));
+              }}
+              disabled={isLocked || isChecking}
+              className={`w-12 h-14 text-xl font-semibold text-center rounded-xl transition-all outline-none ${
+                isSuccess
+                  ? 'border-2 border-[#16A34A] bg-[#F0FDF4]'
+                  : error
+                  ? 'border border-[#DC2626] bg-[#FEF2F2]'
+                  : digit
+                  ? 'bg-[#F8FAFC] border border-[#E2E8F0]'
+                  : 'border-2 border-[#2563EB] ring-2 ring-[#2563EB]/20'
+              } ${isLocked ? 'bg-[#F5F5F4] text-[#A8A29E]' : 'text-[#1C1917]'}`}
+            />
+          ))}
         </div>
+
+        {isChecking && (
+          <div className="flex items-center justify-center gap-2 mt-4 text-[13px] text-[#78716C]">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            {t('checking')}
+          </div>
+        )}
+
+        {isSuccess && (
+          <div className="flex items-center justify-center gap-2 mt-4 text-[13px] text-[#16A34A]">
+            <CheckCircle2 className="w-4 h-4" />
+            {t('success')}
+          </div>
+        )}
+
+        {error && !isLocked && (
+          <div className="text-[13px] text-[#DC2626] text-center mt-4">
+            {t('error', { attempts })}
+          </div>
+        )}
+
+        {isLocked && (
+          <div className="text-[13px] text-[#DC2626] text-center mt-4 font-medium">
+            {t('locked')}
+          </div>
+        )}
+
+        {!isLocked && (
+          <div className="mt-6 text-center">
+            {countdown > 0 ? (
+              <div className="text-[13px] text-[#A8A29E]">
+                {t('resendCountdown', { time: formatCountdown(countdown) })}
+              </div>
+            ) : (
+              <button
+                onClick={handleResend}
+                className="text-[13px] text-[#2563EB] underline"
+              >
+                {t('resend')}
+              </button>
+            )}
+          </div>
+        )}
+
+        <button className="text-[13px] text-[#78716C] text-center mt-4 w-full">
+          {t('wrongNumber')}
+        </button>
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/app/auth/pin-login/actions.ts
+++ b/app/auth/pin-login/actions.ts
@@ -1,0 +1,36 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+
+type PinLoginInput = { phone: string; pin: string };
+type PinLoginResult = { error: string } | undefined;
+
+/**
+ * Verifies the PIN for a returning merchant and establishes a Supabase session.
+ * Uses the same phone-as-email + PIN-as-password convention as completePinSetupAction.
+ *
+ * On success calls redirect('/dashboard') which must NOT be inside a try/catch.
+ */
+export async function verifyPinLoginAction(
+  input: PinLoginInput,
+): Promise<PinLoginResult> {
+  const { phone, pin } = input;
+
+  if (!phone || pin.length !== 4) {
+    return { error: 'invalid_input' };
+  }
+
+  const syntheticEmail = `${phone.replace('+', '')}@plaza-merchant.internal`;
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.signInWithPassword({
+    email: syntheticEmail,
+    password: pin,
+  });
+
+  if (error) return { error: 'invalid_pin' };
+
+  // redirect() must be called OUTSIDE try/catch — it throws NEXT_REDIRECT.
+  redirect('/dashboard');
+}

--- a/app/auth/pin-login/page.tsx
+++ b/app/auth/pin-login/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Delete } from 'lucide-react';
+import { verifyPinLoginAction } from './actions';
 
 const NUMPAD = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
 
@@ -28,23 +29,23 @@ function PINLoginContent() {
   const [attempts, setAttempts] = useState(3);
   const [error, setError] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
-    if (pin.length === 4) {
-      const timer = setTimeout(() => {
-        // TODO: [PIN stub — implement real PIN verification server-side]
-        // Hardcoded PIN for dev: 1234
-        const isCorrect = pin === '1234';
-        if (isCorrect) {
-          router.push('/dashboard');
-        } else {
+    if (pin.length === 4 && !isSubmitting) {
+      setIsSubmitting(true);
+      const timer = setTimeout(async () => {
+        const result = await verifyPinLoginAction({ phone: phoneNumber, pin });
+        if (result?.error) {
           const newAttempts = attempts - 1;
           setAttempts(newAttempts);
           setError(true);
           setPin('');
+          setIsSubmitting(false);
           if (newAttempts === 0) setIsLocked(true);
           setTimeout(() => setError(false), 3000);
         }
+        // On success verifyPinLoginAction redirects to /dashboard — no client code needed.
       }, 500);
       return () => clearTimeout(timer);
     }
@@ -52,34 +53,32 @@ function PINLoginContent() {
   }, [pin]);
 
   function handleNumberPress(num: string) {
-    if (!isLocked && pin.length < 4) setPin(pin + num);
+    if (!isLocked && !isSubmitting && pin.length < 4) setPin(pin + num);
   }
 
   function handleBackspace() {
-    if (!isLocked) setPin(pin.slice(0, -1));
+    if (!isLocked && !isSubmitting) setPin(pin.slice(0, -1));
   }
 
   return (
-    <div className="min-h-screen bg-white flex flex-col md:items-center md:justify-center md:bg-[#FAFAF9]">
-      <div className="flex-1 flex flex-col md:flex-none md:w-full md:max-w-[420px] md:bg-white md:rounded-2xl md:shadow-lg md:p-8">
+    <main className="min-h-screen bg-[#FAFAF9] flex items-center justify-center">
+      <div className="w-full max-w-[420px] bg-white rounded-2xl shadow-lg p-8">
         {/* Logo */}
-        <div className="pt-16 px-4">
+        <div className="pb-6">
           <div className="text-[28px] font-bold text-[#2563EB] text-center">{t('logo')}</div>
         </div>
 
         {/* Merchant card */}
-        <div className="px-4 mt-8">
-          <div className="bg-white rounded-2xl shadow-sm p-4 flex flex-col items-center">
-            <div className="w-16 h-16 bg-[#EFF6FF] rounded-full flex items-center justify-center">
-              <span className="text-xl font-semibold text-[#2563EB]">{getInitials(merchantName)}</span>
-            </div>
-            <div className="text-lg font-semibold text-[#1C1917] mt-2">{merchantName}</div>
-            <div className="text-[13px] text-[#78716C]">{phoneNumber}</div>
+        <div className="bg-[#FAFAF9] rounded-2xl p-4 flex flex-col items-center">
+          <div className="w-16 h-16 bg-[#EFF6FF] rounded-full flex items-center justify-center">
+            <span className="text-xl font-semibold text-[#2563EB]">{getInitials(merchantName)}</span>
           </div>
+          <div className="text-lg font-semibold text-[#1C1917] mt-2">{merchantName}</div>
+          <div className="text-[13px] text-[#78716C]">{phoneNumber}</div>
         </div>
 
         {/* PIN input */}
-        <div className="flex-1 px-4 mt-8">
+        <div className="mt-8">
           <div className="text-xs text-[#78716C] uppercase tracking-wide text-center">{t('pinLabel')}</div>
 
           <div className="flex justify-center gap-4 mt-6">
@@ -115,9 +114,9 @@ function PINLoginContent() {
               <button
                 key={num}
                 onClick={() => handleNumberPress(num.toString())}
-                disabled={isLocked}
+                disabled={isLocked || isSubmitting}
                 className={`h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all ${
-                  isLocked ? 'opacity-50 cursor-not-allowed' : ''
+                  isLocked || isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
                 }`}
               >
                 {num}
@@ -126,9 +125,9 @@ function PINLoginContent() {
             <div />
             <button
               onClick={() => handleNumberPress('0')}
-              disabled={isLocked}
+              disabled={isLocked || isSubmitting}
               className={`h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all ${
-                isLocked ? 'opacity-50 cursor-not-allowed' : ''
+                isLocked || isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
               }`}
             >
               0
@@ -136,9 +135,9 @@ function PINLoginContent() {
             {/* TODO PLZ-033: migrate to i18n */}
             <button
               onClick={handleBackspace}
-              disabled={isLocked}
+              disabled={isLocked || isSubmitting}
               className={`h-16 rounded-2xl bg-white border border-[#E2E8F0] flex items-center justify-center hover:bg-[#F0F4FF] active:scale-95 transition-all ${
-                isLocked ? 'opacity-50 cursor-not-allowed' : ''
+                isLocked || isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
               }`}
               aria-label="Effacer"
             >
@@ -154,7 +153,7 @@ function PINLoginContent() {
           </button>
         </div>
 
-        <div className="pb-8 text-center">
+        <div className="pt-8 text-center">
           <button
             onClick={() => router.push('/auth/login')}
             className="text-xs text-[#A8A29E]"
@@ -163,7 +162,7 @@ function PINLoginContent() {
           </button>
         </div>
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/app/auth/pin-setup/actions.ts
+++ b/app/auth/pin-setup/actions.ts
@@ -1,0 +1,80 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+
+type PinSetupInput = { phone: string; pin: string };
+type PinSetupResult = { error: string } | undefined;
+
+/**
+ * Registers a new merchant auth user (using phone-as-email + PIN-as-password
+ * convention for the stub phase), saves the merchant phone, and establishes a
+ * Supabase session so the middleware allows access to /dashboard.
+ *
+ * Called after the user confirms their PIN on the pin-setup screen.
+ * On success this function calls redirect('/dashboard') — which throws
+ * NEXT_REDIRECT internally so it must NOT be wrapped in try/catch.
+ */
+export async function completePinSetupAction(
+  input: PinSetupInput,
+): Promise<PinSetupResult> {
+  const { phone, pin } = input;
+
+  if (!phone || pin.length !== 4) {
+    return { error: 'invalid_input' };
+  }
+
+  // Derive a deterministic synthetic email from the phone number.
+  // This lets us use Supabase email+password auth as the session layer
+  // while the product-facing UX is phone+PIN.
+  const syntheticEmail = `${phone.replace('+', '')}@plaza-merchant.internal`;
+
+  const service = createServiceClient();
+
+  // Try to create the auth user. If it already exists (re-registration after
+  // a failed flow) we sign in instead.
+  const { data: signUpData, error: signUpError } = await service.auth.admin.createUser({
+    email: syntheticEmail,
+    password: pin,
+    email_confirm: true, // auto-confirm so session is available immediately
+  });
+
+  let userId: string | null = null;
+
+  if (signUpError) {
+    if (signUpError.message.includes('already been registered')) {
+      // User exists — update their password to the new PIN and fetch their id.
+      const { data: listData } = await service.auth.admin.listUsers();
+      const existing = listData?.users?.find((u) => u.email === syntheticEmail);
+      if (!existing) return { error: 'user_not_found' };
+
+      await service.auth.admin.updateUserById(existing.id, { password: pin });
+      userId = existing.id;
+    } else {
+      return { error: signUpError.message };
+    }
+  } else {
+    userId = signUpData.user?.id ?? null;
+  }
+
+  if (!userId) return { error: 'no_user_id' };
+
+  // Upsert the merchant phone so the returning-user check works on next login.
+  await service
+    .from('merchants')
+    .update({ phone })
+    .eq('user_id', userId);
+
+  // Sign in with the regular (non-admin) client to get a session cookie.
+  const supabase = await createClient();
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email: syntheticEmail,
+    password: pin,
+  });
+
+  if (signInError) return { error: signInError.message };
+
+  // redirect() must be called OUTSIDE try/catch — it throws NEXT_REDIRECT.
+  redirect('/dashboard');
+}

--- a/app/auth/pin-setup/page.tsx
+++ b/app/auth/pin-setup/page.tsx
@@ -1,17 +1,20 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useEffect, useRef, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ArrowLeft, Delete, Fingerprint } from 'lucide-react';
+import { completePinSetupAction } from './actions';
 
 type Step = 1 | 2;
 
 const NUMPAD = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
 
-export default function PINSetupPage() {
+function PINSetupContent() {
   const t = useTranslations('auth.pin');
-  const router = useRouter();
+  const searchParams = useSearchParams();
+  const phone = searchParams.get('phone') ?? '';
+  const submitting = useRef(false);
 
   const [step, setStep] = useState<Step>(1);
   const [pin, setPin] = useState('');
@@ -29,10 +32,19 @@ export default function PINSetupPage() {
 
   // Validate confirm PIN
   useEffect(() => {
-    if (confirmPin.length === 4) {
+    if (confirmPin.length === 4 && !submitting.current) {
       if (pin === confirmPin) {
-        // TODO: [PIN stub — send bcrypt PIN hash to server for storage]
-        setTimeout(() => router.push('/dashboard'), 500);
+        submitting.current = true;
+        // Create Supabase auth user and establish session, then redirect to /dashboard.
+        completePinSetupAction({ phone, pin }).then((result) => {
+          if (result?.error) {
+            submitting.current = false;
+            setError(true);
+            setConfirmPin('');
+          }
+          // On success the server action calls redirect() which throws NEXT_REDIRECT —
+          // the browser follows the redirect automatically.
+        });
       } else {
         setError(true);
         setShake(true);
@@ -47,7 +59,7 @@ export default function PINSetupPage() {
         };
       }
     }
-  }, [confirmPin, pin, router]);
+  }, [confirmPin, pin, phone]);
 
   function handleNumberPress(num: string) {
     if (step === 1 && pin.length < 4) setPin(pin + num);
@@ -70,10 +82,10 @@ export default function PINSetupPage() {
   const currentPin = step === 1 ? pin : confirmPin;
 
   return (
-    <div className="min-h-screen bg-white flex flex-col md:items-center md:justify-center md:bg-[#FAFAF9]">
-      <div className="flex-1 flex flex-col md:flex-none md:w-full md:max-w-[420px] md:bg-white md:rounded-2xl md:shadow-lg md:p-8">
+    <main className="min-h-screen bg-[#FAFAF9] flex items-center justify-center">
+      <div className="w-full max-w-[420px] bg-white rounded-2xl shadow-lg p-8">
         {/* Header */}
-        <div className="flex items-center justify-between px-4 pt-4 md:pt-0">
+        <div className="flex items-center justify-between mb-8">
           {/* TODO PLZ-033: migrate to i18n */}
           <button
             onClick={handleBack}
@@ -92,75 +104,81 @@ export default function PINSetupPage() {
           <div className="w-11" />
         </div>
 
-        <div className="flex-1 px-4 mt-8">
-          <div className="text-xs text-[#78716C] uppercase tracking-wide">{t('secureLabel')}</div>
-          <h1 className="text-[22px] font-semibold text-[#1C1917] mt-2">
-            {step === 1 ? t('createTitle') : t('confirmTitle')}
-          </h1>
-          <p className="text-sm text-[#78716C] mt-2">{t('subtitle')}</p>
+        <div className="text-xs text-[#78716C] uppercase tracking-wide">{t('secureLabel')}</div>
+        <h1 className="text-[22px] font-semibold text-[#1C1917] mt-2">
+          {step === 1 ? t('createTitle') : t('confirmTitle')}
+        </h1>
+        <p className="text-sm text-[#78716C] mt-2">{t('subtitle')}</p>
 
-          {/* PIN dots */}
-          <div className={`flex justify-center gap-4 mt-8 ${shake ? 'animate-bounce' : ''}`}>
-            {([0, 1, 2, 3] as const).map((index) => (
-              <div
-                key={index}
-                className={`w-5 h-5 rounded-full transition-all ${
-                  currentPin.length > index
-                    ? error ? 'bg-[#DC2626]' : 'bg-[#2563EB]'
-                    : 'border-2 border-[#E2E8F0] bg-white'
-                }`}
-              />
-            ))}
-          </div>
+        {/* PIN dots */}
+        <div className={`flex justify-center gap-4 mt-8 ${shake ? 'animate-bounce' : ''}`}>
+          {([0, 1, 2, 3] as const).map((index) => (
+            <div
+              key={index}
+              className={`w-5 h-5 rounded-full transition-all ${
+                currentPin.length > index
+                  ? error ? 'bg-[#DC2626]' : 'bg-[#2563EB]'
+                  : 'border-2 border-[#E2E8F0] bg-white'
+              }`}
+            />
+          ))}
+        </div>
 
-          {error && (
-            <div className="text-[13px] text-[#DC2626] text-center mt-4">{t('mismatch')}</div>
-          )}
+        {error && (
+          <div className="text-[13px] text-[#DC2626] text-center mt-4">{t('mismatch')}</div>
+        )}
 
-          {/* Custom numpad */}
-          <div className="grid grid-cols-3 gap-3 mt-8 max-w-[280px] mx-auto">
-            {NUMPAD.map((num) => (
-              <button
-                key={num}
-                onClick={() => handleNumberPress(num.toString())}
-                className="h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all"
-              >
-                {num}
-              </button>
-            ))}
-            {/* Bottom row */}
-            <div />
+        {/* Custom numpad */}
+        <div className="grid grid-cols-3 gap-3 mt-8 max-w-[280px] mx-auto">
+          {NUMPAD.map((num) => (
             <button
-              onClick={() => handleNumberPress('0')}
+              key={num}
+              onClick={() => handleNumberPress(num.toString())}
               className="h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all"
             >
-              0
+              {num}
             </button>
-            {/* TODO PLZ-033: migrate to i18n */}
-            <button
-              onClick={handleBackspace}
-              className="h-16 rounded-2xl bg-white border border-[#E2E8F0] flex items-center justify-center hover:bg-[#F0F4FF] active:scale-95 transition-all"
-              aria-label="Effacer"
-            >
-              <Delete className="w-5 h-5 text-[#1C1917]" />
-            </button>
-          </div>
+          ))}
+          {/* Bottom row */}
+          <div />
+          <button
+            onClick={() => handleNumberPress('0')}
+            className="h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all"
+          >
+            0
+          </button>
+          {/* TODO PLZ-033: migrate to i18n */}
+          <button
+            onClick={handleBackspace}
+            className="h-16 rounded-2xl bg-white border border-[#E2E8F0] flex items-center justify-center hover:bg-[#F0F4FF] active:scale-95 transition-all"
+            aria-label="Effacer"
+          >
+            <Delete className="w-5 h-5 text-[#1C1917]" />
+          </button>
+        </div>
 
-          {/* Biometric (disabled, coming soon) */}
-          <div className="flex items-center gap-3 mt-6 p-4 bg-[#FAFAF9] rounded-xl">
-            <Fingerprint className="w-5 h-5 text-[#A8A29E] flex-shrink-0" />
-            <span className="text-[13px] text-[#78716C] flex-1">{t('biometricLabel')}</span>
-            <div className="flex items-center gap-2">
-              <div className="w-10 h-6 rounded-full bg-[#E2E8F0] relative">
-                <div className="w-5 h-5 rounded-full bg-white absolute start-0.5 top-0.5" />
-              </div>
-              <span className="text-xs text-[#A8A29E] bg-[#F5F5F4] px-2 py-1 rounded-full">
-                {t('biometricSoon')}
-              </span>
+        {/* Biometric (disabled, coming soon) */}
+        <div className="flex items-center gap-3 mt-6 p-4 bg-[#FAFAF9] rounded-xl">
+          <Fingerprint className="w-5 h-5 text-[#A8A29E] flex-shrink-0" />
+          <span className="text-[13px] text-[#78716C] flex-1">{t('biometricLabel')}</span>
+          <div className="flex items-center gap-2">
+            <div className="w-10 h-6 rounded-full bg-[#E2E8F0] relative">
+              <div className="w-5 h-5 rounded-full bg-white absolute start-0.5 top-0.5" />
             </div>
+            <span className="text-xs text-[#A8A29E] bg-[#F5F5F4] px-2 py-1 rounded-full">
+              {t('biometricSoon')}
+            </span>
           </div>
         </div>
       </div>
-    </div>
+    </main>
+  );
+}
+
+export default function PINSetupPage() {
+  return (
+    <Suspense>
+      <PINSetupContent />
+    </Suspense>
   );
 }

--- a/components/layout/DashboardLayout.tsx
+++ b/components/layout/DashboardLayout.tsx
@@ -10,17 +10,17 @@ type Props = {
 export function DashboardLayout({ children, merchantName }: Props) {
   return (
     <div className="flex min-h-screen bg-[#FAFAF9]">
-      {/* Sidebar — desktop only */}
-      <aside className="hidden md:flex fixed left-0 top-0 h-screen w-[240px] bg-white border-r border-[#E2E8F0] flex-col z-40">
+      {/* Sidebar — desktop only (lg = 1024px+) */}
+      <aside className="hidden lg:flex fixed left-0 top-0 h-screen w-[240px] bg-white border-r border-[#E2E8F0] flex-col z-40">
         <SidebarNav merchantName={merchantName} />
       </aside>
 
-      {/* Main content */}
-      <main className="flex-1 md:ml-[240px] pb-16 md:pb-0">
+      {/* Main content — offset by sidebar width on desktop */}
+      <main className="flex-1 lg:ml-[240px] pb-16 lg:pb-0">
         {children}
       </main>
 
-      {/* Bottom nav — mobile only */}
+      {/* Bottom nav — mobile only (hidden on lg+) */}
       <MobileNav />
     </div>
   );

--- a/components/layout/MobileNav.tsx
+++ b/components/layout/MobileNav.tsx
@@ -21,7 +21,7 @@ export function MobileNav() {
     exact ? pathname === href || pathname === `${href}/` : pathname.startsWith(href);
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-[#E2E8F0] h-16 flex items-center justify-around z-50 md:hidden">
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-[#E2E8F0] h-16 flex items-center justify-around z-50 lg:hidden">
       {tabs.map((tab) => {
         const active = isActive(tab.href, tab.exact);
         const Icon = tab.icon;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -100,19 +100,7 @@ const config: Config = {
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
-      /* 8px base grid */
-      spacing: {
-        '1': '8px',
-        '2': '16px',
-        '3': '24px',
-        '4': '32px',
-        '5': '40px',
-        '6': '48px',
-        '8': '64px',
-        '10': '80px',
-        '12': '96px',
-        '16': '128px',
-      },
+
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `tailwind.config.ts` had a custom `spacing` block doubling all standard values (`p-4` = 32px instead of 16px). Block deleted — standard Tailwind spacing restored.
- **Auth flow wired end-to-end**: New user (`/login → /otp → /pin-setup → /dashboard`) and returning user (`/login → /pin-login → /dashboard`) now both establish a real Supabase session so the middleware allows access to `/dashboard`.
- **DashboardLayout breakpoint**: Sidebar breakpoint widened from `md` (768px) to `lg` (1024px) so the layout renders correctly at standard desktop widths.

## Auth flow details

### New session strategy
Uses a `phone-as-email` convention (`{e164digits}@plaza-merchant.internal`) with PIN as password. This lets us use Supabase's standard email+password session layer while presenting a phone+PIN UX to merchants.

### Files added
- `app/auth/pin-setup/actions.ts` — `completePinSetupAction`: uses service-role admin to create/upsert the Supabase user, then signs in via the server client to set the session cookie. `redirect('/dashboard')` is called **outside** `try/catch` so `NEXT_REDIRECT` propagates correctly.
- `app/auth/pin-login/actions.ts` — `verifyPinLoginAction`: signs in the returning user via `signInWithPassword`, then `redirect('/dashboard')` outside `try/catch`.

### Files modified
- `app/auth/pin-setup/page.tsx`: calls `completePinSetupAction`, reads `phone` from search params, guards double-submit with `useRef`, wrapped in `Suspense` for `useSearchParams`
- `app/auth/pin-login/page.tsx`: calls `verifyPinLoginAction` instead of bare `router.push`, `isSubmitting` state disables numpad during server action
- `app/auth/otp/page.tsx`: forwards `phone` param to `/auth/pin-setup` on OTP success
- `app/auth/login/page.tsx` + `actions.ts`: adds `checkPhoneAction` to branch new vs returning user flows

## Test plan

- [ ] New user: enter a phone not in `merchants.phone` → /otp (code `123456`) → /pin-setup (set any 4-digit PIN) → lands on /dashboard with session
- [ ] Returning user: enter a registered phone → /pin-login (PIN = whatever was set at setup) → lands on /dashboard
- [ ] Unauthenticated access to `/dashboard` redirects to `/auth/login`
- [ ] Desktop (1280px): auth screens show as centered card, dashboard sidebar visible on lg+
- [ ] Mobile (375px): auth screens full-width, bottom nav visible, sidebar hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)