### PR TITLE
feat(PLZ-038): customer PIN + hourly delivery slots

### DIFF
--- a/app/store/[slug]/_components/DeliverySlotPicker.tsx
+++ b/app/store/[slug]/_components/DeliverySlotPicker.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useMemo } from 'react';
+import { format } from 'date-fns/format';
+import { addDays } from 'date-fns/addDays';
+import { isToday } from 'date-fns/isToday';
+import { isTomorrow } from 'date-fns/isTomorrow';
+import { fr } from 'date-fns/locale/fr';
+
+// All possible hourly slots 09:00–20:00
+const ALL_SLOTS = [
+  '09:00-10:00','10:00-11:00','11:00-12:00','12:00-13:00',
+  '13:00-14:00','14:00-15:00','15:00-16:00','16:00-17:00',
+  '17:00-18:00','18:00-19:00','19:00-20:00',
+];
+
+interface WorkingHours {
+  [day: string]: { open: string; close: string } | null;
+}
+
+interface Props {
+  selectedDate: Date | null;
+  selectedSlot: string;
+  onDateChange: (date: Date) => void;
+  onSlotChange: (slot: string) => void;
+  workingHours?: WorkingHours | null;
+}
+
+export function DeliverySlotPicker({ selectedDate, selectedSlot, onDateChange, onSlotChange, workingHours }: Props) {
+  // Generate date options: today + next 7 days
+  const dateOptions = useMemo(() => {
+    return Array.from({ length: 8 }, (_, i) => addDays(new Date(), i));
+  }, []);
+
+  // Filter slots for the selected date based on merchant working hours
+  const availableSlots = useMemo(() => {
+    if (!selectedDate) return ALL_SLOTS;
+
+    // Filter by merchant working hours if provided
+    if (workingHours) {
+      const dayName = format(selectedDate, 'EEEE', { locale: fr }).toLowerCase();
+      const hours = workingHours[dayName];
+      if (hours) {
+        return ALL_SLOTS.filter((slot) => {
+          const [start] = slot.split('-');
+          return start >= hours.open && start < hours.close;
+        });
+      }
+    }
+
+    // If today, filter out past slots
+    if (isToday(selectedDate)) {
+      const nowHour = new Date().getHours();
+      return ALL_SLOTS.filter((slot) => {
+        const startHour = parseInt(slot.split(':')[0], 10);
+        return startHour > nowHour;
+      });
+    }
+
+    return ALL_SLOTS;
+  }, [selectedDate, workingHours]);
+
+  function formatDateLabel(date: Date) {
+    if (isToday(date)) return "Aujourd'hui";
+    if (isTomorrow(date)) return 'Demain';
+    return format(date, 'EEE d MMM', { locale: fr });
+  }
+
+  function formatSlotLabel(slot: string) {
+    const [start, end] = slot.split('-');
+    return `${start} \u2013 ${end}`;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Date chips */}
+      <div>
+        <label className="block text-[14px] font-medium text-[#1C1917] mb-2">
+          Date de livraison <span className="text-[#DC2626]">*</span>
+        </label>
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {dateOptions.map((date) => {
+            const isSelected = selectedDate?.toDateString() === date.toDateString();
+            return (
+              <button
+                key={date.toISOString()}
+                type="button"
+                onClick={() => onDateChange(date)}
+                className={`flex-shrink-0 px-3 py-2 rounded-lg text-[13px] font-medium border transition-colors whitespace-nowrap ${
+                  isSelected
+                    ? 'bg-[#2563EB] text-white border-[#2563EB]'
+                    : 'bg-white text-[#1C1917] border-[#E2E8F0] hover:border-[#2563EB] hover:text-[#2563EB]'
+                }`}
+              >
+                {formatDateLabel(date)}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Time slot dropdown */}
+      <div>
+        <label className="block text-[14px] font-medium text-[#1C1917] mb-2">
+          Heure de livraison <span className="text-[#DC2626]">*</span>
+        </label>
+        {availableSlots.length === 0 ? (
+          <p className="text-[13px] text-[#78716C]">Aucun cr\u00e9neau disponible pour cette date.</p>
+        ) : (
+          <select
+            value={selectedSlot}
+            onChange={(e) => onSlotChange(e.target.value)}
+            className="w-full h-11 px-4 bg-white border border-[#E2E8F0] rounded-lg text-[15px] text-[#1C1917] focus:outline-none focus:ring-2 focus:ring-[#2563EB]/20 focus:border-[#2563EB]"
+          >
+            {availableSlots.map((slot) => (
+              <option key={slot} value={slot}>
+                {formatSlotLabel(slot)}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/store/[slug]/_components/OrderStatusClient.tsx
+++ b/app/store/[slug]/_components/OrderStatusClient.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Phone, Check, RefreshCw, Clock } from 'lucide-react';
+import { motion } from 'motion/react';
+import type { Order, OrderItem, Customer, OrderStatus } from '@/types/supabase';
+
+type OrderWithRelations = Order & {
+  customer: Customer;
+  order_items: OrderItem[];
+};
+
+interface Step {
+  id: number;
+  label: string;
+  eta?: string;
+  completed: boolean;
+  current: boolean;
+}
+
+function formatDeliverySlot(slot: string | null): string {
+  if (!slot) return '';
+  return slot.replace('-', ' \u2013 ').replace(/(\d{2}):00/g, '$1h00');
+}
+
+function buildSteps(status: OrderStatus, deliverySlot: string | null): Step[] {
+  const slotEnd = deliverySlot ? deliverySlot.split('-')[1] : null;
+  const steps: Step[] = [
+    { id: 1, label: 'Commande re\u00e7ue', completed: false, current: false },
+    { id: 2, label: 'En cours de confirmation', eta: 'Dans 30\u201360 min', completed: false, current: false },
+    {
+      id: 3,
+      label: 'En route',
+      eta: deliverySlot ? `D\u00e9part ${formatDeliverySlot(deliverySlot)}` : 'Selon votre cr\u00e9neau',
+      completed: false,
+      current: false,
+    },
+    {
+      id: 4,
+      label: 'Livr\u00e9e',
+      eta: slotEnd ? `Avant ${slotEnd.replace(':00', 'h00')}` : undefined,
+      completed: false,
+      current: false,
+    },
+  ];
+
+  if (status === 'pending') {
+    steps[0].completed = true;
+    steps[1].current = true;
+  } else if (status === 'confirmed') {
+    steps[0].completed = true;
+    steps[1].completed = true;
+    steps[2].current = true;
+  } else if (status === 'dispatched') {
+    steps[0].completed = true;
+    steps[1].completed = true;
+    steps[2].completed = true;
+    steps[3].current = true;
+  } else if (status === 'delivered') {
+    steps.forEach((s) => {
+      s.completed = true;
+      s.current = false;
+    });
+  }
+
+  return steps;
+}
+
+interface Props {
+  order: OrderWithRelations;
+  merchantPhone: string | null;
+}
+
+export function OrderStatusClient({ order, merchantPhone }: Props) {
+  const router = useRouter();
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (order.status === 'delivered' || order.status === 'cancelled') return;
+    const interval = setInterval(() => router.refresh(), 30_000);
+    return () => clearInterval(interval);
+  }, [order.status, router]);
+
+  const steps = buildSteps(order.status, order.delivery_slot ?? null);
+  const isCancelled = order.status === 'cancelled';
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    router.refresh();
+    setTimeout(() => setRefreshing(false), 1500);
+  };
+
+  const whatsappHref = merchantPhone
+    ? `https://wa.me/212${merchantPhone.replace(/^0/, '')}`
+    : null;
+
+  return (
+    <div className="min-h-screen bg-[#FAFAF9]" style={{ paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))' }}>
+      <div className="sticky top-0 z-50 bg-white border-b border-[#E2E8F0] h-14 flex items-center px-4">
+        <button
+          onClick={() => router.back()}
+          className="w-10 h-10 flex items-center justify-center -ml-2"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <div className="ml-2">
+          <h1 className="font-bold text-[16px]">Commande #{order.order_number}</h1>
+        </div>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="px-4 py-6 space-y-6"
+      >
+        {/* Order Status */}
+        <div className="bg-white rounded-xl p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="font-bold text-[16px]">\u00c9tat de la commande</h2>
+            <button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              className="flex items-center gap-1.5 text-[13px] text-[#2563EB] font-medium disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+              Actualiser
+            </button>
+          </div>
+
+          {isCancelled ? (
+            <div className="flex items-center gap-3 p-4 bg-red-50 border border-red-200 rounded-xl">
+              <svg
+                className="w-5 h-5 text-red-600 flex-shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+              <p className="text-[14px] text-red-700 font-medium">
+                Cette commande a \u00e9t\u00e9 annul\u00e9e.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-0">
+              {steps.map((step, index) => (
+                <div key={step.id} className="flex gap-4">
+                  <div className="flex flex-col items-center">
+                    <div
+                      className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                        step.completed
+                          ? 'bg-[#16A34A]'
+                          : step.current
+                            ? 'bg-[#2563EB] animate-pulse'
+                            : 'bg-gray-200'
+                      }`}
+                    >
+                      {step.completed ? (
+                        <Check className="w-4 h-4 text-white" strokeWidth={3} />
+                      ) : step.current ? (
+                        <div className="w-2.5 h-2.5 bg-white rounded-full" />
+                      ) : null}
+                    </div>
+                    {index < steps.length - 1 && (
+                      <div
+                        className={`w-0.5 h-16 ${step.completed ? 'bg-[#16A34A]' : 'bg-gray-200'}`}
+                      />
+                    )}
+                  </div>
+                  <div className="flex-1 pb-16">
+                    <h3
+                      className={`font-medium text-[15px] ${
+                        step.completed || step.current ? 'text-[#1C1917]' : 'text-[#A8A29E]'
+                      }`}
+                    >
+                      {step.label}
+                    </h3>
+                    {step.eta && step.current && (
+                      <p className="text-[12px] text-[#78716C] mt-0.5">{step.eta}</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {order.customer_pin && (
+          <div className="bg-[#EFF6FF] border border-[#2563EB]/20 rounded-xl p-4 flex items-center gap-4">
+            <div className="flex gap-1.5">
+              {String(order.customer_pin).padStart(4, '0').split('').map((d, i) => (
+                <div key={i} className="w-8 h-9 bg-white border border-[#2563EB] rounded flex items-center justify-center text-[16px] font-bold text-[#1C1917]">
+                  {d}
+                </div>
+              ))}
+            </div>
+            <p className="text-[12px] text-[#78716C] flex-1">Code \u00e0 communiquer au livreur \u00e0 la r\u00e9ception</p>
+          </div>
+        )}
+
+        {order.delivery_slot && (
+          <div className="bg-[#EFF6FF] rounded-xl p-4 flex items-start gap-3">
+            <Clock className="w-5 h-5 text-[#2563EB] flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-[13px] font-medium text-[#1C1917]">Cr\u00e9neau de livraison</p>
+              <p className="text-[13px] text-[#78716C]">{formatDeliverySlot(order.delivery_slot)}</p>
+            </div>
+          </div>
+        )}
+
+        {!order.delivery_slot && order.notes && (
+          <div className="bg-[#EFF6FF] rounded-xl p-4 flex items-start gap-3">
+            <Clock className="w-5 h-5 text-[#2563EB] flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-[13px] font-medium text-[#1C1917]">Cr\u00e9neau demand\u00e9</p>
+              <p className="text-[13px] text-[#78716C]">{order.notes}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Customer Info */}
+        <div className="bg-white rounded-xl p-4 space-y-3">
+          <h2 className="font-bold text-[15px]">Informations client</h2>
+          <div className="text-[14px] space-y-1">
+            <p className="font-medium">
+              {order.customer.full_name} \u00b7 {order.customer.phone}
+            </p>
+            {order.customer.address && (
+              <p className="text-[#78716C]">
+                {order.customer.address}
+                {order.customer.city ? `, ${order.customer.city}` : ''}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Order Items */}
+        <div className="bg-white rounded-xl p-4 space-y-3">
+          <h2 className="font-bold text-[15px]">Articles command\u00e9s</h2>
+          <div className="space-y-2">
+            {order.order_items.map((item) => (
+              <div key={item.id} className="flex items-center gap-3 py-1">
+                <div className="w-12 h-12 rounded bg-gray-100 flex items-center justify-center">
+                  <svg
+                    className="w-6 h-6 text-gray-400"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+                    />
+                  </svg>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[13px] font-medium truncate">{item.name_fr}</p>
+                  <p className="text-[12px] text-[#78716C]">Qt\u00e9 {item.quantity}</p>
+                </div>
+                <span className="text-[13px] font-medium">
+                  {item.unit_price * item.quantity} MAD
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="border-t border-[#E2E8F0] pt-3 space-y-1.5">
+            <div className="flex justify-between text-[14px]">
+              <span className="text-[#78716C]">Sous-total</span>
+              <span className="font-medium">{order.subtotal} MAD</span>
+            </div>
+            <div className="flex justify-between text-[14px]">
+              <span className="text-[#78716C]">Livraison</span>
+              <span className="text-[#16A34A] font-medium">
+                {order.delivery_fee === 0 ? 'Gratuite' : `${order.delivery_fee} MAD`}
+              </span>
+            </div>
+            <div className="flex justify-between text-[14px] pt-2 border-t border-[#E2E8F0]">
+              <span className="font-bold">Total</span>
+              <span className="font-bold">{order.total} MAD</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="space-y-3 pb-6">
+          {whatsappHref && (
+            <a
+              href={whatsappHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full h-12 border-2 border-[#2563EB] text-[#2563EB] rounded-lg font-medium flex items-center justify-center gap-2 hover:bg-[#EFF6FF] transition-colors"
+            >
+              <Phone className="w-4 h-4" />
+              Contacter la boutique
+            </a>
+          )}
+          <a
+            href="mailto:support@plaza.ma"
+            className="w-full text-[13px] text-[#78716C] py-2 underline text-center block"
+          >
+            Besoin d&apos;aide ? Contacter Plaza
+          </a>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/app/store/[slug]/actions.ts
+++ b/app/store/[slug]/actions.ts
@@ -1,0 +1,177 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import type {
+  Merchant,
+  Product,
+  Order,
+  OrderItem,
+  Customer,
+  CustomerInsert,
+  OrderInsert,
+  OrderItemInsert,
+  PaymentMethod,
+} from '@/types/supabase';
+
+// ---------------------------------------------------------------------------
+// Payload type for createOrder (implemented by Hamza)
+// ---------------------------------------------------------------------------
+
+export type CreateOrderPayload = {
+  orderNumber: string;
+  merchantId: string;
+  merchantSlug: string;
+  customerName: string;
+  customerPhone: string;
+  customerAddress: string | null;
+  customerCity: string | null;
+  deliveryDate?: string | null;    // ISO date string YYYY-MM-DD
+  deliverySlot?: string | null;    // "09:00-10:00"
+  paymentMethod: PaymentMethod;
+  notes: string | null;
+  items: Array<{
+    productId: string;
+    nameFr: string;
+    quantity: number;
+    unitPrice: number; // in MAD
+  }>;
+  subtotal: number; // in MAD
+  deliveryFee: number; // in MAD
+  total: number; // in MAD
+};
+
+// ---------------------------------------------------------------------------
+// Read helpers
+// ---------------------------------------------------------------------------
+
+export async function getMerchantBySlug(
+  slug: string,
+): Promise<Merchant | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from('merchants')
+    .select('*')
+    .eq('store_slug', slug)
+    .single<Merchant>();
+  return data ?? null;
+}
+
+export async function getProductsByMerchant(
+  merchantId: string,
+): Promise<Product[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from('products')
+    .select('*')
+    .eq('merchant_id', merchantId)
+    .eq('is_visible', true)
+    .order('created_at', { ascending: false })
+    .returns<Product[]>();
+  return data ?? [];
+}
+
+export async function getProductById(
+  id: string,
+  merchantId: string,
+): Promise<Product | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from('products')
+    .select('*')
+    .eq('id', id)
+    .eq('merchant_id', merchantId)
+    .eq('is_visible', true)
+    .single<Product>();
+  return data ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Write helpers
+// ---------------------------------------------------------------------------
+
+export async function createOrder(
+  payload: CreateOrderPayload,
+): Promise<{ orderNumber: string; customerPin: number }> {
+  const supabase = await createClient();
+
+  const customerPin = Math.floor(1000 + Math.random() * 9000);
+
+  // 1. Insert customer
+  const { data: customer, error: custError } = (await supabase
+    .from('customers')
+    .insert({
+      full_name: payload.customerName,
+      phone: payload.customerPhone,
+      address: payload.customerAddress,
+      city: payload.customerCity,
+    } as never)
+    .select('id')
+    .single()) as { data: { id: string } | null; error: unknown };
+  if (custError || !customer) throw new Error('Failed to create customer');
+
+  // 2. Insert order (retry on order_number collision)
+  let orderNumber = payload.orderNumber;
+  let order: { id: string } | null = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const { data, error } = (await supabase
+      .from('orders')
+      .insert({
+        order_number: orderNumber,
+        merchant_id: payload.merchantId,
+        customer_id: customer.id,
+        payment_method: payload.paymentMethod,
+        subtotal: payload.subtotal,
+        delivery_fee: payload.deliveryFee,
+        total: payload.total,
+        notes: payload.notes,
+        customer_pin: customerPin,
+        delivery_date: payload.deliveryDate ?? null,
+        delivery_slot: payload.deliverySlot ?? null,
+      } as never)
+      .select('id')
+      .single()) as { data: { id: string } | null; error: unknown };
+    if (!error && data) {
+      order = data;
+      break;
+    }
+    // regenerate on collision
+    orderNumber = `PLZ-${Math.floor(Math.random() * 900 + 100)}`;
+  }
+  if (!order) throw new Error('Failed to create order');
+
+  // 3. Insert order_items
+  const orderItems = payload.items.map((item) => ({
+    order_id: order!.id,
+    product_id: item.productId || null,
+    name_fr: item.nameFr,
+    quantity: item.quantity,
+    unit_price: item.unitPrice,
+  }));
+  const { error: itemsError } = await supabase
+    .from('order_items')
+    .insert(orderItems as never);
+  if (itemsError) throw new Error('Failed to create order items');
+
+  return { orderNumber, customerPin };
+}
+
+export async function getOrderByNumber(
+  orderNumber: string,
+): Promise<(Order & { customer: Customer; order_items: OrderItem[] }) | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('orders')
+    .select(
+      `
+      *,
+      customer:customers(*),
+      order_items(*)
+    `,
+    )
+    .eq('order_number', orderNumber)
+    .single();
+  if (error || !data) return null;
+  return data as Order & { customer: Customer; order_items: OrderItem[] };
+}
+
+// getSlugByOrderNumber lives in app/_actions/trackOrder.ts — import from there

--- a/app/store/[slug]/commande/page.tsx
+++ b/app/store/[slug]/commande/page.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { format } from 'date-fns/format';
+import { fr } from 'date-fns/locale/fr';
+import { ArrowLeft, CreditCard, Banknote } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useCart } from '../_components/CartProvider';
+import { DeliverySlotPicker } from '../_components/DeliverySlotPicker';
+import { MapLocationPicker } from '../_components/MapLocationPicker';
+import { getDeliveryFee, generateOrderNumber } from '../_lib/deliveryUtils';
+import { getMerchantBySlug } from '../actions';
+import type { Merchant } from '@/types/supabase';
+import type { PaymentMethod } from '@/types/supabase';
+
+
+type UIPaymentMethod = 'cash' | 'card-delivery';
+
+function uiPaymentToDb(method: UIPaymentMethod): PaymentMethod {
+  if (method === 'cash') return 'cod';
+  return 'terminal';
+}
+
+export default function CheckoutPage() {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const router = useRouter();
+  const { items, total } = useCart();
+
+  const [merchant, setMerchant] = useState<Merchant | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [paymentMethod, setPaymentMethod] = useState<UIPaymentMethod>('cash');
+  const [deliveryDate, setDeliveryDate] = useState<Date | null>(null);
+  const [deliverySlot, setDeliverySlot] = useState<string>('');
+
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [addressNotes, setAddressNotes] = useState('');
+  const [city, setCity] = useState('');
+  const [locationLat, setLocationLat] = useState<number | null>(null);
+  const [locationLng, setLocationLng] = useState<number | null>(null);
+
+  const [codConfirmed, setCodConfirmed] = useState(false);
+  useEffect(() => setCodConfirmed(false), [paymentMethod]);
+
+  useEffect(() => {
+    const today = new Date();
+    setDeliveryDate(today);
+    const nowHour = today.getHours();
+    const firstSlot = ['09:00-10:00','10:00-11:00','11:00-12:00','12:00-13:00',
+      '13:00-14:00','14:00-15:00','15:00-16:00','16:00-17:00',
+      '17:00-18:00','18:00-19:00','19:00-20:00']
+      .find(s => parseInt(s.split(':')[0], 10) > nowHour) ?? '09:00-10:00';
+    setDeliverySlot(firstSlot);
+  }, []);
+
+  useEffect(() => {
+    getMerchantBySlug(slug).then(setMerchant);
+  }, [slug]);
+
+  const threshold = merchant?.delivery_free_threshold ?? undefined;
+  const deliveryFee = getDeliveryFee(total, threshold);
+  const finalTotal = total + deliveryFee;
+
+  const isFormValid = (): boolean => {
+    if (!firstName.trim()) return false;
+    if (!lastName.trim()) return false;
+    if (!/^0[5-7]\d{8}$/.test(phone.trim())) return false;
+    if (!deliveryDate) return false;
+    if (!deliverySlot) return false;
+    if (locationLat === null || locationLng === null) return false;
+    if (!codConfirmed) return false;
+    return true;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isFormValid() || !merchant) return;
+    setLoading(true);
+
+    const orderNumber = generateOrderNumber();
+
+    const formattedDate = deliveryDate
+      ? format(deliveryDate, "d MMMM yyyy", { locale: fr })
+      : null;
+
+    sessionStorage.setItem(
+      'plaza_pending_order',
+      JSON.stringify({
+        name: `${firstName.trim()} ${lastName.trim()}`,
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        phone,
+        address: addressNotes,
+        city,
+        locationLat,
+        locationLng,
+        deliveryDate: deliveryDate?.toISOString().split('T')[0] ?? null,
+        deliverySlot,
+        deliveryDisplayDate: formattedDate,
+        deliveryDisplaySlot: deliverySlot,
+        paymentMethod,
+        paymentMethodDb: uiPaymentToDb(paymentMethod),
+        orderNumber,
+        merchantId: merchant.id,
+        merchantSlug: slug,
+        deliveryFeeThreshold: threshold ?? null,
+      }),
+    );
+
+    router.push(`/store/${slug}/verification`);
+  };
+
+  return (
+    <div className="min-h-screen bg-[#FAFAF9] pb-24">
+      <div className="sticky top-0 z-50 bg-white border-b border-[#E2E8F0] h-14 flex items-center px-4">
+        <button
+          onClick={() => router.back()}
+          className="w-10 h-10 flex items-center justify-center -ml-2"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <h1 className="font-bold text-[18px] ml-2">Passer la commande</h1>
+      </div>
+
+      <motion.form
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        onSubmit={handleSubmit}
+        className="max-w-2xl mx-auto px-4 py-6 space-y-6"
+      >
+        {/* Contact Information */}
+        <div className="bg-white rounded-xl p-5 space-y-4 border border-[#E2E8F0]">
+          <h2 className="font-bold text-[17px]">Informations de contact</h2>
+          <div>
+            <label className="block text-[14px] font-medium text-[#1C1917] mb-2">
+              Pr\u00e9nom <span className="text-[#DC2626] ml-0.5">*</span>
+            </label>
+            <input
+              type="text"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              placeholder="Votre pr\u00e9nom"
+              className="w-full h-12 px-4 bg-[#FAFAF9] border border-[#E2E8F0] rounded-lg text-[15px] focus:outline-none focus:ring-2 focus:ring-[#2563EB]/20 focus:border-[#2563EB]"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-[14px] font-medium text-[#1C1917] mb-2">
+              Nom <span className="text-[#DC2626] ml-0.5">*</span>
+            </label>
+            <input
+              type="text"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              placeholder="Votre nom"
+              className="w-full h-12 px-4 bg-[#FAFAF9] border border-[#E2E8F0] rounded-lg text-[15px] focus:outline-none focus:ring-2 focus:ring-[#2563EB]/20 focus:border-[#2563EB]"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-[14px] font-medium text-[#1C1917] mb-2">
+              T\u00e9l\u00e9phone <span className="text-[#DC2626] ml-0.5">*</span>
+            </label>
+            <input
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="06XXXXXXXX"
+              className="w-full h-12 px-4 bg-[#FAFAF9] border border-[#E2E8F0] rounded-lg text-[15px] focus:outline-none focus:ring-2 focus:ring-[#2563EB]/20 focus:border-[#2563EB]"
+              required
+            />
+          </div>
+        </div>
+
+        {/* Delivery Location */}
+        <div className="bg-white rounded-xl p-5 space-y-4 border border-[#E2E8F0]">
+          <h2 className="font-bold text-[17px]">Adresse de livraison <span className="text-[#DC2626] ml-0.5">*</span></h2>
+
+          <MapLocationPicker
+            onLocationSelect={(lat, lng, cityGuess) => {
+              setLocationLat(lat);
+              setLocationLng(lng);
+              if (cityGuess) setCity(cityGuess);
+            }}
+          />
+
+          <div>
+            <label className="block text-[14px] font-medium text-[#1C1917] mb-2">
+              Indications suppl\u00e9mentaires <span className="text-[#A8A29E] font-normal">(optionnel)</span>
+            </label>
+            <textarea
+              placeholder="\u00c9tage, code d'entr\u00e9e, point de rep\u00e8re..."
+              rows={2}
+              value={addressNotes}
+              onChange={(e) => setAddressNotes(e.target.value)}
+              className="w-full px-4 py-3 bg-[#FAFAF9] border border-[#E2E8F0] rounded-lg text-[15px] placeholder:text-[#A8A29E] focus:outline-none focus:ring-2 focus:ring-[#2563EB]/20 focus:border-[#2563EB] resize-none"
+            />
+          </div>
+        </div>
+
+        {/* Delivery Time */}
+        <div className="bg-white rounded-xl p-5 space-y-4 border border-[#E2E8F0]">
+          <h2 className="font-bold text-[17px]">Date de livraison souhait\u00e9e <span className="text-[#DC2626] ml-0.5">*</span></h2>
+          <DeliverySlotPicker
+            selectedDate={deliveryDate}
+            selectedSlot={deliverySlot}
+            onDateChange={setDeliveryDate}
+            onSlotChange={setDeliverySlot}
+            workingHours={null}
+          />
+        </div>
+
+        {/* Payment Method */}
+        <div className="bg-white rounded-xl p-5 space-y-4 border border-[#E2E8F0]">
+          <h2 className="font-bold text-[17px]">Mode de paiement</h2>
+
+          <button
+            type="button"
+            onClick={() => setPaymentMethod('cash')}
+            className={`w-full p-4 rounded-lg border-2 transition-all flex items-center gap-3 ${
+              paymentMethod === 'cash'
+                ? 'border-[#2563EB] bg-[#EFF6FF]'
+                : 'border-[#E2E8F0] bg-white hover:border-[#2563EB]/30'
+            }`}
+          >
+            <div
+              className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                paymentMethod === 'cash' ? 'border-[#2563EB]' : 'border-[#E2E8F0]'
+              }`}
+            >
+              {paymentMethod === 'cash' && (
+                <div className="w-3 h-3 rounded-full bg-[#2563EB]" />
+              )}
+            </div>
+            <Banknote className="w-5 h-5 text-[#78716C]" />
+            <div className="flex-1 text-left">
+              <div className="font-medium text-[15px]">Paiement \u00e0 la livraison</div>
+              <div className="text-[13px] text-[#78716C]">Payez en esp\u00e8ces au livreur</div>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setPaymentMethod('card-delivery')}
+            className={`w-full p-4 rounded-lg border-2 transition-all flex items-center gap-3 ${
+              paymentMethod === 'card-delivery'
+                ? 'border-[#2563EB] bg-[#EFF6FF]'
+                : 'border-[#E2E8F0] bg-white hover:border-[#2563EB]/30'
+            }`}
+          >
+            <div
+              className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                paymentMethod === 'card-delivery' ? 'border-[#2563EB]' : 'border-[#E2E8F0]'
+              }`}
+            >
+              {paymentMethod === 'card-delivery' && (
+                <div className="w-3 h-3 rounded-full bg-[#2563EB]" />
+              )}
+            </div>
+            <CreditCard className="w-5 h-5 text-[#78716C]" />
+            <div className="flex-1 text-left">
+              <div className="font-medium text-[15px]">Carte \u00e0 la livraison</div>
+              <div className="text-[13px] text-[#78716C]">Payez par carte au livreur</div>
+            </div>
+          </button>
+
+          {(paymentMethod === 'cash' || paymentMethod === 'card-delivery') && (
+            <label className="flex items-start gap-3 cursor-pointer pt-2 border-t border-[#E2E8F0]">
+              <input
+                type="checkbox"
+                checked={codConfirmed}
+                onChange={(e) => setCodConfirmed(e.target.checked)}
+                className="mt-0.5 w-5 h-5 accent-[#2563EB] flex-shrink-0 cursor-pointer"
+              />
+              <span className="text-[14px] text-[#78716C] leading-snug">
+                Je comprends que je paierai en{' '}
+                {paymentMethod === 'cash' ? 'esp\u00e8ces' : 'carte bancaire'} au moment de la
+                livraison. Aucun pr\u00e9paiement n&apos;est requis.
+              </span>
+            </label>
+          )}
+        </div>
+
+        {/* Order Summary */}
+        <div className="bg-white rounded-xl p-5 space-y-4 border border-[#E2E8F0]">
+          <h2 className="font-bold text-[17px]">R\u00e9sum\u00e9 de commande</h2>
+          <div className="space-y-3">
+            {items.map((item) => (
+              <div key={item.id} className="flex items-center gap-3 py-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={item.image}
+                  alt={item.name}
+                  className="w-14 h-14 rounded-lg object-cover"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-[14px] font-medium truncate">{item.name}</p>
+                  <p className="text-[13px] text-[#78716C]">Qt\u00e9 {item.quantity}</p>
+                </div>
+                <span className="text-[15px] font-medium">
+                  {item.price * item.quantity} MAD
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="border-t border-[#E2E8F0] pt-4 space-y-2">
+            <div className="flex justify-between text-[15px]">
+              <span className="text-[#78716C]">Sous-total</span>
+              <span className="font-medium">{total} MAD</span>
+            </div>
+            <div className="flex justify-between text-[15px]">
+              <span className="text-[#78716C]">Livraison</span>
+              <span
+                className={deliveryFee === 0 ? 'text-[#16A34A] font-medium' : 'font-medium'}
+              >
+                {deliveryFee === 0 ? 'Gratuit' : `${deliveryFee} MAD`}
+              </span>
+            </div>
+            {deliveryFee === 0 && (
+              <div className="flex items-center gap-1.5 text-[#16A34A] text-[13px] bg-[#F0FDF4] px-3 py-2 rounded-lg">
+                <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <span className="font-medium">Livraison gratuite appliqu\u00e9e !</span>
+              </div>
+            )}
+            <div className="flex justify-between pt-3 border-t border-[#E2E8F0]">
+              <span className="font-bold text-[19px]">Total</span>
+              <span className="font-bold text-[19px] text-[#2563EB]">{finalTotal} MAD</span>
+            </div>
+          </div>
+        </div>
+      </motion.form>
+
+      <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-[#E2E8F0] p-4">
+        <div className="max-w-2xl mx-auto">
+          <motion.button
+            type="button"
+            onClick={handleSubmit}
+            disabled={loading || !isFormValid() || !merchant}
+            whileTap={{ scale: 0.98 }}
+            className="w-full h-14 bg-[#2563EB] text-white rounded-lg font-medium text-[16px] hover:bg-[#1d4ed8] transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <>
+                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                Traitement...
+              </>
+            ) : (
+              `Confirmer la commande \u2022 ${finalTotal} MAD`
+            )}
+          </motion.button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/store/[slug]/confirmation/page.tsx
+++ b/app/store/[slug]/confirmation/page.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Check, Copy, CheckCheck, Clock } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useCart } from '../_components/CartProvider';
+import { getDeliveryFee } from '../_lib/deliveryUtils';
+import type { CartItem } from '../_components/CartProvider';
+
+interface ConfirmedOrder {
+  name?: string;
+  phone?: string;
+  address?: string;
+  city?: string;
+  deliveryDate?: string;
+  deliverySlot?: string;      // "09:00-10:00"
+  deliveryDisplayDate?: string;
+  deliveryDisplaySlot?: string;
+  paymentMethod?: string;
+  orderNumber?: string;
+  merchantId?: string;
+  deliveryFeeThreshold?: number | null;
+  merchantSlug?: string;
+  customerPin?: number;
+}
+
+export default function ConfirmationPage() {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const router = useRouter();
+  const { items, total, clearCart } = useCart();
+
+  const [order, setOrder] = useState<ConfirmedOrder>({});
+  const [animate, setAnimate] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [snapshotItems, setSnapshotItems] = useState<CartItem[]>([]);
+  const [snapshotTotal, setSnapshotTotal] = useState(0);
+
+  useEffect(() => {
+    setSnapshotItems([...items]);
+    setSnapshotTotal(total);
+    const stored = sessionStorage.getItem('plaza_pending_order');
+    if (stored) {
+      try {
+        setOrder(JSON.parse(stored) as ConfirmedOrder);
+      } catch {
+        // ignore
+      }
+    }
+    clearCart();
+    sessionStorage.removeItem('plaza_pending_order');
+    setTimeout(() => setAnimate(true), 100);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const orderNumber = order.orderNumber ?? 'PLZ-???';
+  const deliveryFee = getDeliveryFee(snapshotTotal, order.deliveryFeeThreshold ?? undefined);
+
+  const handleCopy = async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(orderNumber);
+      } else {
+        const textArea = document.createElement('textarea');
+        textArea.value = orderNumber;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+          document.execCommand('copy');
+        } catch {
+          // ignore
+        }
+        textArea.remove();
+      }
+    } catch {
+      // ignore
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="min-h-screen bg-[#FAFAF9] flex flex-col items-center justify-center p-4">
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="w-full max-w-md space-y-6"
+      >
+        <div className="bg-[#16A34A] h-28 -mx-4 flex items-center justify-center">
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: animate ? 1 : 0 }}
+            transition={{ type: 'spring', delay: 0.2 }}
+            className="w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-lg"
+          >
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: animate ? 1 : 0 }}
+              transition={{ delay: 0.4 }}
+            >
+              <Check className="w-10 h-10 text-[#16A34A]" strokeWidth={3} />
+            </motion.div>
+          </motion.div>
+        </div>
+
+        <div className="text-center space-y-4">
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3 }}
+            className="font-bold text-[26px]"
+          >
+            Commande confirm\u00e9e !
+          </motion.h1>
+
+          {order.name && (
+            <motion.p
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.35 }}
+              className="text-[15px] text-[#78716C]"
+            >
+              Merci, <span className="font-medium text-[#1C1917]">{order.name}</span> !
+            </motion.p>
+          )}
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.4 }}
+            className="bg-white rounded-xl p-5 border-2 border-[#2563EB] shadow-sm"
+          >
+            <div className="text-[13px] text-[#78716C] mb-2 font-medium">
+              \uD83D\uDCCB Votre num\u00e9ro de commande
+            </div>
+            <div className="flex items-center justify-center gap-3 mb-3">
+              <span className="font-bold text-[28px] text-[#2563EB] tracking-wide">
+                {orderNumber}
+              </span>
+              <button
+                onClick={handleCopy}
+                className="p-2 hover:bg-[#EFF6FF] rounded-lg transition-colors"
+              >
+                {copied ? (
+                  <CheckCheck className="w-5 h-5 text-[#16A34A]" />
+                ) : (
+                  <Copy className="w-5 h-5 text-[#78716C]" />
+                )}
+              </button>
+            </div>
+            <div className="bg-[#FEF3C7] border border-[#F59E0B] rounded-lg px-4 py-3">
+              <p className="text-[13px] text-[#92400E] font-medium">
+                \u26a0\uFE0F Conservez ce num\u00e9ro pour suivre votre commande
+              </p>
+            </div>
+          </motion.div>
+
+          {order.customerPin && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.45 }}
+              className="border-2 border-[#2563EB] bg-[#EFF6FF] rounded-xl p-5 text-center"
+            >
+              <p className="text-[13px] font-medium text-[#2563EB] mb-3">Votre code de r\u00e9ception</p>
+              <div className="flex justify-center gap-3 mb-3">
+                {String(order.customerPin).padStart(4, '0').split('').map((digit, i) => (
+                  <div key={i} className="w-12 h-14 bg-white border-2 border-[#2563EB] rounded-lg flex items-center justify-center text-[28px] font-bold text-[#1C1917]">
+                    {digit}
+                  </div>
+                ))}
+              </div>
+              <p className="text-[12px] text-[#78716C]">Communiquez ce code au livreur pour confirmer la r\u00e9ception de votre commande.</p>
+            </motion.div>
+          )}
+
+          {order.paymentMethod === 'cash' && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.45 }}
+              className="flex items-start gap-3 p-4 bg-[#F0FDF4] border border-[#16A34A]/30 rounded-xl"
+            >
+              <svg
+                className="w-5 h-5 text-[#16A34A] flex-shrink-0 mt-0.5"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <p className="text-[14px] text-[#78716C]">
+                Vous paierez <span className="font-semibold text-[#1C1917]">{snapshotTotal + deliveryFee} MAD</span> en esp\u00e8ces \u00e0 la livraison.
+              </p>
+            </motion.div>
+          )}
+
+          {order.paymentMethod === 'card-delivery' && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.45 }}
+              className="flex items-start gap-3 p-4 bg-[#F0FDF4] border border-[#16A34A]/30 rounded-xl"
+            >
+              <svg
+                className="w-5 h-5 text-[#16A34A] flex-shrink-0 mt-0.5"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <p className="text-[14px] text-[#78716C]">
+                Vous paierez <span className="font-semibold text-[#1C1917]">{snapshotTotal + deliveryFee} MAD</span> par carte \u00e0 la livraison.
+              </p>
+            </motion.div>
+          )}
+
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.5 }}
+            className="text-[15px] text-[#78716C] px-4"
+          >
+            Nous vous contacterons dans les{' '}
+            <span className="font-medium text-[#1C1917]">30 minutes</span> pour confirmer la
+            livraison.
+          </motion.p>
+
+          {(order.deliveryDisplayDate || order.deliverySlot) && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ delay: 0.6 }}
+              className="inline-flex items-center gap-2 px-4 py-2.5 bg-[#EFF6FF] text-[#2563EB] rounded-full text-[14px] font-medium mt-3"
+            >
+              <Clock className="w-4 h-4" />
+              {order.deliveryDisplayDate && order.deliverySlot
+                ? `Livraison le ${order.deliveryDisplayDate} entre ${order.deliverySlot.replace('-', ' et ').replace(/(\d{2}):00/g, '$1h00')}`
+                : order.deliveryDisplayDate
+                  ? `Livraison le ${order.deliveryDisplayDate}`
+                  : 'Livraison planifi\u00e9e'}
+            </motion.div>
+          )}
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.7 }}
+          className="bg-white rounded-xl p-5 border border-[#E2E8F0]"
+        >
+          <h2 className="font-bold text-[16px] mb-4">R\u00e9sum\u00e9 de commande</h2>
+          <div className="space-y-3 mb-4">
+            {snapshotItems.map((item) => (
+              <div key={item.id} className="flex items-center gap-3 py-1">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={item.image}
+                  alt={item.name}
+                  className="w-12 h-12 rounded-lg object-cover"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-[14px] font-medium truncate">{item.name}</p>
+                  <p className="text-[13px] text-[#78716C]">Qt\u00e9 {item.quantity}</p>
+                </div>
+                <span className="text-[14px] font-medium">
+                  {item.price * item.quantity} MAD
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="border-t border-[#E2E8F0] pt-4 space-y-2">
+            <div className="flex justify-between text-[15px]">
+              <span className="text-[#78716C]">Sous-total</span>
+              <span className="font-medium">{snapshotTotal} MAD</span>
+            </div>
+            <div className="flex justify-between text-[15px]">
+              <span className="text-[#78716C]">Livraison</span>
+              <span
+                className={deliveryFee === 0 ? 'text-[#16A34A] font-medium' : 'font-medium'}
+              >
+                {deliveryFee === 0 ? 'Gratuit' : `${deliveryFee} MAD`}
+              </span>
+            </div>
+            <div className="flex justify-between pt-2 border-t border-[#E2E8F0] text-[15px]">
+              <span className="font-bold">Total</span>
+              <span className="font-bold">{snapshotTotal + deliveryFee} MAD</span>
+            </div>
+            {order.address && (
+              <div className="flex items-start gap-2 text-[13px] text-[#78716C] pt-2 mt-2 border-t border-[#E2E8F0]">
+                <svg
+                  className="w-4 h-4 flex-shrink-0 mt-0.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+                <span>
+                  {order.address}
+                  {order.city ? `, ${order.city}` : ''}
+                </span>
+              </div>
+            )}
+          </div>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.8 }}
+          className="space-y-3"
+        >
+          <button
+            onClick={() => router.push(`/store/${slug}/commande/${orderNumber}`)}
+            className="w-full h-12 bg-[#2563EB] text-white rounded-lg font-medium text-[15px] hover:bg-[#1d4ed8] transition-colors shadow-sm"
+          >
+            Suivre ma commande
+          </button>
+
+          <button
+            onClick={() => router.push(`/store/${slug}`)}
+            className="w-full h-12 border border-[#E2E8F0] text-[#78716C] rounded-lg font-medium text-[15px] hover:border-[#2563EB] hover:text-[#2563EB] transition-colors"
+          >
+            Retour \u00e0 la boutique
+          </button>
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}

--- a/app/store/[slug]/verification/page.tsx
+++ b/app/store/[slug]/verification/page.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { motion } from 'motion/react';
+import { createOrder } from '../actions';
+import type { CreateOrderPayload } from '../actions';
+import { useCart } from '../_components/CartProvider';
+import { getDeliveryFee } from '../_lib/deliveryUtils';
+
+interface PendingOrder {
+  name: string;
+  phone: string;
+  address: string;
+  city: string;
+  deliveryDate?: string | null;       // YYYY-MM-DD
+  deliverySlot?: string | null;       // "09:00-10:00"
+  deliveryDisplayDate?: string | null;
+  deliveryDisplaySlot?: string | null;
+  paymentMethod: string;
+  paymentMethodDb: 'cod' | 'terminal' | 'card';
+  notes?: string | null;
+  orderNumber: string;
+  merchantId: string;
+  merchantSlug: string;
+  deliveryFeeThreshold?: number | null;
+}
+
+export default function VerificationPage() {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const router = useRouter();
+  const { items, total } = useCart();
+
+  const [pendingOrder, setPendingOrder] = useState<PendingOrder | null>(null);
+  const [otp, setOtp] = useState(['', '', '', '', '', '']);
+  const [error, setError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('plaza_pending_order');
+    if (stored) {
+      try {
+        setPendingOrder(JSON.parse(stored) as PendingOrder);
+      } catch {
+        // ignore malformed data
+      }
+    }
+    inputRefs.current[0]?.focus();
+  }, []);
+
+  const phone = pendingOrder?.phone ?? 'votre num\u00e9ro';
+
+  const handleChange = (index: number, value: string) => {
+    if (value.length > 1) return;
+    if (!/^\d*$/.test(value)) return;
+
+    const newOtp = [...otp];
+    newOtp[index] = value;
+    setOtp(newOtp);
+    setError(false);
+
+    if (value && index < 5) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleKeyDown = (index: number, e: React.KeyboardEvent) => {
+    if (e.key === 'Backspace' && !otp[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    e.preventDefault();
+    const pastedData = e.clipboardData.getData('text').slice(0, 6);
+    if (!/^\d+$/.test(pastedData)) return;
+
+    const newOtp = pastedData
+      .split('')
+      .concat(Array<string>(6 - pastedData.length).fill(''));
+    setOtp(newOtp);
+    inputRefs.current[Math.min(pastedData.length, 5)]?.focus();
+  };
+
+  const handleVerify = async () => {
+    const otpValue = otp.join('');
+    if (otpValue.length !== 6) {
+      setError(true);
+      setErrorMessage('Veuillez entrer un code \u00e0 6 chiffres.');
+      return;
+    }
+
+    if (!pendingOrder) {
+      setError(true);
+      setErrorMessage('Donn\u00e9es de commande introuvables. Veuillez recommencer.');
+      return;
+    }
+
+    setLoading(true);
+    setError(false);
+
+    try {
+      const payload: CreateOrderPayload = {
+        orderNumber: pendingOrder.orderNumber,
+        merchantId: pendingOrder.merchantId,
+        merchantSlug: pendingOrder.merchantSlug,
+        customerName: pendingOrder.name,
+        customerPhone: pendingOrder.phone,
+        customerAddress: pendingOrder.address || null,
+        customerCity: pendingOrder.city || null,
+        deliveryDate: pendingOrder.deliveryDate ?? null,
+        deliverySlot: pendingOrder.deliverySlot ?? null,
+        paymentMethod: pendingOrder.paymentMethodDb,
+        notes: pendingOrder.notes ?? null,
+        items: items.map((item) => ({
+          productId: item.id,
+          nameFr: item.name,
+          quantity: item.quantity,
+          unitPrice: item.price,
+        })),
+        subtotal: total,
+        deliveryFee: getDeliveryFee(total, pendingOrder.deliveryFeeThreshold ?? undefined),
+        total: total + getDeliveryFee(total, pendingOrder.deliveryFeeThreshold ?? undefined),
+      };
+
+      const result = await createOrder(payload);
+
+      // Update sessionStorage with confirmed data including PIN
+      const existing = JSON.parse(sessionStorage.getItem('plaza_pending_order') ?? '{}');
+      sessionStorage.setItem('plaza_pending_order', JSON.stringify({
+        ...existing,
+        orderNumber: result.orderNumber,
+        customerPin: result.customerPin,
+        deliveryDisplayDate: pendingOrder.deliveryDisplayDate,
+        deliveryDisplaySlot: pendingOrder.deliveryDisplaySlot,
+        deliverySlot: pendingOrder.deliverySlot,
+      }));
+
+      router.push(`/store/${slug}/confirmation`);
+    } catch {
+      setError(true);
+      setErrorMessage('Une erreur est survenue. Veuillez r\u00e9essayer.');
+      setLoading(false);
+    }
+  };
+
+  const handleResend = () => {
+    setOtp(['', '', '', '', '', '']);
+    setError(false);
+    setErrorMessage('');
+    inputRefs.current[0]?.focus();
+  };
+
+  return (
+    <div className="min-h-screen bg-[#FAFAF9]">
+      <div className="sticky top-0 z-50 bg-white border-b border-[#E2E8F0] h-14 flex items-center px-4">
+        <button
+          onClick={() => router.back()}
+          className="w-10 h-10 flex items-center justify-center -ml-2"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <h1 className="font-bold text-[18px] ml-2">V\u00e9rification</h1>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="max-w-md mx-auto px-4 py-12"
+      >
+        <div className="text-center mb-8">
+          <div className="w-16 h-16 bg-[#EFF6FF] rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg
+              className="w-8 h-8 text-[#2563EB]"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+              />
+            </svg>
+          </div>
+          <h2 className="font-bold text-[24px] mb-2">V\u00e9rifiez votre num\u00e9ro</h2>
+          <p className="text-[14px] text-[#78716C]">
+            Nous avons envoy\u00e9 un code \u00e0 6 chiffres au
+          </p>
+          <p className="text-[15px] font-medium text-[#1C1917] mt-1">{phone}</p>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <div className="flex gap-2 justify-center mb-2">
+              {otp.map((digit, index) => (
+                <input
+                  key={index}
+                  ref={(el) => {
+                    inputRefs.current[index] = el;
+                  }}
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={1}
+                  value={digit}
+                  onChange={(e) => handleChange(index, e.target.value)}
+                  onKeyDown={(e) => handleKeyDown(index, e)}
+                  onPaste={index === 0 ? handlePaste : undefined}
+                  className={`w-12 h-14 text-center text-[20px] font-bold border-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#2563EB]/20 transition-colors ${
+                    error
+                      ? 'border-[#DC2626] bg-red-50'
+                      : digit
+                        ? 'border-[#2563EB] bg-[#EFF6FF]'
+                        : 'border-[#E2E8F0] bg-white'
+                  }`}
+                />
+              ))}
+            </div>
+            {error && (
+              <motion.p
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="text-[13px] text-[#DC2626] text-center"
+              >
+                {errorMessage}
+              </motion.p>
+            )}
+          </div>
+
+          <button
+            onClick={handleVerify}
+            disabled={loading || otp.join('').length !== 6}
+            className="w-full h-14 bg-[#2563EB] text-white rounded-lg font-medium hover:bg-[#1d4ed8] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <>
+                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                V\u00e9rification...
+              </>
+            ) : (
+              'V\u00e9rifier le code'
+            )}
+          </button>
+
+          <div className="text-center">
+            <p className="text-[14px] text-[#78716C] mb-2">
+              Vous n&apos;avez pas re\u00e7u le code ?
+            </p>
+            <button
+              onClick={handleResend}
+              className="text-[14px] text-[#2563EB] font-medium hover:underline"
+            >
+              Renvoyer le code
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-8 p-4 bg-[#EFF6FF] rounded-lg border border-[#2563EB]/20">
+          <p className="text-[13px] text-[#78716C] text-center">
+            Pour ce MVP, tout code \u00e0 6 chiffres est accept\u00e9.
+          </p>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -238,6 +238,10 @@ export type Database = {
           notes:            string | null
           created_at:       string
           updated_at:       string
+          // PLZ-038: reception PIN + delivery scheduling (migration 2026-04-10)
+          customer_pin:     number | null
+          delivery_date:    string | null   // YYYY-MM-DD from Postgres date
+          delivery_slot:    string | null   // format: "09:00-10:00"
         }
         Insert: {
           id?:               string
@@ -253,6 +257,9 @@ export type Database = {
           notes?:            string | null
           created_at?:       string
           updated_at?:       string
+          customer_pin?:     number | null
+          delivery_date?:    string | null
+          delivery_slot?:    string | null
         }
         Update: {
           id?:               string
@@ -268,6 +275,9 @@ export type Database = {
           notes?:            string | null
           created_at?:       string
           updated_at?:       string
+          customer_pin?:     number | null
+          delivery_date?:    string | null
+          delivery_slot?:    string | null
         }
         Relationships: [
           {


### PR DESCRIPTION
## Summary

- **Supabase types** (`types/supabase.ts`): added `customer_pin`, `delivery_date`, `delivery_slot` to `orders` Row/Insert/Update — mirrors Othmane's migration
- **`createOrder()` action** (`app/store/[slug]/actions.ts`): generates a random 4-digit PIN (`1000–9999`), stores it alongside `delivery_date` and `delivery_slot` on insert; returns `{ orderNumber, customerPin }`
- **`DeliverySlotPicker` component** (`app/store/[slug]/_components/DeliverySlotPicker.tsx`): new `'use client'` component — 8-day date chip strip + hourly slot dropdown (09:00–20:00); filters past slots when today is selected; respects `workingHours` map if provided
- **Checkout page** (`app/store/[slug]/commande/page.tsx`): replaces `DateTimePicker` with `DeliverySlotPicker`; default slot initialised on mount; sessionStorage payload updated (`deliveryDate` YYYY-MM-DD, `deliverySlot`, `deliveryDisplayDate`, `deliveryDisplaySlot`)
- **Verification page** (`app/store/[slug]/verification/page.tsx`): passes `deliveryDate`/`deliverySlot` to `createOrder`; stores returned `customerPin` + display fields in sessionStorage before routing to confirmation
- **Confirmation page** (`app/store/[slug]/confirmation/page.tsx`): shows 4-box PIN display card; delivery chip shows exact slot formatted as "09h00 et 10h00"
- **Tracking page** (`app/store/[slug]/_components/OrderStatusClient.tsx`): PIN reminder card below timeline; delivery slot chip replaces old notes chip; ETA sub-label shown on the active timeline step

## Test plan

- [ ] Checkout: date chips show today + 7 days; today's past hours are filtered; slot dropdown updates on date change
- [ ] Submit order: sessionStorage contains `deliveryDate` (YYYY-MM-DD), `deliverySlot`, `deliveryDisplayDate`, `deliveryDisplaySlot`
- [ ] Verification → confirmation: `customerPin` is a 4-digit number visible in the PIN box card
- [ ] Confirmation: delivery chip reads e.g. "Livraison le 10 avril 2026 entre 09h00 et 10h00"
- [ ] Tracking (`/store/[slug]/commande/[orderNumber]`): PIN reminder and delivery slot chip visible; ETA label appears on the current step

cc @Anas — please review against standing QA checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)