### PR TITLE
fix(storefront): confirmation page regression — subtotal + order number + date/time

### DIFF
--- a/app/store/[slug]/confirmation/page.tsx
+++ b/app/store/[slug]/confirmation/page.tsx
@@ -31,6 +31,21 @@ interface ConfirmedOrder {
   customerPin?: number;
 }
 
+const MONTHS_FR = [
+  'janvier','février','mars','avril','mai','juin',
+  'juillet','août','septembre','octobre','novembre','décembre'
+]
+
+function formatDateFR(dateStr: string): string {
+  if (!dateStr) return ''
+  const parts = dateStr.split('-')
+  if (parts.length !== 3) return dateStr
+  const [year, month, day] = parts
+  const monthName = MONTHS_FR[parseInt(month, 10) - 1]
+  if (!monthName) return dateStr
+  return `${parseInt(day, 10)} ${monthName} ${year}`
+}
+
 export default function ConfirmationPage() {
   const params = useParams<{ slug: string }>();
   const slug = params.slug;
@@ -79,8 +94,8 @@ export default function ConfirmationPage() {
         setOrder({
           ...parsedOrder,
           // Prefer confirm* identity keys as they are written after createOrder resolves
-          orderId: parsedOrder.orderId ?? ssOrderId ?? undefined,
-          orderNumber: parsedOrder.orderNumber ?? ssOrderNumber ?? undefined,
+          orderId: ssOrderId || parsedOrder.orderId || undefined,
+          orderNumber: ssOrderNumber || parsedOrder.orderNumber || undefined,
           customerPin: parsedOrder.customerPin ?? (ssPin ? parseInt(ssPin, 10) : undefined),
         });
       } catch {
@@ -252,10 +267,14 @@ export default function ConfirmationPage() {
 
         {/* Delivery Time */}
         {(() => {
-          const displayDate = order.deliveryDisplayDate || confirmDate;
+          const rawDate = order.deliveryDisplayDate || confirmDate;
           const slot = order.deliverySlot || confirmSlot;
-          if (!displayDate && !slot) return null;
-          const fmt = (t: string) => t.replace(':', 'h').replace(/^(\d+h)00$/, '$1');
+          if (!rawDate && !slot) return null;
+          // Format date: if it looks like ISO (YYYY-MM-DD) convert to "16 avril 2026"
+          const displayDate = rawDate && /^\d{4}-\d{2}-\d{2}$/.test(rawDate)
+            ? formatDateFR(rawDate)
+            : rawDate;
+          const fmt = (t: string) => t.replace(':', 'h');
           let label = 'Livraison planifiée';
           if (displayDate && slot) {
             const parts = slot.split('-');


### PR DESCRIPTION
## What was broken

Three regressions on the `/confirmation` page introduced across commits `081f3fe` and `f10e821`:

1. **Order number showed blank** — `setOrder` was merging `parsedOrder.orderNumber ?? ssOrderNumber`, meaning the pre-generated order number (written before `createOrder()` ran) always shadowed `confirmOrderNumber` (written after `createOrder()` returned). Fix: flip priority to `ssOrderNumber || parsedOrder.orderNumber`.

2. **Date displayed as ISO string** (`2026-04-16`) — Commit `081f3fe` added `confirmDate` as a fallback for `deliveryDisplayDate`, but stored and displayed the raw ISO date without locale formatting. Fix: added `formatDateFR()` utility that converts `YYYY-MM-DD` → `16 avril 2026`; applied when the raw date matches the ISO pattern.

3. **Time displayed without minutes** (`15h` instead of `15h00`) — The `fmt()` function contained `.replace(/^(\d+h)00$/, '$1')` which stripped trailing `00`. Fix: removed that clause so `15:00` → `15h00` and `16:00` → `16h00`, giving `entre 15h00 et 16h00`.

## What was NOT changed

- `verification/page.tsx` — subtotal write logic was already correct; `confirmSubtotal` was being written before `clearCart()` as intended.
- `commande/page.tsx` — no changes needed.
- TypeScript: 0 errors (`tsc --noEmit` passes clean).

## Test plan

- [ ] Place an order through the full flow (commande → verification → confirmation)
- [ ] Confirm order number shows (e.g. `PLZ-1234`) and matches what DB recorded
- [ ] Confirm subtotal shows the correct MAD amount (not 0)
- [ ] Confirm date displays as `16 avril 2026` (not `2026-04-16`)
- [ ] Confirm time slot displays as `entre 15h00 et 16h00` (not `entre 15h et 16h`)

**@Anas — please review and merge when ready. Do NOT merge yourself.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)