### PR TITLE
fix: map Morocco bounds, stock guardrails, working hours debounce

### DIFF
--- a/app/dashboard/boutique/WorkingHoursSection.tsx
+++ b/app/dashboard/boutique/WorkingHoursSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useState, useTransition, useRef, useEffect } from 'react';
 import { updateWorkingHours } from './actions';
 import type { WorkingHours, DaySchedule } from './actions';
 
@@ -39,6 +39,13 @@ export function WorkingHoursSection({ initialHours }: Props) {
   const [sameForAll, setSameForAll] = useState(false);
   const [schemaPending, setSchemaPending] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
 
   function save(next: WorkingHours) {
     startTransition(async () => {
@@ -49,11 +56,18 @@ export function WorkingHoursSection({ initialHours }: Props) {
     });
   }
 
+  function scheduleSave(next: WorkingHours) {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      save(next);
+    }, 500);
+  }
+
   function updateDay(key: string, patch: Partial<DaySchedule>) {
     setHours((prev) => {
       const current = prev[key] ?? DEFAULT_HOURS[key] ?? { open: false, from: '', to: '' };
       const next = { ...prev, [key]: { ...current, ...patch } };
-      save(next);
+      scheduleSave(next);
       return next;
     });
   }
@@ -67,7 +81,7 @@ export function WorkingHoursSection({ initialHours }: Props) {
         next[key] = { ...monHours };
       }
       setHours(next);
-      save(next);
+      scheduleSave(next);
     }
   }
 

--- a/app/store/[slug]/_components/MapLocationPicker.tsx
+++ b/app/store/[slug]/_components/MapLocationPicker.tsx
@@ -13,6 +13,7 @@ export function MapLocationPicker({ onLocationSelect }: Props) {
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markerRef = useRef<mapboxgl.Marker | null>(null);
   const onLocationSelectRef = useRef(onLocationSelect);
+  const initializedRef = useRef(false);
   const [picked, setPicked] = useState(false);
   const [locating, setLocating] = useState(false);
   const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? '';
@@ -62,7 +63,13 @@ export function MapLocationPicker({ onLocationSelect }: Props) {
     });
     mapRef.current = map;
 
-    map.fitBounds([[-17.5, 20.5], [-0.5, 36.5]] as [[number, number], [number, number]], { padding: 20, duration: 0 });
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      map.fitBounds(
+        [[-17.5, 20.77], [-1.0, 35.92]] as [[number, number], [number, number]],
+        { padding: 40, duration: 0 },
+      );
+    }
     map.getCanvas().style.cursor = 'crosshair';
 
     map.on('click', async (e) => {

--- a/app/store/[slug]/_components/ProductDetailClient.tsx
+++ b/app/store/[slug]/_components/ProductDetailClient.tsx
@@ -82,6 +82,7 @@ export function ProductDetailClient({
       : null;
 
   const cartCount = items.reduce((sum, item) => sum + item.quantity, 0);
+  const atStockLimit = product.stock !== null && quantity >= product.stock;
 
   // Breadcrumb parts
   const breadcrumbParts = [product.category_l1, product.category_l2, product.category_l3].filter(
@@ -90,14 +91,16 @@ export function ProductDetailClient({
 
   function handleAddToCart() {
     if (outOfStock) return;
-    for (let i = 0; i < quantity; i++) {
-      addItem({
+    addItem(
+      {
         id: product.id,
         name: product.name_fr,
         price: priceMAD,
         image: product.image_url ?? '',
-      });
-    }
+        stock: product.stock,
+      },
+      quantity,
+    );
   }
 
   function handleBuyNow() {
@@ -255,13 +258,20 @@ export function ProductDetailClient({
                   {quantity}
                 </span>
                 <button
-                  onClick={() => setQuantity(quantity + 1)}
-                  className="w-12 h-12 flex items-center justify-center hover:bg-gray-50"
+                  onClick={() => {
+                    if (product.stock !== null && quantity >= product.stock) return;
+                    setQuantity(quantity + 1);
+                  }}
+                  disabled={atStockLimit}
+                  className="w-12 h-12 flex items-center justify-center hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   <Plus className="w-5 h-5 text-[#78716C]" />
                 </button>
               </div>
             </div>
+            {atStockLimit && (
+              <p className="text-xs text-amber-600 mt-1">Plus que {product.stock} en stock</p>
+            )}
           </div>
 
           {/* Desktop Action Buttons */}
@@ -378,13 +388,20 @@ export function ProductDetailClient({
                 {quantity}
               </span>
               <button
-                onClick={() => setQuantity(quantity + 1)}
-                className="w-12 h-12 flex items-center justify-center hover:bg-gray-50"
+                onClick={() => {
+                  if (product.stock !== null && quantity >= product.stock) return;
+                  setQuantity(quantity + 1);
+                }}
+                disabled={atStockLimit}
+                className="w-12 h-12 flex items-center justify-center hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 <Plus className="w-5 h-5 text-[#78716C]" />
               </button>
             </div>
           </div>
+          {atStockLimit && (
+            <p className="text-xs text-amber-600 mt-1">Plus que {product.stock} en stock</p>
+          )}
         </div>
 
         {/* Trust Badges */}

--- a/app/store/[slug]/actions.ts
+++ b/app/store/[slug]/actions.ts
@@ -94,6 +94,21 @@ export async function createOrder(
 ): Promise<{ orderNumber: string; customerPin: number; orderId: string }> {
   const supabase = await createClient();
 
+  // Stock pre-flight check — throws so the caller's existing catch block handles it
+  for (const item of payload.items) {
+    const { data: product } = await supabase
+      .from('products')
+      .select('stock, name_fr')
+      .eq('id', item.productId)
+      .maybeSingle<{ stock: number | null; name_fr: string }>();
+
+    if (product && product.stock !== null && product.stock < item.quantity) {
+      throw new Error(
+        `Stock insuffisant: ${product.name_fr} (${product.stock} disponible, ${item.quantity} demandé)`,
+      );
+    }
+  }
+
   const customerPin = Math.floor(1000 + Math.random() * 9000);
 
   // Pre-generate UUIDs server-side so we can avoid .select() after insert.

--- a/components/MapboxMap.tsx
+++ b/components/MapboxMap.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
@@ -14,8 +14,32 @@ export default function MapboxMap({ lat, lng, onLocationChange }: Props) {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markerRef = useRef<mapboxgl.Marker | null>(null);
+  const initializedRef = useRef(false);
+  const [locating, setLocating] = useState(false);
 
   const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+
+  const handleLocate = () => {
+    if (!navigator.geolocation || !mapRef.current) return;
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude: posLat, longitude: posLng } = pos.coords;
+        mapRef.current?.flyTo({ center: [posLng, posLat], zoom: 15, duration: 1000 });
+        if (markerRef.current) {
+          markerRef.current.setLngLat([posLng, posLat]);
+        } else {
+          markerRef.current = new mapboxgl.Marker({ color: '#E8632A' })
+            .setLngLat([posLng, posLat])
+            .addTo(mapRef.current!);
+        }
+        onLocationChange(posLat, posLng);
+        setLocating(false);
+      },
+      () => setLocating(false),
+      { timeout: 8000 },
+    );
+  };
 
   useEffect(() => {
     if (!token) return;
@@ -33,8 +57,14 @@ export default function MapboxMap({ lat, lng, onLocationChange }: Props) {
 
     mapRef.current = map;
 
-    if (!(lat && lng)) {
-      map.fitBounds([[-17.5, 20.5], [-0.5, 36.5]] as [[number, number], [number, number]], { padding: 20, duration: 0 });
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      if (!(lat && lng)) {
+        map.fitBounds(
+          [[-17.5, 20.77], [-1.0, 35.92]] as [[number, number], [number, number]],
+          { padding: 40, duration: 0 },
+        );
+      }
     }
 
     if (lat !== null && lng !== null) {
@@ -108,10 +138,28 @@ export default function MapboxMap({ lat, lng, onLocationChange }: Props) {
   }
 
   return (
-    <div
-      ref={mapContainerRef}
-      suppressHydrationWarning
-      className="w-full h-[260px] rounded-lg border border-[#E2E8F0] overflow-hidden"
-    />
+    <div className="relative">
+      <div
+        ref={mapContainerRef}
+        suppressHydrationWarning
+        className="w-full h-[260px] rounded-lg border border-[#E2E8F0] overflow-hidden"
+      />
+      <button
+        type="button"
+        onClick={handleLocate}
+        disabled={locating}
+        className="absolute top-2 right-2 z-10 bg-white rounded-lg shadow-md p-2 hover:bg-stone-50 disabled:opacity-60"
+        title="Ma position"
+      >
+        {locating ? (
+          <div className="w-5 h-5 border-2 border-stone-400 border-t-transparent rounded-full animate-spin" />
+        ) : (
+          <svg viewBox="0 0 24 24" className="w-5 h-5 text-[#2563EB]" fill="none" stroke="currentColor" strokeWidth={2}>
+            <circle cx="12" cy="12" r="3"/>
+            <path d="M12 2v3m0 14v3M2 12h3m14 0h3"/>
+          </svg>
+        )}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- **MapLocationPicker.tsx** — corrected Morocco `fitBounds` extents to `[[-17.5, 20.77], [-1.0, 35.92]]` (includes Western Sahara + eastern Algeria border); added `initializedRef` so `fitBounds` only runs once on first map init, not on re-renders
- **components/MapboxMap.tsx** (dashboard boutique) — same bounds fix + `initializedRef`; added current-location button with geolocation `flyTo` (zoom 15, 1000ms), spinner state, marker placement
- **ProductDetailClient.tsx** — quantity increment capped at `product.stock`; `+` button disabled at limit with amber warning "Plus que N en stock" shown on both desktop and mobile selectors; `handleAddToCart` now uses single `addItem(product, quantity)` call with `stock` passed through
- **app/store/[slug]/actions.ts** (`createOrder`) — stock pre-flight check before any DB insert: queries each item's product stock, throws `Error` with human-readable message on insufficient stock (caught by caller's existing try/catch)
- **WorkingHoursSection.tsx** — replaced direct `save()` calls inside `updateDay`/`handleSameForAll` with debounced `scheduleSave()` (500ms timer via `saveTimerRef`); local state updates instantly on toggle/time change; timer cleaned up on unmount

**Verified already in place (no changes needed):**
- `CartProvider.tsx` — stock cap in `addItem` was correct from previous sprint
- `lib/db/orders.ts` `updateOrderStatus` — stock check + decrement on `confirmed` was already implemented

## Test plan

- [ ] Storefront commande map: open on mobile — map shows full Morocco on load; location button flies to GPS position and drops marker
- [ ] Dashboard boutique map: same — full Morocco on load, location button works
- [ ] Product detail: try incrementing quantity past stock — `+` button goes disabled, amber warning appears; "Ajouter au panier" correctly caps at stock via CartProvider
- [ ] Checkout: submit order with quantity > remaining stock (manipulate sessionStorage) — server action throws, customer sees error state
- [ ] Working hours: toggle a day or change a time — no page refresh; save indicator appears 500ms later; rapid changes only trigger one save

@Anas — please review and merge when ready. Do NOT merge this PR without Anas approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)