### PR TITLE
fix(map): satellite style for checkout, light-v11 for dashboard, extend southern bounds

### DIFF
--- a/app/store/[slug]/_components/MapLocationPicker.tsx
+++ b/app/store/[slug]/_components/MapLocationPicker.tsx
@@ -57,7 +57,7 @@ export function MapLocationPicker({ onLocationSelect }: Props) {
     mapboxgl.accessToken = token;
     const map = new mapboxgl.Map({
       container: mapContainer.current,
-      style: 'mapbox://styles/mapbox/streets-v12',
+      style: 'mapbox://styles/mapbox/satellite-streets-v12',
       center: [-6.8, 31.5] as [number, number],
       zoom: 4.5,
     });
@@ -66,8 +66,8 @@ export function MapLocationPicker({ onLocationSelect }: Props) {
     if (!initializedRef.current) {
       initializedRef.current = true;
       map.fitBounds(
-        [[-17.5, 20.77], [-1.0, 35.92]] as [[number, number], [number, number]],
-        { padding: 40, duration: 0 },
+        [[-17.5, 20.0], [-1.0, 35.92]] as [[number, number], [number, number]],
+        { padding: 20, duration: 0 },
       );
     }
     map.getCanvas().style.cursor = 'crosshair';

--- a/components/MapboxMap.tsx
+++ b/components/MapboxMap.tsx
@@ -50,7 +50,7 @@ export default function MapboxMap({ lat, lng, onLocationChange }: Props) {
 
     const map = new mapboxgl.Map({
       container: mapContainerRef.current,
-      style: 'mapbox://styles/mapbox/streets-v12',
+      style: 'mapbox://styles/mapbox/light-v11',
       center: [lng ?? -6.8, lat ?? 31.5] as [number, number],
       zoom: lat && lng ? 13 : 4.5,
     });
@@ -61,8 +61,8 @@ export default function MapboxMap({ lat, lng, onLocationChange }: Props) {
       initializedRef.current = true;
       if (!(lat && lng)) {
         map.fitBounds(
-          [[-17.5, 20.77], [-1.0, 35.92]] as [[number, number], [number, number]],
-          { padding: 40, duration: 0 },
+          [[-17.5, 20.0], [-1.0, 35.92]] as [[number, number], [number, number]],
+          { padding: 20, duration: 0 },
         );
       }
     }


### PR DESCRIPTION
## Summary

- **MapLocationPicker** (customer checkout): changed map style from `streets-v12` to `satellite-streets-v12` — satellite imagery shows terrain without political borders between Morocco and Western Sahara
- **MapboxMap** (merchant boutique dashboard): changed map style from `streets-v12` to `light-v11` — cleaner minimal style for business use, no political border artifacts
- Both maps: extended southern `fitBounds` limit from `20.77` → `20.0` to better include Western Sahara territory in the initial viewport
- Both maps: `fitBounds` padding adjusted to `20` to match the wider bounds

## Files changed

- `app/store/[slug]/_components/MapLocationPicker.tsx`
- `components/MapboxMap.tsx`

## Test plan

- [ ] Open customer checkout map — confirms satellite-streets style renders, no visible Morocco/Western Sahara political border line
- [ ] Open merchant boutique map — confirms light-v11 style renders cleanly
- [ ] Both maps: initial viewport shows Western Sahara territory in southern view
- [ ] Location button still works in both maps
- [ ] TypeScript: 0 errors (`tsc --noEmit`)

cc @Anas — please review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)