### PR TITLE
feat(stock): atomic decrement via RPC, stock restore on cancel, rupture badge

### DIFF
--- a/app/store/[slug]/_components/ProductCard.tsx
+++ b/app/store/[slug]/_components/ProductCard.tsx
@@ -133,6 +133,13 @@ export function ProductCard({ product, slug }: ProductCardProps) {
             </span>
           </div>
 
+          {/* Stock status badge */}
+          {product.stock === 0 ? (
+            <span className="text-xs font-medium text-red-500">Rupture de stock</span>
+          ) : product.stock !== null && product.stock <= 5 ? (
+            <span className="text-xs font-medium text-amber-600">Plus que {product.stock} en stock</span>
+          ) : null}
+
           {/* Action buttons */}
           <div className="mt-auto pt-2 flex gap-1.5">
             <button

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -262,29 +262,42 @@ export async function updateOrderStatus(
       }
     }
 
-    // 3. All checks passed — decrement stock atomically
+    // 3. All checks passed — decrement stock atomically via RPC
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: decrementError } = await (supabase as any)
+      .rpc('decrement_stock', { order_id: orderId });
+
+    if (decrementError) {
+      throw new Error(`Stock insuffisant pour certains produits`);
+    }
+  }
+
+  // ── Stock restore: return stock to products when cancelling a confirmed order ─
+  if (newStatus === 'cancelled' && current.status === 'confirmed') {
+    type OrderItemStockRow = { product_id: string | null; quantity: number };
     type ProductStockOnly = { stock: number | null };
-    for (const item of orderItems) {
-      if (!item.product_id) continue;
 
-      const { data: productForUpdate } = await supabase
-        .from('products')
-        .select('stock')
-        .eq('id', item.product_id)
-        .maybeSingle<ProductStockOnly>();
+    const { data: orderItems } = await supabase
+      .from('order_items')
+      .select('product_id, quantity')
+      .eq('order_id', orderId)
+      .returns<OrderItemStockRow[]>();
 
-      if (productForUpdate?.stock !== null && productForUpdate?.stock !== undefined) {
-        const { error: updateStockErr } = await supabase
+    if (orderItems) {
+      for (const item of orderItems) {
+        if (!item.product_id) continue;
+
+        const { data: product } = await supabase
           .from('products')
-          .update({ stock: Math.max(0, productForUpdate.stock - item.quantity) } as never)
-          .eq('id', item.product_id);
+          .select('stock')
+          .eq('id', item.product_id)
+          .maybeSingle<ProductStockOnly>();
 
-        if (updateStockErr) {
-          // Non-fatal: log but don't block order confirmation
-          console.error(
-            `Failed to decrement stock for product ${item.product_id}:`,
-            updateStockErr,
-          );
+        if (product?.stock !== null && product?.stock !== undefined) {
+          await supabase
+            .from('products')
+            .update({ stock: product.stock + item.quantity } as never)
+            .eq('id', item.product_id);
         }
       }
     }


### PR DESCRIPTION
## Summary

- **`lib/db/orders.ts` — atomic RPC decrement**: replaced the manual per-item SELECT + UPDATE loop with a single `supabase.rpc('decrement_stock', { order_id })` call. The `decrement_stock` Postgres function is already live in production. Uses `as any` cast since the generated types have `Functions: Record<string, never>` (types not regenerated yet for this function).
- **`lib/db/orders.ts` — stock restore on cancellation**: when `newStatus === 'cancelled'` AND `current.status === 'confirmed'`, iterates order items and restores stock via SELECT current stock + UPDATE `stock + quantity` for each product. Only fires when stock was previously decremented (confirmed → cancelled path).
- **`ProductCard.tsx` — inline stock badge**: adds "Rupture de stock" (red text) and "Plus que N en stock" (amber text) inline badges in the card body between price row and action buttons. The add-to-cart button was already disabled for out-of-stock products.

## Verification (D & E)

- **CartProvider.tsx**: `addItem` already checks `product.stock`, caps at stock limit, and returns `{ blocked: true, reason: 'stock' }`. `ProductCard.tsx` already reads `result.blocked`. No changes needed.
- **`actions.ts` `createOrder()`**: stock pre-flight loop already present (lines 98–110). It throws on insufficient stock; `verification/page.tsx` already has a `try/catch` that logs and handles the error gracefully.

## Files changed

- `lib/db/orders.ts`
- `app/store/[slug]/_components/ProductCard.tsx`

## Test plan

- [ ] Confirm an order with sufficient stock → stock decremented atomically via RPC, no per-item race condition
- [ ] Cancel a confirmed order → stock restored for all items
- [ ] Cancel a pending order (not confirmed) → stock NOT restored (guard on `current.status === 'confirmed'`)
- [ ] Product with `stock === 0`: "Rupture de stock" red badge visible in card body, add/buy buttons disabled
- [ ] Product with `stock <= 5 && stock > 0`: "Plus que N en stock" amber badge visible
- [ ] Product with `stock > 5` or `stock === null`: no badge
- [ ] TypeScript: 0 errors (`tsc --noEmit`)

cc @Anas — please review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)