### PR TITLE
feat(storefront): loading states and skeletons across customer + dashboard flows

### DIFF
--- a/app/dashboard/commandes/loading.tsx
+++ b/app/dashboard/commandes/loading.tsx
@@ -1,0 +1,48 @@
+export default function CommandesLoading() {
+  return (
+    <div className="p-4 md:p-8 max-w-[1040px] mx-auto">
+      {/* Page header skeleton */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="h-7 w-36 bg-[#F5F5F4] animate-pulse rounded" />
+      </div>
+
+      {/* Filter tabs skeleton */}
+      <div className="flex gap-2 mb-4 overflow-hidden">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-8 w-24 flex-shrink-0 bg-[#F5F5F4] animate-pulse rounded-full" />
+        ))}
+      </div>
+
+      {/* Desktop table skeleton (hidden on mobile) */}
+      <div className="hidden md:block bg-white rounded-xl shadow-sm overflow-hidden">
+        <div className="h-12 bg-[#F8FAFC] border-b border-[#E2E8F0]" />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-14 px-4 flex items-center gap-4 border-b border-[#F3F4F6]">
+            <div className="w-[130px] h-4 bg-[#F5F5F4] animate-pulse rounded" />
+            <div className="w-[160px] h-4 bg-[#F5F5F4] animate-pulse rounded" />
+            <div className="w-[100px] h-4 bg-[#F5F5F4] animate-pulse rounded" />
+            <div className="w-[130px] h-4 bg-[#F5F5F4] animate-pulse rounded" />
+            <div className="w-[140px] h-5 bg-[#F5F5F4] animate-pulse rounded-full" />
+            <div className="w-[130px] h-5 bg-[#F5F5F4] animate-pulse rounded-full" />
+          </div>
+        ))}
+      </div>
+
+      {/* Mobile cards skeleton (hidden on desktop) */}
+      <div className="md:hidden space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="bg-white rounded-xl p-3 shadow-sm">
+            <div className="flex items-start justify-between mb-2">
+              <div className="h-4 w-24 bg-[#F5F5F4] animate-pulse rounded" />
+              <div className="h-4 w-20 bg-[#F5F5F4] animate-pulse rounded" />
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-24 bg-[#F5F5F4] animate-pulse rounded-full" />
+              <div className="h-5 w-20 bg-[#F5F5F4] animate-pulse rounded-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/store/[slug]/commande/[id]/loading.tsx
+++ b/app/store/[slug]/commande/[id]/loading.tsx
@@ -1,0 +1,58 @@
+export default function OrderStatusLoading() {
+  return (
+    <div className="min-h-screen bg-[#FAFAF9]">
+      {/* Header skeleton */}
+      <div className="sticky top-0 z-30 bg-white border-b border-[#E2E8F0] h-14 flex items-center px-4 gap-3">
+        <div className="w-9 h-9 rounded-full bg-[#F5F5F4] animate-pulse" />
+        <div className="h-5 w-48 bg-[#F5F5F4] animate-pulse rounded flex-1" />
+        <div className="w-9 h-9 rounded-full bg-[#F5F5F4] animate-pulse" />
+      </div>
+
+      <div className="p-4 space-y-4">
+        {/* Timeline skeleton */}
+        <div className="bg-white rounded-xl p-5 space-y-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex gap-4">
+              <div className="flex flex-col items-center">
+                <div className="w-10 h-10 rounded-full bg-[#F5F5F4] animate-pulse flex-shrink-0" />
+                {i < 3 && <div className="w-0.5 h-12 bg-[#F5F5F4] animate-pulse mt-1" />}
+              </div>
+              <div className="flex-1 space-y-1.5 pt-2">
+                <div className="h-4 w-40 bg-[#F5F5F4] animate-pulse rounded" />
+                <div className="h-3 w-24 bg-[#F5F5F4] animate-pulse rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Customer info skeleton */}
+        <div className="bg-white rounded-xl p-5 space-y-3">
+          <div className="h-5 w-36 bg-[#F5F5F4] animate-pulse rounded" />
+          <div className="space-y-2">
+            <div className="h-3 w-16 bg-[#F5F5F4] animate-pulse rounded" />
+            <div className="h-4 w-32 bg-[#F5F5F4] animate-pulse rounded" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-3 w-20 bg-[#F5F5F4] animate-pulse rounded" />
+            <div className="h-4 w-28 bg-[#F5F5F4] animate-pulse rounded" />
+          </div>
+        </div>
+
+        {/* Order summary skeleton */}
+        <div className="bg-white rounded-xl p-5 space-y-3">
+          <div className="h-5 w-40 bg-[#F5F5F4] animate-pulse rounded" />
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <div className="w-12 h-12 rounded-lg bg-[#F5F5F4] animate-pulse flex-shrink-0" />
+              <div className="flex-1 space-y-1.5">
+                <div className="h-4 w-32 bg-[#F5F5F4] animate-pulse rounded" />
+                <div className="h-3 w-20 bg-[#F5F5F4] animate-pulse rounded" />
+              </div>
+              <div className="h-4 w-16 bg-[#F5F5F4] animate-pulse rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/store/[slug]/confirmation/page.tsx
+++ b/app/store/[slug]/confirmation/page.tsx
@@ -19,7 +19,7 @@ interface ConfirmedOrder {
   address?: string;
   city?: string;
   deliveryDate?: string;
-  deliverySlot?: string;      // "09:00-10:00"
+  deliverySlot?: string; // "09:00-10:00"
   deliveryDisplayDate?: string;
   deliveryDisplaySlot?: string;
   paymentMethod?: string;
@@ -32,18 +32,28 @@ interface ConfirmedOrder {
 }
 
 const MONTHS_FR = [
-  'janvier','février','mars','avril','mai','juin',
-  'juillet','août','septembre','octobre','novembre','décembre'
-]
+  'janvier',
+  'février',
+  'mars',
+  'avril',
+  'mai',
+  'juin',
+  'juillet',
+  'août',
+  'septembre',
+  'octobre',
+  'novembre',
+  'décembre',
+];
 
 function formatDateFR(dateStr: string): string {
-  if (!dateStr) return ''
-  const parts = dateStr.split('-')
-  if (parts.length !== 3) return dateStr
-  const [year, month, day] = parts
-  const monthName = MONTHS_FR[parseInt(month, 10) - 1]
-  if (!monthName) return dateStr
-  return `${parseInt(day, 10)} ${monthName} ${year}`
+  if (!dateStr) return '';
+  const parts = dateStr.split('-');
+  if (parts.length !== 3) return dateStr;
+  const [year, month, day] = parts;
+  const monthName = MONTHS_FR[parseInt(month, 10) - 1];
+  if (!monthName) return dateStr;
+  return `${parseInt(day, 10)} ${monthName} ${year}`;
 }
 
 export default function ConfirmationPage() {
@@ -60,6 +70,8 @@ export default function ConfirmationPage() {
   const [confirmTotal, setConfirmTotal] = useState(0);
   const [confirmDate, setConfirmDate] = useState('');
   const [confirmSlot, setConfirmSlot] = useState('');
+  // Prevent empty order-number flash: hold render until sessionStorage is read
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
     // ── Read confirm* keys (written by verification/page.tsx before createOrder) ──
@@ -71,8 +83,14 @@ export default function ConfirmationPage() {
     const ssOrderId = sessionStorage.getItem('confirmOrderId');
     const ssOrderNumber = sessionStorage.getItem('confirmOrderNumber');
     const ssPin = sessionStorage.getItem('confirmPin');
-    const ssDate = sessionStorage.getItem('confirmDate') || sessionStorage.getItem('deliveryDate') || '';
-    const ssSlot = sessionStorage.getItem('confirmSlot') || sessionStorage.getItem('deliverySlot') || '';
+    const ssDate =
+      sessionStorage.getItem('confirmDate') ||
+      sessionStorage.getItem('deliveryDate') ||
+      '';
+    const ssSlot =
+      sessionStorage.getItem('confirmSlot') ||
+      sessionStorage.getItem('deliverySlot') ||
+      '';
 
     if (ssSubtotal) setConfirmSubtotal(parseFloat(ssSubtotal));
     if (ssDelivery) setConfirmDelivery(parseFloat(ssDelivery));
@@ -96,7 +114,9 @@ export default function ConfirmationPage() {
           // Prefer confirm* identity keys as they are written after createOrder resolves
           orderId: ssOrderId || parsedOrder.orderId || undefined,
           orderNumber: ssOrderNumber || parsedOrder.orderNumber || undefined,
-          customerPin: parsedOrder.customerPin ?? (ssPin ? parseInt(ssPin, 10) : undefined),
+          customerPin:
+            parsedOrder.customerPin ??
+            (ssPin ? parseInt(ssPin, 10) : undefined),
         });
       } catch {
         // Fallback to confirm* keys only
@@ -146,6 +166,9 @@ export default function ConfirmationPage() {
     sessionStorage.removeItem('confirmPin');
     sessionStorage.removeItem('confirmDate');
     sessionStorage.removeItem('confirmSlot');
+
+    // Mark ready — all state is now populated from sessionStorage
+    setReady(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -178,10 +201,17 @@ export default function ConfirmationPage() {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  // Hold render until sessionStorage has been read — prevents blank order number flash
+  if (!ready)
+    return (
+      <div className="min-h-screen bg-[#FAFAF9] flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-[#2563EB] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+
   return (
     <div className="min-h-screen bg-[#FAFAF9] p-4">
       <div className="max-w-md mx-auto py-8 space-y-6">
-
         {/* Success */}
         <motion.div
           initial={{ scale: 0.9, opacity: 0 }}
@@ -210,7 +240,7 @@ export default function ConfirmationPage() {
               className="text-3xl font-bold tracking-wide"
               style={{ color: 'var(--color-primary)' }}
             >
-              {orderNumber}
+              {orderNumber || ''}
             </span>
             <button
               onClick={handleCopy}
@@ -249,15 +279,21 @@ export default function ConfirmationPage() {
           >
             <p className="text-sm text-[#78716C]">Votre code de réception</p>
             <div className="flex gap-2 justify-center">
-              {String(order.customerPin).padStart(4, '0').split('').map((digit, i) => (
-                <div
-                  key={i}
-                  className="w-12 h-14 bg-white rounded-lg flex items-center justify-center text-3xl font-bold border-2"
-                  style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
-                >
-                  {digit}
-                </div>
-              ))}
+              {String(order.customerPin)
+                .padStart(4, '0')
+                .split('')
+                .map((digit, i) => (
+                  <div
+                    key={i}
+                    className="w-12 h-14 bg-white rounded-lg flex items-center justify-center text-3xl font-bold border-2"
+                    style={{
+                      borderColor: 'var(--color-primary)',
+                      color: 'var(--color-primary)',
+                    }}
+                  >
+                    {digit}
+                  </div>
+                ))}
             </div>
             <p className="text-xs text-[#78716C] text-center">
               Communiquez ce code au livreur pour confirmer la réception.
@@ -271,9 +307,10 @@ export default function ConfirmationPage() {
           const slot = order.deliverySlot || confirmSlot;
           if (!rawDate && !slot) return null;
           // Format date: if it looks like ISO (YYYY-MM-DD) convert to "16 avril 2026"
-          const displayDate = rawDate && /^\d{4}-\d{2}-\d{2}$/.test(rawDate)
-            ? formatDateFR(rawDate)
-            : rawDate;
+          const displayDate =
+            rawDate && /^\d{4}-\d{2}-\d{2}$/.test(rawDate)
+              ? formatDateFR(rawDate)
+              : rawDate;
           const fmt = (t: string) => t.replace(':', 'h');
           let label = 'Livraison planifiée';
           if (displayDate && slot) {
@@ -294,10 +331,21 @@ export default function ConfirmationPage() {
               animate={{ y: 0, opacity: 1 }}
               transition={{ delay: 0.4 }}
               className="rounded-xl border px-4 py-3 flex items-center justify-center gap-2"
-              style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 10%, transparent)', borderColor: 'color-mix(in srgb, var(--color-primary) 40%, transparent)' }}
+              style={{
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-primary) 10%, transparent)',
+                borderColor:
+                  'color-mix(in srgb, var(--color-primary) 40%, transparent)',
+              }}
             >
-              <Clock className="w-5 h-5" style={{ color: 'var(--color-primary)' }} />
-              <span className="text-sm font-semibold" style={{ color: 'var(--color-primary)' }}>
+              <Clock
+                className="w-5 h-5"
+                style={{ color: 'var(--color-primary)' }}
+              />
+              <span
+                className="text-sm font-semibold"
+                style={{ color: 'var(--color-primary)' }}
+              >
                 {label}
               </span>
             </motion.div>
@@ -325,7 +373,9 @@ export default function ConfirmationPage() {
                   <p className="text-sm font-medium text-[#1C1917] line-clamp-1">
                     {item.name}
                   </p>
-                  <p className="text-xs text-[#78716C]">Quantité: {item.quantity}</p>
+                  <p className="text-xs text-[#78716C]">
+                    Quantité: {item.quantity}
+                  </p>
                 </div>
                 <p className="font-semibold text-[#1C1917] text-sm">
                   {/* price in centimes from DB, divide by 100 for MAD display — division already done in ProductCard/ProductDetailClient before addItem */}
@@ -338,7 +388,9 @@ export default function ConfirmationPage() {
             <div className="flex justify-between text-sm">
               <span className="text-[#78716C]">Sous-total</span>
               {/* confirmSubtotal is in MAD — written by verification/page.tsx before clearCart */}
-              <span className="font-semibold text-[#1C1917]">{confirmSubtotal.toFixed(0)} MAD</span>
+              <span className="font-semibold text-[#1C1917]">
+                {confirmSubtotal.toFixed(0)} MAD
+              </span>
             </div>
             <div className="flex justify-between text-sm">
               <span className="text-[#78716C]">Livraison</span>

--- a/app/store/[slug]/produit/[id]/loading.tsx
+++ b/app/store/[slug]/produit/[id]/loading.tsx
@@ -1,0 +1,36 @@
+export default function ProductDetailLoading() {
+  return (
+    <div className="min-h-screen bg-[#FAFAF9]">
+      {/* Header skeleton */}
+      <div className="sticky top-0 z-50 bg-white border-b border-[#E2E8F0] h-14 flex items-center px-4 gap-3">
+        <div className="w-9 h-9 rounded-full bg-[#F5F5F4] animate-pulse" />
+        <div className="h-5 w-40 bg-[#F5F5F4] animate-pulse rounded" />
+      </div>
+
+      {/* Product image skeleton */}
+      <div className="w-full aspect-square bg-[#F5F5F4] animate-pulse" />
+
+      {/* Product info skeleton */}
+      <div className="p-4 space-y-4">
+        {/* Title */}
+        <div className="space-y-2">
+          <div className="h-6 w-3/4 bg-[#F5F5F4] animate-pulse rounded" />
+          <div className="h-4 w-1/2 bg-[#F5F5F4] animate-pulse rounded" />
+        </div>
+
+        {/* Price */}
+        <div className="h-8 w-28 bg-[#F5F5F4] animate-pulse rounded" />
+
+        {/* Description lines */}
+        <div className="space-y-2 pt-2">
+          <div className="h-4 w-full bg-[#F5F5F4] animate-pulse rounded" />
+          <div className="h-4 w-5/6 bg-[#F5F5F4] animate-pulse rounded" />
+          <div className="h-4 w-4/6 bg-[#F5F5F4] animate-pulse rounded" />
+        </div>
+
+        {/* CTA button skeleton */}
+        <div className="h-14 w-full bg-[#F5F5F4] animate-pulse rounded-xl mt-6" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Confirmation page** — adds `ready` state guard: page renders a centered spinner until `useEffect` finishes reading sessionStorage, eliminating the blank order-number flash on first render
- **Product detail loading** — new `app/store/[slug]/produit/[id]/loading.tsx` with image placeholder + text line skeletons (Next.js route-level loading file)
- **Order tracking loading** — new `app/store/[slug]/commande/[id]/loading.tsx` with a 4-step timeline skeleton while Supabase fetches the order server-side
- **Dashboard commandes loading** — new `app/dashboard/commandes/loading.tsx` with 5 skeleton table rows (desktop) and 5 skeleton cards (mobile)

**Already present — not duplicated:**
- Store home product grid skeleton (`app/store/[slug]/loading.tsx`)
- Dashboard stats + recent orders skeleton (`app/dashboard/loading.tsx`)
- Checkout submit button spinner (`commande/page.tsx` `loading` state)
- OTP processing overlay (`verification/page.tsx` `isProcessing` overlay)

## Files changed

| File | Change |
|------|--------|
| `app/store/[slug]/confirmation/page.tsx` | Add `ready` state + spinner guard |
| `app/store/[slug]/produit/[id]/loading.tsx` | New — product detail skeleton |
| `app/store/[slug]/commande/[id]/loading.tsx` | New — order tracking skeleton |
| `app/dashboard/commandes/loading.tsx` | New — orders list skeleton |

## Test plan

- [ ] Navigate to a product detail page — verify skeleton appears during server fetch
- [ ] Navigate to order tracking (`/store/[slug]/commande/[id]`) — verify timeline skeleton appears during load
- [ ] Navigate to dashboard commandes — verify 5 skeleton rows appear before orders load
- [ ] Complete OTP flow → confirmation page — verify no blank order number flash (spinner shows briefly instead)
- [ ] TypeScript: `npx tsc --noEmit` → 0 errors

cc @Anas — please review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)