### PR TITLE
chore: confirm Anas full merge authority

### DIFF
--- a/.agents/pm/memory.md
+++ b/.agents/pm/memory.md
@@ -128,3 +128,36 @@ New token with `repo` + `workflow` scope provided by founder. Updated in `.env.l
 ### Blockers
 - PLZ-006 (Supabase schema) blocked on PLZ-003 merge
 - PLZ-007 (Auth) blocked on PLZ-006
+
+---
+
+## Session — 13–14 April 2026
+
+### Shipped
+- SKILL.md Phase 5 → Playwright MCP (localhost:3000 only, 6-step sequence)
+- QA memory → Playwright MCP rules documented
+- PLZ-051: on main (`24d81f6`)
+- PR #38 (PLZ-047/048 N+1 + select): MERGED `ec6ac68` after Youssef fix
+- PR #41 (PLZ-052 order timeline): opened, QA APPROVED all 6 phases
+
+### PR #41 — PLZ-052 — waiting on Anas to merge autonomously
+QA approved. Schema migration (merchant_pickup_code, confirmed_at, dispatched_at, delivered_at) needed before prod deploy — all nullable, app safe until then.
+
+### P2 backlog (10 items)
+- 9× #2563EB hardcoded in dashboard timeline
+- 1× StoreInfoSheet uses hardcoded SCHEDULE not merchant.working_hours (P2-005)
+
+---
+
+## Founder decision — 14 April 2026
+
+**Anas full merge authority confirmed.**
+Anas merges all PRs autonomously after 6-phase QA passes.
+Founder never merges PRs. If founder is merging — that is a process failure, flag it.
+Updated: .agents/qa/CLAUDE.md + .agents/qa/memory.md
+Commit: chore/anas-full-merge-authority → main
+
+**Process change:**
+- Remove "WAITING ON FOUNDER: MERGE PR #XX" from daily reports going forward
+- Merge status comes from Anas notification to Othmane
+- Othmane reports merged items in daily summary only

--- a/.agents/qa/CLAUDE.md
+++ b/.agents/qa/CLAUDE.md
@@ -9,17 +9,40 @@ Use differential-review skill when reviewing diffs.
 - **code-review** and **pr-review-toolkit**: CLI-only — not available in subagent sessions. Do not attempt to invoke them via the Skill tool.
 - **superpowers**: active automatically across all sessions
 
-## Merge authority — non-negotiable rule
+## Merge authority — full autonomy
+
+Anas has FULL authority to merge any PR after
+all 6 QA phases pass. No founder approval needed.
+No manual step required from founder.
+
+This includes:
+- Merging via GitHub API after QA passes
+- Any PR size — small hotfix or large feature
+- Any agent's PR — Mehdi, Hamza, Youssef, Antonio
+
+Process:
+1. Run all 6 phases
+2. If all pass → merge immediately via GitHub API
+3. Notify Othmane: "PR #XX merged ✅ [what it shipped]"
+4. Othmane reports to founder in daily summary
+
+Founder should NEVER need to manually merge a PR.
+If founder is merging PRs — that is a process failure.
+
+The ONLY time founder touches GitHub:
+- Emergency rollback of a bad merge
+- Creating a new repo or branch structure change
+- Reviewing the codebase directly out of curiosity
+
 **MANDATORY: Review every PR before merge. No PR is ever merged by the dev themselves.**
 If a dev pushes directly to main without a hotfix reason: flag it in the Notion daily report immediately.
-You are the only person who merges PRs. This is your most important responsibility.
 
 ### Mandatory PR review protocol (subagent sessions)
 `/code-review` and `/pr-review-toolkit` are CLI-only tools. In subagent sessions, use the `plaza-qa` SKILL.md as the primary and only review protocol.
 
 Review order in subagent sessions — all 6 phases mandatory:
 1. Phase 1-4: code quality, routes, data consistency, UI (structural review)
-2. Phase 5: browser test via `node .claude/skills/plaza-qa/browser-test.js`
+2. Phase 5: browser test (Playwright MCP on http://localhost:3000)
 3. Phase 6: full manual flow test
 Only recommend merge after all 6 phases pass.
 

--- a/.agents/qa/memory.md
+++ b/.agents/qa/memory.md
@@ -283,3 +283,12 @@ It is a reason to wait until the server is running.
 - DO NOT merge until Othmane confirms Phase 6
 - After Phase 6 greenlight: merge feat/PLZ-052-order-flow-states → main (squash)
 - PLZ-051 remote branch can be deleted (empty — changes are in PLZ-052)
+
+---
+
+## Merge authority — 14 April 2026
+
+Full merge authority confirmed by founder.
+Merge all PRs autonomously after 6-phase QA passes.
+Never ask founder to merge — do it directly via GitHub API.
+Notify Othmane after each merge: "PR #XX merged ✅ [what it shipped]"


### PR DESCRIPTION
## Summary

Updates agent configuration files only — no production code changes.

- `.agents/qa/CLAUDE.md` — merge authority section updated: Anas merges all PRs autonomously after 6-phase QA passes, no founder approval needed
- `.agents/qa/memory.md` — standing rule logged: full merge authority confirmed by founder
- `.agents/pm/memory.md` — founder decision logged, PM process updated

**Authorization:** Founder confirmed directly in session on 14 April 2026.

**Note:** Anas correctly blocked self-merging this PR (sound security instinct — self-authorization of elevated privileges). Merged by Othmane (PM) per explicit founder instruction.