### PR TITLE
PLZ-060 + PLZ-061 backend — admin foundation + driver approvals

### DIFF
--- a/.agents/backend/memory.md
+++ b/.agents/backend/memory.md
@@ -5,9 +5,74 @@ _Updated after every session._
 
 ## Current state
 
-Status: Sprint 2 — 14 April 2026.
+Status: 18 April 2026.
 PLZ-047 (P1) + PLZ-048 (P2) complete. PR #38 merged.
 PLZ-054 (P0): customers anon SELECT RLS policy — PR open, tagged Anas for review.
+
+**New ownership (2026-04-18):** You now handle ALL Supabase requests and db topics.
+Any migration that lands in `supabase/migrations/` is your responsibility to push.
+
+### PLZ-060 + PLZ-061 — Admin panel backend (2026-04-18)
+
+Branch: `plz-060-061-backend` (off main `12b3492`). Seven commits, all local, waiting on PM review before Anas merges via REST API.
+
+What shipped:
+- `admin_users` table + deny-all RLS + founder seed by email join.
+- `lib/admin-trust-cookie.ts` HMAC-signed trust cookie helpers
+  (30-day long / 10-min pending) using `ADMIN_TRUST_SECRET`.
+- `lib/admin-auth.ts` `requireAdmin()` helper (service role → `admin_users`).
+- Middleware admin guard requiring Supabase session + trust cookie on `/admin/**`
+  except `/admin/login` and `/admin/auth/callback`. Added `/admin` to `SKIP_INTL`.
+- Magic-link login: `app/admin/login/actions.ts` (`requestAdminMagicLink`) +
+  `app/admin/auth/callback/route.ts` (code exchange, admin recheck, trust-cookie mint).
+- `drivers` approval columns migration + backfill of `onboarding_status='active'`
+  rows → `approval_status='approved'`. Extended `onboarding_status` CHECK to
+  include `'rejected'`.
+- `app/admin/drivers/[id]/actions.ts` with `approveDriverAction`,
+  `resubmitDocumentAction`, `rejectDriverAction`, `getDocumentSignedUrl`
+  (60s TTL). All gate on `requireAdmin()`; all use service role.
+- **Testing-mode revert in `app/driver/onboarding/actions.ts`** —
+  `saveIdentityAndSubmitAction` + `submitOnboardingAction` now set
+  `pending_validation` + `approval_status='pending'` and redirect to
+  `/driver/onboarding/pending`. Commit hash `1eeced6`.
+- `types/supabase.ts` hand-updated for `admin_users` and new driver columns.
+  Run `supabase gen types typescript` after migrations land on remote to
+  replace the hand edit.
+- `.env.local.example` adds `ADMIN_TRUST_SECRET` + `NEXT_PUBLIC_SITE_URL`.
+
+### Pending migrations — NOT yet pushed to remote
+
+| File | What it does | Priority | Row impact |
+|---|---|---|---|
+| `20260416000001_plz059_drivers_phone_unique.sql` | UNIQUE on `drivers.phone` | **P0** | 0 — constraint only |
+| `20260416000002_plz059_drivers_city.sql` | `drivers.city text` + index | P1 | 0 — nullable column |
+| `20260418000001_plz060_admin_users.sql` | New `admin_users` table + RLS | **P0 for PLZ-060** | 0 — new table |
+| `20260418000002_plz060_seed_founder_admin.sql` | Seed founder by auth.users email join | P0 | 1 row (or 0 if founder hasn't magic-linked yet; idempotent) |
+| `20260418000003_plz061_driver_approvals.sql` | `drivers` approval columns + backfill | **P0 for PLZ-061** | Schema + UPDATE on all `onboarding_status='active'` drivers (currently 1-3 test drivers) |
+
+Push order: 059 files → 060 files (in order) → 061. Verify with:
+```sql
+SELECT conname FROM pg_constraint WHERE conrelid = 'drivers'::regclass AND contype = 'u';
+SELECT column_name FROM information_schema.columns WHERE table_name = 'drivers' AND column_name = 'city';
+SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name='admin_users';
+SELECT column_name FROM information_schema.columns WHERE table_name='drivers' AND column_name LIKE '%approval%';
+SELECT email FROM public.admin_users WHERE is_active = true;
+```
+
+Hold: do NOT push to remote until Othmane ACKs the file list + row impact (per PM's brief).
+
+### Open questions for PM
+
+- The founder seed migration joins `auth.users` on email. If the founder hasn't
+  yet been magic-linked in, the migration is a silent no-op. Options:
+  (a) push migration now, have founder request magic link once (it will create
+      the auth.users row), then re-run the seed migration idempotently, OR
+  (b) manually insert the `auth.users` row via a second migration before the
+      seed. Recommend (a) — less coupling.
+- Should admins without the "trust this device" checkbox still get in for one
+  session? Current implementation sets a session-scoped trust cookie so they do
+  — otherwise middleware would immediately bounce them after login. Flag if
+  this needs tightening.
 
 ---
 
@@ -95,6 +160,11 @@ Post findings to Notion: "Backend Audit — [date]"
 | 2026-04-13 | terminal_enabled, phone_verified, cmi_enabled | ✅ Production | DROP COLUMN terminal_enabled, phone_verified, cmi_enabled |
 | 2026-04-13 | decrement_stock() function | ✅ Production | DROP FUNCTION decrement_stock(uuid) |
 | 2026-04-14 | PLZ-054: customers anon SELECT policy (storefront tracking) | ⏳ PR open | DROP POLICY "customers: public select by order" ON customers |
+| 2026-04-16 | PLZ-059: `drivers.phone` UNIQUE constraint | ⏳ Not pushed | DROP CONSTRAINT drivers_phone_unique |
+| 2026-04-16 | PLZ-059: `drivers.city` text column + index | ⏳ Not pushed | DROP COLUMN city; DROP INDEX drivers_city_idx |
+| 2026-04-18 | PLZ-060: `admin_users` table + deny-all RLS | ⏳ Not pushed | DROP TABLE admin_users CASCADE |
+| 2026-04-18 | PLZ-060: seed founder admin (idempotent) | ⏳ Not pushed | DELETE FROM admin_users WHERE email='m.benmansour2017@gmail.com' |
+| 2026-04-18 | PLZ-061: `drivers` approval columns + backfill | ⏳ Not pushed | DROP COLUMN approval_status, approved_at, approved_by, rejection_reason, license_approved, insurance_approved, id_front_approved, id_back_approved; restore old `onboarding_status` CHECK |
 
 ---
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -10,3 +10,11 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # PostHog — get from your PostHog project settings
 NEXT_PUBLIC_POSTHOG_KEY=phc_your-posthog-key
 NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+
+# Admin panel (PLZ-060) — trust-device cookie HMAC signing key
+# Generate with: `openssl rand -hex 32` (must be at least 32 chars)
+# ⚠️ Rotating this invalidates all existing admin trust cookies.
+ADMIN_TRUST_SECRET=replace-with-32-byte-hex-secret
+
+# Public site URL for building magic-link redirect URLs (admin callback)
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/app/admin/auth/callback/route.ts
+++ b/app/admin/auth/callback/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+import {
+  TRUST_COOKIE_NAME,
+  TRUST_COOKIE_OPTIONS,
+  TRUST_PENDING_COOKIE_NAME,
+  signTrustCookie,
+} from '@/lib/admin-trust-cookie';
+
+/**
+ * Admin magic-link callback (PLZ-060).
+ *
+ * Flow:
+ *  1. Exchange the `code` query param for a Supabase session.
+ *  2. Verify the authenticated user is a row in admin_users (active).
+ *  3. If the `plaza_admin_trust_pending` cookie is set to "1", mint a
+ *     long-lived signed trust cookie. Otherwise, do not set the trust
+ *     cookie and the user will be treated as an untrusted device — they
+ *     will be bounced back to /admin/login by middleware. (Future: allow
+ *     per-session admin use without trust cookie; for v1 trust is required.)
+ *  4. Clear the pending cookie and redirect to /admin.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+
+  const loginUrl = new URL('/admin/login', request.url);
+  loginUrl.searchParams.set('error', 'callback_failed');
+
+  if (!code) {
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const supabase = await createClient();
+  const { error: exchangeError } =
+    await supabase.auth.exchangeCodeForSession(code);
+
+  if (exchangeError) {
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Verify admin membership (deny-all RLS → service role).
+  const service = createServiceClient();
+  const { data: adminRow } = await service
+    .from('admin_users')
+    .select('id, is_active')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!adminRow || !adminRow.is_active) {
+    // Sign out the just-created session — this user is not an admin.
+    await supabase.auth.signOut();
+    loginUrl.searchParams.set('error', 'not_admin');
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Read the trust-device intent from the pending cookie.
+  const cookieStore = await cookies();
+  const trustPending = cookieStore.get(TRUST_PENDING_COOKIE_NAME)?.value;
+
+  // Always clear the pending cookie.
+  cookieStore.set(TRUST_PENDING_COOKIE_NAME, '', {
+    ...TRUST_COOKIE_OPTIONS,
+    maxAge: 0,
+    path: '/admin',
+  });
+
+  // Build redirect response.
+  const redirectUrl = new URL('/admin', request.url);
+  const response = NextResponse.redirect(redirectUrl);
+
+  if (trustPending === '1') {
+    const signed = signTrustCookie(user.id);
+    response.cookies.set(TRUST_COOKIE_NAME, signed, TRUST_COOKIE_OPTIONS);
+  } else {
+    // v1 behaviour: the middleware requires a trust cookie on /admin/**.
+    // If the user did not opt in to trust-device, we still set a short-lived
+    // trust cookie (session-scoped: no maxAge) so they can use this session.
+    // On next visit without the long cookie, they'll log in again.
+    const signed = signTrustCookie(user.id);
+    response.cookies.set(TRUST_COOKIE_NAME, signed, {
+      ...TRUST_COOKIE_OPTIONS,
+      maxAge: undefined, // session cookie
+    });
+  }
+
+  return response;
+}

--- a/app/admin/drivers/[id]/actions.ts
+++ b/app/admin/drivers/[id]/actions.ts
@@ -1,0 +1,225 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createServiceClient } from '@/lib/supabase/service';
+import { requireAdmin } from '@/lib/admin-auth';
+
+type ActionResult = { success: true } | { success: false; error: string };
+
+type DocField =
+  | 'license_approved'
+  | 'insurance_approved'
+  | 'id_front_approved'
+  | 'id_back_approved';
+
+const DOC_FIELDS: readonly DocField[] = [
+  'license_approved',
+  'insurance_approved',
+  'id_front_approved',
+  'id_back_approved',
+] as const;
+
+const DOC_STORAGE_COLUMN: Record<DocField, 'license_photo_url' | 'insurance_url' | 'id_front_url' | 'id_back_url'> = {
+  license_approved: 'license_photo_url',
+  insurance_approved: 'insurance_url',
+  id_front_approved: 'id_front_url',
+  id_back_approved: 'id_back_url',
+};
+
+const MIN_REASON_LENGTH = 10;
+
+/**
+ * Approve a driver. Marks all four per-doc flags true, flips
+ * approval_status → 'approved', onboarding_status → 'active',
+ * records approved_by + approved_at.
+ */
+export async function approveDriverAction(
+  driverId: string,
+): Promise<ActionResult> {
+  const { adminRow } = await requireAdmin();
+  const service = createServiceClient();
+
+  // Guard against half-baked state: refuse approval if any document is
+  // still missing a URL. Approving with missing docs would mean the
+  // driver was approved without showing paperwork.
+  const { data: driver, error: fetchError } = await service
+    .from('drivers')
+    .select(
+      'id, license_photo_url, insurance_url, id_front_url, id_back_url',
+    )
+    .eq('id', driverId)
+    .maybeSingle();
+
+  if (fetchError || !driver) {
+    return { success: false, error: 'driver_not_found' };
+  }
+
+  if (
+    !driver.license_photo_url ||
+    !driver.insurance_url ||
+    !driver.id_front_url ||
+    !driver.id_back_url
+  ) {
+    return { success: false, error: 'missing_documents' };
+  }
+
+  const { error } = await service
+    .from('drivers')
+    .update({
+      approval_status: 'approved',
+      onboarding_status: 'active',
+      approved_by: adminRow.id,
+      approved_at: new Date().toISOString(),
+      rejection_reason: null,
+      license_approved: true,
+      insurance_approved: true,
+      id_front_approved: true,
+      id_back_approved: true,
+    })
+    .eq('id', driverId);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath('/admin/drivers');
+  revalidatePath(`/admin/drivers/${driverId}`);
+  return { success: true };
+}
+
+/**
+ * Ask the driver to resubmit a single document. Flips the per-doc
+ * flag to false, sets approval_status = 'resubmit', appends the
+ * reason (scoped to that doc) onto rejection_reason.
+ *
+ * Reason is mandatory (>= 10 chars) so the driver has actionable
+ * feedback on /driver/onboarding/pending.
+ */
+export async function resubmitDocumentAction(
+  driverId: string,
+  docField: DocField,
+  reason: string,
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  if (!DOC_FIELDS.includes(docField)) {
+    return { success: false, error: 'invalid_doc_field' };
+  }
+
+  const trimmed = (reason ?? '').trim();
+  if (trimmed.length < MIN_REASON_LENGTH) {
+    return { success: false, error: 'reason_too_short' };
+  }
+
+  const service = createServiceClient();
+
+  // Fetch existing reason to append (scoped tag makes it easy for the
+  // driver UI to parse per-doc reasons later if needed).
+  const { data: driver, error: fetchError } = await service
+    .from('drivers')
+    .select('id, rejection_reason')
+    .eq('id', driverId)
+    .maybeSingle();
+
+  if (fetchError || !driver) {
+    return { success: false, error: 'driver_not_found' };
+  }
+
+  const label = docField.replace('_approved', '');
+  const newLine = `[${label}] ${trimmed}`;
+  const nextReason = driver.rejection_reason
+    ? `${driver.rejection_reason}\n${newLine}`
+    : newLine;
+
+  const { error } = await service
+    .from('drivers')
+    .update({
+      [docField]: false,
+      approval_status: 'resubmit',
+      rejection_reason: nextReason,
+      // Keep onboarding_status as 'pending_validation' — the driver
+      // needs to re-upload this document but is not rejected outright.
+    })
+    .eq('id', driverId);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath('/admin/drivers');
+  revalidatePath(`/admin/drivers/${driverId}`);
+  return { success: true };
+}
+
+/**
+ * Reject a driver outright. Flips approval_status and onboarding_status
+ * to 'rejected'. Reason is mandatory.
+ */
+export async function rejectDriverAction(
+  driverId: string,
+  reason: string,
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const trimmed = (reason ?? '').trim();
+  if (trimmed.length < MIN_REASON_LENGTH) {
+    return { success: false, error: 'reason_too_short' };
+  }
+
+  const service = createServiceClient();
+
+  const { error } = await service
+    .from('drivers')
+    .update({
+      approval_status: 'rejected',
+      onboarding_status: 'rejected',
+      rejection_reason: trimmed,
+    })
+    .eq('id', driverId);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath('/admin/drivers');
+  revalidatePath(`/admin/drivers/${driverId}`);
+  return { success: true };
+}
+
+/**
+ * Generate a short-lived signed URL (60s TTL) for a driver document.
+ * The admin viewer calls this on document-card mount. Returns `null`
+ * if the driver doesn't have that document uploaded yet.
+ */
+export async function getDocumentSignedUrl(
+  driverId: string,
+  docField: DocField,
+): Promise<{ url: string } | { url: null } | { error: string }> {
+  await requireAdmin();
+
+  if (!DOC_FIELDS.includes(docField)) {
+    return { error: 'invalid_doc_field' };
+  }
+
+  const service = createServiceClient();
+
+  const urlColumn = DOC_STORAGE_COLUMN[docField];
+  const { data: driver, error: fetchError } = await service
+    .from('drivers')
+    .select(`id, ${urlColumn}`)
+    .eq('id', driverId)
+    .maybeSingle<{ id: string } & Record<typeof urlColumn, string | null>>();
+
+  if (fetchError || !driver) {
+    return { error: 'driver_not_found' };
+  }
+
+  const path = driver[urlColumn];
+  if (!path) {
+    return { url: null };
+  }
+
+  const { data: signed, error: signError } = await service.storage
+    .from('driver-documents')
+    .createSignedUrl(path, 60);
+
+  if (signError || !signed) {
+    return { error: signError?.message ?? 'signed_url_failed' };
+  }
+
+  return { url: signed.signedUrl };
+}

--- a/app/admin/login/actions.ts
+++ b/app/admin/login/actions.ts
@@ -1,0 +1,80 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+import {
+  TRUST_PENDING_COOKIE_NAME,
+  TRUST_PENDING_COOKIE_OPTIONS,
+} from '@/lib/admin-trust-cookie';
+
+export type RequestMagicLinkResult =
+  | { success: true }
+  | { success: false; error: 'invalid_email' | 'not_admin' | 'send_failed' };
+
+/**
+ * Request a magic-link email for admin login.
+ *
+ * - Validates the email.
+ * - Verifies the email belongs to an active admin user (service role).
+ * - Sends a magic link via Supabase that redirects to /admin/auth/callback.
+ * - Sets a short-lived cookie (10 min) carrying the trustDevice intent, so the
+ *   callback route can mint the long-lived trust cookie when appropriate.
+ *
+ * We deliberately DO NOT leak whether an email is registered — always return
+ * `{ success: true }` on non-admin emails to prevent enumeration. The only
+ * visible error cases are `invalid_email` (user typo) and `send_failed`
+ * (infra issue we want surfaced).
+ */
+export async function requestAdminMagicLink(
+  email: string,
+  trustDevice: boolean,
+): Promise<RequestMagicLinkResult> {
+  const trimmed = (email ?? '').trim().toLowerCase();
+
+  // Basic email shape check — no need to over-engineer.
+  if (!trimmed || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+    return { success: false, error: 'invalid_email' };
+  }
+
+  // Anti-enumeration: look up admin first via service role, but return
+  // success even when not found so the UI doesn't disclose membership.
+  const service = createServiceClient();
+  const { data: adminRow } = await service
+    .from('admin_users')
+    .select('id, is_active')
+    .eq('email', trimmed)
+    .maybeSingle();
+
+  if (!adminRow || !adminRow.is_active) {
+    return { success: true };
+  }
+
+  // Stash trustDevice intent in a short-lived cookie that the callback reads.
+  const cookieStore = await cookies();
+  cookieStore.set(
+    TRUST_PENDING_COOKIE_NAME,
+    trustDevice ? '1' : '0',
+    TRUST_PENDING_COOKIE_OPTIONS,
+  );
+
+  const supabase = await createClient();
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    process.env.NEXT_PUBLIC_APP_URL ??
+    'http://localhost:3000';
+
+  const { error } = await supabase.auth.signInWithOtp({
+    email: trimmed,
+    options: {
+      shouldCreateUser: false,
+      emailRedirectTo: `${siteUrl}/admin/auth/callback`,
+    },
+  });
+
+  if (error) {
+    return { success: false, error: 'send_failed' };
+  }
+
+  return { success: true };
+}

--- a/app/driver/onboarding/actions.ts
+++ b/app/driver/onboarding/actions.ts
@@ -73,9 +73,17 @@ export async function saveIdentityAndSubmitAction(
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'unauthenticated' };
 
+  // PLZ-061: testing-mode revert. Driver goes into the pending-validation
+  // queue, admin must approve via /admin/drivers before onboarding_status
+  // flips to 'active'.
   const { error } = await supabase
     .from('drivers')
-    .update({ id_front_url: frontUrl, id_back_url: backUrl, onboarding_status: 'pending_validation' } as never)
+    .update({
+      id_front_url: frontUrl,
+      id_back_url: backUrl,
+      onboarding_status: 'pending_validation',
+      approval_status: 'pending',
+    } as never)
     .eq('user_id', user.id);
   if (error) return { error: error.message };
   redirect('/driver/onboarding/pending');
@@ -86,9 +94,13 @@ export async function submitOnboardingAction(): Promise<{ error: string } | unde
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'unauthenticated' };
 
+  // PLZ-061: testing-mode revert. See saveIdentityAndSubmitAction.
   const { error } = await supabase
     .from('drivers')
-    .update({ onboarding_status: 'pending_validation' } as never)
+    .update({
+      onboarding_status: 'pending_validation',
+      approval_status: 'pending',
+    } as never)
     .eq('user_id', user.id);
 
   if (error) return { error: error.message };

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,0 +1,51 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+
+export type AdminRole = 'admin' | 'ops' | 'support';
+
+export type AdminRow = {
+  id: string;
+  role: AdminRole;
+  is_active: boolean;
+};
+
+/**
+ * Require an authenticated admin on a page or server action.
+ *
+ * - Verifies Supabase session exists.
+ * - Looks up admin_users via service role (RLS deny-all).
+ * - Redirects to /admin/login if either check fails.
+ *
+ * Note: this helper does NOT verify the trust-device cookie — that
+ * is enforced by middleware before any /admin/** request reaches here.
+ */
+export async function requireAdmin(): Promise<{
+  user: { id: string; email: string | null };
+  adminRow: AdminRow;
+}> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/admin/login');
+  }
+
+  const service = createServiceClient();
+  const { data: adminRow } = await service
+    .from('admin_users')
+    .select('id, role, is_active')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!adminRow || !adminRow.is_active) {
+    redirect('/admin/login');
+  }
+
+  return {
+    user: { id: user.id, email: user.email ?? null },
+    adminRow: adminRow as AdminRow,
+  };
+}

--- a/lib/admin-trust-cookie.ts
+++ b/lib/admin-trust-cookie.ts
@@ -1,0 +1,80 @@
+import crypto from 'node:crypto';
+
+/**
+ * Admin trust-device cookie (PLZ-060).
+ *
+ * Problem: Supabase session TTLs are project-wide — we can't set a 30-day
+ * session for admins without also extending it for merchants/drivers.
+ *
+ * Solution: layer an HMAC-signed HttpOnly cookie on top of the Supabase session.
+ * Admin middleware requires BOTH to be valid.
+ *
+ * Cookie format: `${userId}.${issuedAtMs}.${hmacSha256(userId.issuedAtMs)}`
+ */
+
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+function getSecret(): string {
+  const secret = process.env.ADMIN_TRUST_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      'ADMIN_TRUST_SECRET env var is missing or shorter than 32 chars. ' +
+        'Generate one with: `openssl rand -hex 32` and add it to .env.local.',
+    );
+  }
+  return secret;
+}
+
+export function signTrustCookie(userId: string): string {
+  const issuedAt = Date.now();
+  const payload = `${userId}.${issuedAt}`;
+  const sig = crypto
+    .createHmac('sha256', getSecret())
+    .update(payload)
+    .digest('hex');
+  return `${payload}.${sig}`;
+}
+
+export function verifyTrustCookie(cookie: string, userId: string): boolean {
+  const parts = cookie.split('.');
+  if (parts.length !== 3) return false;
+  const [cookieUserId, issuedAtRaw, sig] = parts;
+
+  if (cookieUserId !== userId) return false;
+
+  const issuedAt = Number(issuedAtRaw);
+  if (!Number.isFinite(issuedAt)) return false;
+  if (Date.now() - issuedAt > MAX_AGE_SECONDS * 1000) return false;
+
+  const expected = crypto
+    .createHmac('sha256', getSecret())
+    .update(`${cookieUserId}.${issuedAt}`)
+    .digest('hex');
+
+  // Constant-time compare — both must be equal length or timingSafeEqual throws.
+  const sigBuf = Buffer.from(sig, 'hex');
+  const expectedBuf = Buffer.from(expected, 'hex');
+  if (sigBuf.length !== expectedBuf.length) return false;
+
+  return crypto.timingSafeEqual(sigBuf, expectedBuf);
+}
+
+export const TRUST_COOKIE_NAME = 'plaza_admin_trust';
+export const TRUST_PENDING_COOKIE_NAME = 'plaza_admin_trust_pending';
+
+export const TRUST_COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: process.env.NODE_ENV === 'production',
+  path: '/admin',
+  maxAge: MAX_AGE_SECONDS,
+};
+
+// Short-lived cookie set on /admin/login, read on /admin/auth/callback.
+export const TRUST_PENDING_COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: process.env.NODE_ENV === 'production',
+  path: '/admin',
+  maxAge: 60 * 10, // 10 minutes
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,10 @@ import { type NextRequest, NextResponse } from 'next/server';
 import createIntlMiddleware from 'next-intl/middleware';
 import { createServerClient } from '@supabase/ssr';
 import { locales, defaultLocale } from './i18n/request';
+import {
+  TRUST_COOKIE_NAME,
+  verifyTrustCookie,
+} from './lib/admin-trust-cookie';
 
 const intlMiddleware = createIntlMiddleware({
   locales,
@@ -13,8 +17,60 @@ const PROTECTED_PREFIXES = ['/dashboard', '/onboarding', '/driver/livraisons', '
 // Internal pages that are exempt from auth (no merchant data exposed).
 const PUBLIC_OVERRIDES = ['/dashboard/agents'];
 
+// Admin routes that should NOT require admin auth (login screen + callback).
+const ADMIN_PUBLIC_PATHS = ['/admin/login', '/admin/auth/callback'];
+
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
+
+  // ── Admin guard (PLZ-060) ─────────────────────────────────────
+  // /admin/** requires both a Supabase session AND a valid signed
+  // trust cookie. Public paths (login, callback) are exempt.
+  if (pathname.startsWith('/admin')) {
+    const isAdminPublic = ADMIN_PUBLIC_PATHS.some(
+      (p) => pathname === p || pathname.startsWith(p + '/'),
+    );
+
+    if (!isAdminPublic) {
+      const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+          cookies: {
+            getAll() {
+              return request.cookies.getAll();
+            },
+            setAll() {
+              // Intentionally empty.
+            },
+          },
+        },
+      );
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      const trustCookie = request.cookies.get(TRUST_COOKIE_NAME)?.value;
+      const trustOk = user && trustCookie
+        ? verifyTrustCookie(trustCookie, user.id)
+        : false;
+
+      if (!user || !trustOk) {
+        const loginUrl = new URL('/admin/login', request.url);
+        const response = NextResponse.redirect(loginUrl);
+        // Clear stale trust cookie on failure.
+        response.cookies.set(TRUST_COOKIE_NAME, '', {
+          path: '/admin',
+          maxAge: 0,
+        });
+        return response;
+      }
+    }
+
+    // Admin paths never need intl rewriting (French-only for v1).
+    return NextResponse.next();
+  }
 
   const isPublicOverride = PUBLIC_OVERRIDES.some((p) => pathname.startsWith(p));
   const isProtected =
@@ -59,7 +115,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   // Skip intl rewriting for root — app/page.tsx
   // handles its own redirect to /dashboard or /auth/login
   // Skip intl rewriting for routes that do not use locale-prefixed folder structure
-  const SKIP_INTL = ["/", "/auth", "/onboarding", "/dashboard", "/store", "/driver", "/track"];
+  const SKIP_INTL = ["/", "/auth", "/onboarding", "/dashboard", "/store", "/driver", "/track", "/admin"];
   if (SKIP_INTL.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
     return NextResponse.next();
   }

--- a/supabase/migrations/20260418000001_plz060_admin_users.sql
+++ b/supabase/migrations/20260418000001_plz060_admin_users.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- PLZ-060 — Admin users table
+-- Foundation for the Plaza admin panel. Admin reads happen via
+-- service role only (deny-all RLS). Founder is seeded in the
+-- follow-up migration 20260418000002_plz060_seed_founder_admin.sql.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.admin_users (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  email       text NOT NULL,
+  role        text NOT NULL DEFAULT 'admin'
+    CHECK (role IN ('admin','ops','support')),
+  is_active   boolean NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS admin_users_user_id_idx
+  ON public.admin_users(user_id);
+
+CREATE INDEX IF NOT EXISTS admin_users_email_idx
+  ON public.admin_users(email);
+
+-- Deny-all RLS: admin reads go through service role only.
+ALTER TABLE public.admin_users ENABLE ROW LEVEL SECURITY;
+
+-- No policies added — with RLS enabled and no policies, all
+-- anon/authenticated access is denied. Service role bypasses RLS.

--- a/supabase/migrations/20260418000002_plz060_seed_founder_admin.sql
+++ b/supabase/migrations/20260418000002_plz060_seed_founder_admin.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- PLZ-060 — Seed founder admin user
+-- Inserts the founder into admin_users by looking up the matching
+-- auth.users row by email. If the founder account doesn't exist
+-- yet in auth.users, the INSERT is a no-op (WHERE clause filters it
+-- out). In that case, sign up via magic link and re-run this migration
+-- (or seed manually) — the migration is idempotent via ON CONFLICT.
+-- ============================================================
+
+INSERT INTO public.admin_users (user_id, email, role, is_active)
+SELECT u.id, u.email, 'admin', true
+FROM auth.users u
+WHERE u.email = 'm.benmansour2017@gmail.com'
+ON CONFLICT (user_id) DO UPDATE
+  SET email = EXCLUDED.email,
+      role = EXCLUDED.role,
+      is_active = EXCLUDED.is_active,
+      updated_at = now();

--- a/supabase/migrations/20260418000003_plz061_driver_approvals.sql
+++ b/supabase/migrations/20260418000003_plz061_driver_approvals.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- PLZ-061 — Driver approval columns + backfill
+-- Adds admin-approval workflow fields to drivers. Backfill marks
+-- already-active drivers (onboarding_status = 'active') as approved
+-- so the testing-mode cohort keeps working post-revert.
+-- ============================================================
+
+-- Extend onboarding_status with 'rejected' (used by rejectDriverAction).
+-- We drop + re-add the CHECK constraint to include the new value.
+DO $$
+DECLARE
+  conname text;
+BEGIN
+  SELECT c.conname
+    INTO conname
+  FROM pg_constraint c
+  WHERE c.conrelid = 'public.drivers'::regclass
+    AND c.contype  = 'c'
+    AND pg_get_constraintdef(c.oid) ILIKE '%onboarding_status%';
+
+  IF conname IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.drivers DROP CONSTRAINT %I', conname);
+  END IF;
+END $$;
+
+ALTER TABLE public.drivers
+  ADD CONSTRAINT drivers_onboarding_status_check
+  CHECK (onboarding_status IN (
+    'pending_onboarding',
+    'pending_validation',
+    'active',
+    'suspended',
+    'rejected'
+  ));
+
+-- Approval workflow columns.
+ALTER TABLE public.drivers
+  ADD COLUMN IF NOT EXISTS approval_status text NOT NULL DEFAULT 'pending'
+    CHECK (approval_status IN ('pending','approved','rejected','resubmit')),
+  ADD COLUMN IF NOT EXISTS approved_at timestamptz,
+  ADD COLUMN IF NOT EXISTS approved_by uuid REFERENCES public.admin_users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS rejection_reason text,
+  ADD COLUMN IF NOT EXISTS license_approved   boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS insurance_approved boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS id_front_approved  boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS id_back_approved   boolean NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS drivers_approval_status_idx
+  ON public.drivers(approval_status);
+
+-- Backfill: any driver already onboarded + active is implicitly approved
+-- (testing-mode cohort, production-seeded drivers). This keeps them
+-- logged in and dispatchable after the testing-mode revert.
+UPDATE public.drivers
+SET
+  approval_status    = 'approved',
+  approved_at        = COALESCE(approved_at, now()),
+  license_approved   = true,
+  insurance_approved = true,
+  id_front_approved  = true,
+  id_back_approved   = true
+WHERE onboarding_status = 'active'
+  AND approval_status   = 'pending';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -399,45 +399,110 @@ export type Database = {
           insurance_url:      string | null
           id_front_url:       string | null
           id_back_url:        string | null
-          onboarding_status:  'pending_onboarding' | 'pending_validation' | 'active' | 'suspended'
-          // PLZ-058: dispatch engine columns
+          onboarding_status:  'pending_onboarding' | 'pending_validation' | 'active' | 'suspended' | 'rejected'
+          // PLZ-058/059: dispatch engine + city column
           city:               string | null
+          // PLZ-061: admin approval columns
+          approval_status:    'pending' | 'approved' | 'rejected' | 'resubmit'
+          approved_at:        string | null
+          approved_by:        string | null
+          rejection_reason:   string | null
+          license_approved:   boolean
+          insurance_approved: boolean
+          id_front_approved:  boolean
+          id_back_approved:   boolean
         }
         Insert: {
-          id?:                string
-          full_name:          string
-          phone:              string
-          is_available?:      boolean
-          created_at?:        string
-          user_id?:           string | null
-          otp_attempts?:      number
-          locked_until?:      string | null
-          phone_verified?:    boolean
-          vehicle_type?:      'moto' | 'velo' | 'voiture' | 'autre' | null
-          license_photo_url?: string | null
-          insurance_url?:     string | null
-          id_front_url?:      string | null
-          id_back_url?:       string | null
-          onboarding_status?: 'pending_onboarding' | 'pending_validation' | 'active' | 'suspended'
-          city?:              string | null
+          id?:                 string
+          full_name:           string
+          phone:               string
+          is_available?:       boolean
+          created_at?:         string
+          user_id?:            string | null
+          otp_attempts?:       number
+          locked_until?:       string | null
+          phone_verified?:     boolean
+          vehicle_type?:       'moto' | 'velo' | 'voiture' | 'autre' | null
+          license_photo_url?:  string | null
+          insurance_url?:      string | null
+          id_front_url?:       string | null
+          id_back_url?:        string | null
+          onboarding_status?:  'pending_onboarding' | 'pending_validation' | 'active' | 'suspended' | 'rejected'
+          city?:               string | null
+          approval_status?:    'pending' | 'approved' | 'rejected' | 'resubmit'
+          approved_at?:        string | null
+          approved_by?:        string | null
+          rejection_reason?:   string | null
+          license_approved?:   boolean
+          insurance_approved?: boolean
+          id_front_approved?:  boolean
+          id_back_approved?:   boolean
         }
         Update: {
-          id?:                string
-          full_name?:         string
-          phone?:             string
-          is_available?:      boolean
-          created_at?:        string
-          user_id?:           string | null
-          otp_attempts?:      number
-          locked_until?:      string | null
-          phone_verified?:    boolean
-          vehicle_type?:      'moto' | 'velo' | 'voiture' | 'autre' | null
-          license_photo_url?: string | null
-          insurance_url?:     string | null
-          id_front_url?:      string | null
-          id_back_url?:       string | null
-          onboarding_status?: 'pending_onboarding' | 'pending_validation' | 'active' | 'suspended'
-          city?:              string | null
+          id?:                 string
+          full_name?:          string
+          phone?:              string
+          is_available?:       boolean
+          created_at?:         string
+          user_id?:            string | null
+          otp_attempts?:       number
+          locked_until?:       string | null
+          phone_verified?:     boolean
+          vehicle_type?:       'moto' | 'velo' | 'voiture' | 'autre' | null
+          license_photo_url?:  string | null
+          insurance_url?:      string | null
+          id_front_url?:       string | null
+          id_back_url?:        string | null
+          onboarding_status?:  'pending_onboarding' | 'pending_validation' | 'active' | 'suspended' | 'rejected'
+          city?:               string | null
+          approval_status?:    'pending' | 'approved' | 'rejected' | 'resubmit'
+          approved_at?:        string | null
+          approved_by?:        string | null
+          rejection_reason?:   string | null
+          license_approved?:   boolean
+          insurance_approved?: boolean
+          id_front_approved?:  boolean
+          id_back_approved?:   boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'drivers_approved_by_fkey'
+            columns: ['approved_by']
+            isOneToOne: false
+            referencedRelation: 'admin_users'
+            referencedColumns: ['id']
+          }
+        ]
+      }
+
+      // ── Admin Users (PLZ-060) ───────────────────────────────────
+      admin_users: {
+        Row: {
+          id:         string
+          user_id:    string
+          email:      string
+          role:       'admin' | 'ops' | 'support'
+          is_active:  boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?:         string
+          user_id:     string
+          email:       string
+          role?:       'admin' | 'ops' | 'support'
+          is_active?:  boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?:         string
+          user_id?:    string
+          email?:      string
+          role?:       'admin' | 'ops' | 'support'
+          is_active?:  boolean
+          created_at?: string
+          updated_at?: string
         }
         Relationships: []
       }
@@ -781,6 +846,7 @@ export type DispatchError   = Database['public']['Tables']['dispatch_errors']['R
 export type SupportTicket   = Database['public']['Tables']['support_tickets']['Row']
 export type SupportMessage  = Database['public']['Tables']['support_messages']['Row']
 export type DeliveryZone    = Database['public']['Tables']['delivery_zones']['Row']
+export type AdminUser       = Database['public']['Tables']['admin_users']['Row']
 
 export type MerchantInsert       = Database['public']['Tables']['merchants']['Insert']
 export type ProductInsert        = Database['public']['Tables']['products']['Insert']


### PR DESCRIPTION
## Summary

Backend half of the admin panel Phase 1 (PLZ-060) and Phase 2 (PLZ-061). Ships the `admin_users` table, magic-link auth with a trust-device cookie layer, the drivers approval schema, and the approval server actions. Also reverts the driver onboarding testing-mode auto-approve.

## Scope

### PLZ-060 — Admin foundation
- `admin_users` table + deny-all RLS + seed for founder (joins `auth.users` on email — idempotent).
- `lib/admin-auth.ts` with `requireAdmin()` helper (service-role query).
- `lib/admin-trust-cookie.ts` — HMAC-signed HttpOnly cookie, 30-day TTL. Uses `ADMIN_TRUST_SECRET` env var.
- `/admin/login` server action `requestAdminMagicLink(email, trustDevice)` and `/admin/auth/callback` route.
- `middleware.ts` — admin guard requires both a valid Supabase session AND a valid trust cookie. `/admin` added to `SKIP_INTL`.
- `ADMIN_TRUST_SECRET` added to `.env.local.example`.

### PLZ-061 — Driver approvals backend
- `drivers` schema additions: `approval_status`, `approved_at`, `approved_by`, `rejection_reason`, plus per-doc flags (`license_approved`, `insurance_approved`, `id_front_approved`, `id_back_approved`).
- Backfill: existing active drivers get `approval_status = 'approved'` and all per-doc flags true.
- `onboarding_status` CHECK extended to include `'rejected'`.
- Server actions in `app/admin/drivers/[id]/actions.ts`: `approveDriverAction`, `resubmitDocumentAction`, `rejectDriverAction`, `getDocumentSignedUrl` (60s TTL).
- **Testing-mode revert:** `saveIdentityAndSubmitAction` and `submitOnboardingAction` in `app/driver/onboarding/actions.ts` now set `onboarding_status = 'pending_validation'`, `approval_status = 'pending'`, and redirect to `/driver/onboarding/pending` (no more auto-approve).

## Migrations

Five files (push order already lexicographic):
- `20260416000001_plz059_drivers_phone_unique.sql` — constraint only, 0 rows.
- `20260416000002_plz059_drivers_city.sql` — nullable column + index, 0 rows.
- `20260418000001_plz060_admin_users.sql` — new table + deny-all RLS.
- `20260418000002_plz060_seed_founder_admin.sql` — inserts founder iff `auth.users` has a row; idempotent on conflict.
- `20260418000003_plz061_driver_approvals.sql` — new columns on `drivers` + CHECK update + backfill on 1–3 test rows.

## Post-merge steps (in order)
1. Founder magic-links `/admin/login` once (creates `auth.users` row).
2. Re-run seed INSERT manually in Supabase Studio (idempotent) to populate `admin_users`.
3. Regenerate `types/supabase.ts` via `supabase gen types typescript` to replace hand-edits.

## Test plan
- [ ] Migrations apply cleanly on remote.
- [ ] `/admin` redirects to `/admin/login` without a session.
- [ ] Magic-link email arrives, callback sets session + trust cookie (if opted in).
- [ ] `/admin` is accessible after login.
- [ ] Clearing `plaza_admin_trust` cookie forces re-auth on next request.
- [ ] Driver onboarding submission lands on `/driver/onboarding/pending` with `approval_status = 'pending'`.
- [ ] `approveDriverAction` flips `onboarding_status` to `active`.

## Notes
- Frontend (`plz-060-061-frontend`) lands in a follow-up PR after this one merges. It currently stubs `lib/admin-auth.stub.ts` + mock driver data; those swap to real imports once this is merged.
- `types/supabase.ts` is hand-edited in this PR to compile locally; regenerate post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)