### PR TITLE
fix(PLZ-063b): split signOutAdmin to lib/admin-auth-client.ts — fix P0 build failure

### DIFF
--- a/app/admin/_components/AdminShell.tsx
+++ b/app/admin/_components/AdminShell.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
-import { signOutAdmin } from '@/lib/admin-auth';
+import { signOutAdmin } from '@/lib/admin-auth-client';
 import { SidebarNav } from './SidebarNav';
 import { Topbar } from './Topbar';
 

--- a/lib/admin-auth-client.ts
+++ b/lib/admin-auth-client.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { createClient } from '@/lib/supabase/client';
+import { TRUST_COOKIE_NAME } from '@/lib/admin-trust-cookie';
+
+/**
+ * Sign out the current admin (browser-safe).
+ *
+ * - Invalidates the Supabase session via the browser client (clears sb-* cookies).
+ * - Clears the plaza_admin_trust cookie for belt-and-suspenders cleanup.
+ *   (HttpOnly cookies set by the server cannot be deleted from JS, but the
+ *   server middleware will reject any future requests once the Supabase session
+ *   is gone.)
+ *
+ * Import this in 'use client' components — NOT lib/admin-auth.ts which is
+ * server-only (it imports next/headers via lib/supabase/server.ts).
+ */
+export async function signOutAdmin(): Promise<void> {
+  const supabase = createClient();
+  await supabase.auth.signOut();
+
+  // Best-effort removal of the trust cookie from the browser side.
+  // The cookie path must match the one used when it was set (/admin).
+  document.cookie = `${TRUST_COOKIE_NAME}=; Max-Age=0; path=/admin`;
+}

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,8 +1,6 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { createServiceClient } from '@/lib/supabase/service';
-import { createClient as createBrowserClient } from '@/lib/supabase/client';
-import { TRUST_COOKIE_NAME } from '@/lib/admin-trust-cookie';
 
 export type AdminRole = 'admin' | 'ops' | 'support';
 
@@ -50,24 +48,4 @@ export async function requireAdmin(): Promise<{
     user: { id: user.id, email: user.email ?? null },
     adminRow: adminRow as AdminRow,
   };
-}
-
-/**
- * Sign out the current admin:
- * - Invalidates the Supabase session (browser client, clears sb-* cookies).
- * - Deletes the plaza_admin_trust HttpOnly cookie by setting max-age=0.
- *
- * This is a client-callable async function — import it in client components
- * that need a logout button.
- */
-export async function signOutAdmin(): Promise<void> {
-  const supabase = createBrowserClient();
-  await supabase.auth.signOut();
-
-  // Delete the trust cookie by setting it with max-age=0 via document.cookie
-  // (HttpOnly cookies set by the server cannot be deleted from JS, but the
-  // server middleware will reject any future requests once the Supabase session
-  // is gone.  For belt-and-suspenders we also hit the server logout route.)
-  // The cookie is scoped to /admin so this deletion is path-specific.
-  document.cookie = `${TRUST_COOKIE_NAME}=; Max-Age=0; path=/admin`;
 }


### PR DESCRIPTION
## P0 Hotfix — main build is broken after PR #54 merge

### Root cause

`lib/admin-auth.ts` is imported by the server-side admin layout (`app/admin/(shell)/layout.tsx`), which uses `next/headers` via `lib/supabase/server.ts`. PR #54 added `signOutAdmin()` to this file, which calls `document.cookie` (browser API) and `createBrowserClient()`. This creates a Next.js server/client bundle boundary violation:

```
TypeError: __webpack_modules__[moduleId] is not a function
Import trace: lib/admin-auth.ts → app/admin/(shell)/layout.tsx
```

This only surfaces at **build time** (`next build` / Vercel deploy) — `npm run dev` masks it. The Vercel failure on PR #54 was the signal.

### Fix (3 files)

| File | Change |
|---|---|
| `lib/admin-auth.ts` | Remove `signOutAdmin`, `createBrowserClient` import, `TRUST_COOKIE_NAME` import — server-only again |
| `lib/admin-auth-client.ts` | **New file** — `'use client'` module containing `signOutAdmin()` only |
| `app/admin/_components/AdminShell.tsx` | Import `signOutAdmin` from `@/lib/admin-auth-client` instead of `@/lib/admin-auth` |

### Logout behaviour is unchanged

`signOutAdmin()` logic is identical — only the module it lives in has changed.

### Verified

- `npx tsc --noEmit` → EXIT 0
- `npx next build` → ✓ Compiled successfully

🤖 QA hotfix by Anas