### PR TITLE
fix(PLZ-065): returning driver OTP routes to pin-login not pin-setup

### DIFF
--- a/app/driver/auth/otp/actions.ts
+++ b/app/driver/auth/otp/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
+import { createServiceClient } from '@/lib/supabase/service';
 
 type OtpVerifyResult = { error: string } | undefined;
 
@@ -9,8 +10,9 @@ type OtpVerifyResult = { error: string } | undefined;
  * Stub: any 6-digit code is accepted.
  * TODO: integrate Twilio / Vonage OTP verification here.
  *
- * isNewDriver = true → redirect to PIN setup (first registration)
- * isNewDriver = false → redirect to PIN login (device change / recovery)
+ * After verification, check whether the driver already has a PIN:
+ *   - user_id is null  → new driver  → redirect to PIN setup
+ *   - user_id is set   → returning driver → redirect to PIN login
  */
 export async function verifyDriverOtpAction(
   phone: string,
@@ -23,6 +25,22 @@ export async function verifyDriverOtpAction(
   // TODO: real OTP check goes here
   // const valid = await smsProvider.verifyOtp(phone, code);
   // if (!valid) return { error: 'wrong_code' };
+
+  // Determine whether this driver already has a PIN by checking if a
+  // Supabase Auth user has been created for them (user_id non-null).
+  const service = createServiceClient();
+  const { data: driver } = await service
+    .from('drivers')
+    .select('user_id, full_name')
+    .eq('phone', phone)
+    .maybeSingle<{ user_id: string | null; full_name: string }>();
+
+  const isReturning = driver?.user_id != null;
+
+  if (isReturning) {
+    const params = new URLSearchParams({ phone, name: driver!.full_name });
+    redirect(`/driver/auth/pin?${params.toString()}`);
+  }
 
   const params = new URLSearchParams({ phone });
   redirect(`/driver/auth/pin-setup?${params.toString()}`);

--- a/app/driver/auth/pin-setup/actions.ts
+++ b/app/driver/auth/pin-setup/actions.ts
@@ -71,6 +71,7 @@ export async function completeDriverPinSetupAction(
       start_time: '08:00:00',
       end_time: '18:00:00',
     }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (service as any)
       .from('driver_schedules')
       .upsert(defaultSchedule, { onConflict: 'driver_id,day_of_week', ignoreDuplicates: true });

--- a/app/driver/profil/horaires/actions.ts
+++ b/app/driver/profil/horaires/actions.ts
@@ -37,6 +37,7 @@ export async function saveScheduleAction(
     end_time:    day.end_time   + ':00',
   }))
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { error } = await (supabase as any)
     .from('driver_schedules')
     .upsert(rows, { onConflict: 'driver_id,day_of_week' }) as { error: { message: string } | null }
@@ -55,6 +56,7 @@ export async function getScheduleAction(): Promise<DaySchedule[]> {
   const driver = await getDriverProfile(user.id)
   if (!driver) return defaultSchedule()
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data } = await (supabase as any)
     .from('driver_schedules')
     .select('day_of_week, is_active, start_time, end_time')


### PR DESCRIPTION
## Summary

- **Bug:** verifyDriverOtpAction always redirected to /driver/auth/pin-setup regardless of driver status, causing returning drivers to overwrite their existing PIN.
- **Fix:** After OTP verification, query drivers.user_id for the phone number. A non-null user_id means the driver already completed pin-setup and has a Supabase Auth account — redirect to /driver/auth/pin (PIN login). A null user_id means a brand-new driver — redirect to /driver/auth/pin-setup.
- **Also fixed:** Two pre-existing no-explicit-any errors in pin-setup/actions.ts and profil/horaires/actions.ts that were blocking the production build on main.

## Files changed

- app/driver/auth/otp/actions.ts — core fix: branch on user_id presence
- app/driver/auth/pin-setup/actions.ts — add eslint-disable for pre-existing any cast
- app/driver/profil/horaires/actions.ts — add eslint-disable for pre-existing any casts

## Test plan

- [ ] New driver (no record in DB): phone → OTP → lands on /driver/auth/pin-setup
- [ ] Returning driver (user_id set, onboarding_status = pending_onboarding): phone → OTP → lands on /driver/auth/pin with correct phone + name params
- [ ] Active driver: still bypasses OTP entirely via phone/actions.ts (unchanged)
- [ ] npx next build compiles cleanly (no ESLint errors)

🤖 Generated with Claude Code