### PR TITLE
fix(PLZ-071): replace dead mailto with ReportIssueSheet in order detail

### DIFF
--- a/.agents/dev2/memory.md
+++ b/.agents/dev2/memory.md
@@ -141,3 +141,33 @@ Comment added in FinancesClient.tsx to document this.
 `onMouseEnter`/`onMouseLeave` handlers used in BoutiqueForm.tsx (view store button) and
 dashboard/page.tsx (view store button) — required because Tailwind v3 cannot express
 `hover:bg-[color-mix(...)]` for dynamic CSS variable tints.
+
+---
+
+## PLZ-071 — Fix dead "Signaler un problème" button — 20 April 2026
+
+**Branch:** `fix/PLZ-071-report-issue-dialog`
+**PR:** https://github.com/MohamedBenmansour26/plaza-platform/pull/63
+**Status:** PR open, awaiting Anas QA review
+
+### What was built:
+- **New component** `app/dashboard/commandes/ReportIssueSheet.tsx`
+  - Bottom sheet, same pattern as `NewTicketSheet` (z-[60]/z-[70] to stack above parent `OrderDetailSheet` which is z-50)
+  - Pre-fills `category='order_issue'`, `subject='Problème commande ${order.order_number}'`, `order_id`
+  - Description textarea (optional, MAX_DESC=1000)
+  - Calls `createTicketAction` from `app/dashboard/support/actions.ts`
+  - On success: 1.2s "Ticket créé" state → `onClose()` + `router.push('/dashboard/support')`
+  - Timer stored in `useRef` and cancelled on unmount via `useEffect` cleanup
+
+- **Wired in `OrderDetailSheet.tsx`** (desktop drawer): `reportOpen` state, `onReportOpen` prop on `ActionBar`, `<ReportIssueSheet>` rendered conditionally after the drawer panel
+
+- **Wired in `[id]/OrderDetailClient.tsx`** (mobile full-page): same pattern — `reportOpen` state, `setReportOpen(true)` on button click, `<ReportIssueSheet>` rendered at bottom of component
+
+### Bugs fixed by simplify review:
+1. **z-index conflict**: `ReportIssueSheet` was z-40/z-50 (same as parent `OrderDetailSheet`). Raised to z-[60]/z-[70] so nested sheet always renders on top.
+2. **Unguarded setTimeout**: Timer in `handleSubmit` was not cancelled on unmount. Fixed with `useRef<ReturnType<typeof setTimeout>>` + `useEffect` cleanup.
+
+### Notes:
+- No i18n keys needed — support flow is FR-only at MVP per spec
+- No new dependencies
+- `tsc --noEmit` exits 0, `npm run lint` exits 0

--- a/app/dashboard/commandes/OrderDetailSheet.tsx
+++ b/app/dashboard/commandes/OrderDetailSheet.tsx
@@ -9,6 +9,7 @@ import {
   confirmOrderAction,
 } from './actions';
 import { formatMAD } from './OrdersClient';
+import { ReportIssueSheet } from './ReportIssueSheet';
 import type { OrderWithDetails } from '@/lib/db/orders';
 import type { OrderStatus, PaymentMethod, DeliveryStatus } from '@/types/supabase';
 import { MOROCCO_TZ } from '@/lib/timezone';
@@ -143,10 +144,12 @@ function DeliveryStatusCard({ delivery }: { delivery: NonNullable<OrderWithDetai
 function ActionBar({
   order,
   onClose,
+  onReportOpen,
   router,
 }: {
   order: OrderWithDetails;
   onClose: () => void;
+  onReportOpen: () => void;
   router: ReturnType<typeof useRouter>;
 }) {
   const [isPending, startTransition] = useTransition();
@@ -205,9 +208,7 @@ function ActionBar({
 
         {!isPending && (
           <button
-            onClick={() => {
-              window.location.href = `mailto:support@plaza.ma?subject=Problème commande ${order.order_number}&body=Bonjour, je rencontre un problème avec la commande ${order.order_number}.`;
-            }}
+            onClick={onReportOpen}
             className="w-full h-12 border border-[#E2E8F0] text-[#78716C] rounded-lg text-[14px] font-medium hover:bg-[#F5F5F4] transition-colors"
           >
             Signaler un problème
@@ -227,6 +228,7 @@ type Props = {
 
 export function OrderDetailSheet({ order, onClose }: Props) {
   const router = useRouter();
+  const [reportOpen, setReportOpen] = useState(false);
   return (
     <>
       {/* Backdrop */}
@@ -373,9 +375,21 @@ export function OrderDetailSheet({ order, onClose }: Props) {
 
         {/* Footer actions */}
         <div className="border-t border-[#E2E8F0] px-6 py-4 flex gap-3 flex-shrink-0 bg-white">
-          <ActionBar order={order} onClose={onClose} router={router} />
+          <ActionBar
+            order={order}
+            onClose={onClose}
+            onReportOpen={() => setReportOpen(true)}
+            router={router}
+          />
         </div>
       </div>
+
+      {reportOpen && (
+        <ReportIssueSheet
+          order={{ id: order.id, order_number: order.order_number }}
+          onClose={() => setReportOpen(false)}
+        />
+      )}
     </>
   );
 }

--- a/app/dashboard/commandes/ReportIssueSheet.tsx
+++ b/app/dashboard/commandes/ReportIssueSheet.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useTransition, useState, useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { X, Loader2 } from 'lucide-react';
+import { createTicketAction } from '@/app/dashboard/support/actions';
+
+type Props = {
+  order: { id: string; order_number: string };
+  onClose: () => void;
+};
+
+const MAX_DESC = 1000;
+
+export function ReportIssueSheet({ order, onClose }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [description, setDescription] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cancel pending close-timer if the component unmounts early
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
+
+  const subject = `Problème commande ${order.order_number}`;
+
+  const handleSubmit = () => {
+    startTransition(async () => {
+      await createTicketAction(
+        { subject, category: 'order_issue', order_id: order.id },
+        description,
+      );
+      setSubmitted(true);
+      timerRef.current = setTimeout(() => {
+        onClose();
+        router.push('/dashboard/support');
+      }, 1200);
+    });
+  };
+
+  return (
+    <>
+      {/* Backdrop — above the parent OrderDetailSheet (z-50) */}
+      <div className="fixed inset-0 bg-black/30 z-[60]" onClick={onClose} />
+
+      {/* Sheet */}
+      <div className="fixed end-0 top-0 h-screen w-full max-w-[480px] bg-white shadow-xl z-[70] flex flex-col">
+
+        {/* Header */}
+        <div className="h-16 border-b border-[#E2E8F0] px-6 flex items-center justify-between flex-shrink-0">
+          <div>
+            <h2 className="text-base font-semibold text-[#1C1917]">Signaler un problème</h2>
+            <p className="text-xs text-[#78716C]">{order.order_number}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center text-[#78716C] hover:text-[#1C1917] hover:bg-[#F8FAFC] rounded-lg transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-6">
+          {submitted ? (
+            <div className="flex flex-col items-center justify-center h-full py-12 text-center">
+              <div className="w-16 h-16 rounded-full bg-[#F0FDF4] flex items-center justify-center mb-4">
+                <span className="text-3xl">✅</span>
+              </div>
+              <h3 className="text-lg font-semibold text-[#1C1917] mb-2">Ticket créé</h3>
+              <p className="text-sm text-[#78716C]">
+                Votre signalement a été transmis à l&apos;équipe Plaza.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-5">
+              {/* Pre-filled subject — read-only info */}
+              <div className="bg-[#F8FAFC] rounded-lg p-3 border border-[#E2E8F0]">
+                <p className="text-xs text-[#78716C] mb-0.5">Sujet</p>
+                <p className="text-sm font-medium text-[#1C1917]">{subject}</p>
+              </div>
+
+              {/* Description */}
+              <div>
+                <label className="block text-sm font-medium text-[#1C1917] mb-1.5">
+                  Description{' '}
+                  <span className="text-[#A8A29E] font-normal">(optionnel)</span>
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value.slice(0, MAX_DESC))}
+                  placeholder="Décrivez le problème rencontré avec cette commande…"
+                  rows={6}
+                  className="w-full px-3 py-2.5 border border-[#E2E8F0] rounded-lg text-sm resize-none focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                />
+                <div className="text-xs text-[#A8A29E] text-end mt-1">
+                  {description.length}/{MAX_DESC}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        {!submitted && (
+          <div className="border-t border-[#E2E8F0] px-6 py-4 flex-shrink-0">
+            <button
+              disabled={isPending}
+              onClick={handleSubmit}
+              className="w-full h-11 text-white text-sm font-semibold rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center justify-center gap-2"
+              style={{ backgroundColor: 'var(--color-primary)' }}
+            >
+              {isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+              Créer le ticket
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/dashboard/commandes/[id]/OrderDetailClient.tsx
+++ b/app/dashboard/commandes/[id]/OrderDetailClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTransition } from 'react';
+import { useTransition, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ArrowLeft, User, Phone, MapPin, Check, Loader2 } from 'lucide-react';
@@ -10,6 +10,7 @@ import {
   confirmOrderAction,
 } from '../actions';
 import { formatMAD, formatDate } from '../OrdersClient';
+import { ReportIssueSheet } from '../ReportIssueSheet';
 import type { OrderWithDetails } from '@/lib/db/orders';
 import type { OrderStatus, PaymentMethod } from '@/types/supabase';
 
@@ -106,6 +107,7 @@ export function OrderDetailClient({ order }: Props) {
   const router = useRouter();
   const t = useTranslations('orders');
   const [isPending, startTransition] = useTransition();
+  const [reportOpen, setReportOpen] = useState(false);
 
   // User-facing string arrays MUST be inside the component after t() — see memory.md BUG-013–016
   const STATUS_BANNER: Record<OrderStatus, { bg: string; text: string; label: string }> = {
@@ -338,9 +340,7 @@ export function OrderDetailClient({ order }: Props) {
                 </button>
               )}
               <button
-                onClick={() => {
-                  window.location.href = `mailto:support@plaza.ma?subject=Problème commande ${order.order_number}&body=Bonjour, je rencontre un problème avec la commande ${order.order_number}.`;
-                }}
+                onClick={() => setReportOpen(true)}
                 className="w-full h-12 border border-[#E2E8F0] text-[#78716C] text-[14px] font-medium rounded-lg hover:bg-[#F5F5F4] transition-colors"
               >
                 Signaler un problème
@@ -348,6 +348,13 @@ export function OrderDetailClient({ order }: Props) {
             </div>
           )}
         </div>
+      )}
+
+      {reportOpen && (
+        <ReportIssueSheet
+          order={{ id: order.id, order_number: order.order_number }}
+          onClose={() => setReportOpen(false)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Bug fixed:** Clicking "Signaler un problème" in order detail views previously triggered a broken `mailto:` link (or did nothing). Now opens a proper bottom sheet.
- **New component:** `app/dashboard/commandes/ReportIssueSheet.tsx` — bottom sheet that creates a real Supabase support ticket via `createTicketAction`, pre-linked to the order (`order_id`, `category: 'order_issue'`, subject auto-filled).
- **Wired in two locations:** `OrderDetailSheet.tsx` (desktop drawer) and `[id]/OrderDetailClient.tsx` (mobile full-page view) — both replaced the mailto onclick with `reportOpen` state + `<ReportIssueSheet>`.
- On success: shows "Ticket créé" confirmation for 1.2s, then closes the sheet and navigates to `/dashboard/support`.

## What I tested

- `tsc --noEmit` exits 0 (zero TypeScript errors)
- `npm run lint` exits 0 (zero errors; pre-existing img warnings in Mehdi's store files are unchanged)
- Reviewed both integration points: `OrderDetailSheet` (z-index stacking above parent sheet confirmed with z-[60]/z-[70]) and `OrderDetailClient` (standalone page, no z-index conflict)
- Verified `createTicketAction` signature matches usage: `{ subject, category: 'order_issue', order_id }` + description string
- Timer cleanup on unmount guarded via `useRef` + `useEffect` cleanup

## Files changed

| File | Change |
|---|---|
| `app/dashboard/commandes/ReportIssueSheet.tsx` | **New** — the bottom sheet component |
| `app/dashboard/commandes/OrderDetailSheet.tsx` | Wire up `reportOpen` state + render `<ReportIssueSheet>` |
| `app/dashboard/commandes/[id]/OrderDetailClient.tsx` | Same — wire up `reportOpen` state + render `<ReportIssueSheet>` |

## i18n keys required

None — support flow is FR-only at MVP per PLZ-071 spec. All strings hardcoded in French.

## Acceptance criteria checklist

- [x] Clicking "Signaler un problème" opens `ReportIssueSheet` (no mailto, no dead click)
- [x] Sheet shows order reference in header, optional description textarea, "Créer le ticket" submit button
- [x] Submit creates a real ticket via `createTicketAction` with `order_id` set
- [x] Success state shows briefly, then closes and navigates to `/dashboard/support`
- [x] Works in `OrderDetailSheet` (mobile bottom-sheet entry)
- [x] Works in `OrderDetailClient` (full-page entry)
- [x] Zero TypeScript errors
- [x] Zero lint errors

/cc @Anas — please run 6-phase QA and merge when green.