### PR TITLE
fix(PLZ-072): cart hydration race + dispatch null-coordinate fallback

### DIFF
--- a/app/store/[slug]/_components/CartProvider.tsx
+++ b/app/store/[slug]/_components/CartProvider.tsx
@@ -5,7 +5,6 @@ import {
   useContext,
   useState,
   useEffect,
-  useRef,
   type ReactNode,
 } from 'react';
 
@@ -39,7 +38,7 @@ export function CartProvider({
   slug: string;
 }) {
   const [items, setItems] = useState<CartItem[]>([]);
-  const isHydrated = useRef(false);
+  const [isHydrated, setIsHydrated] = useState(false);
 
   // Hydrate from localStorage on mount
   useEffect(() => {
@@ -51,16 +50,16 @@ export function CartProvider({
         // ignore malformed data
       }
     }
-    isHydrated.current = true;
+    setIsHydrated(true);
   }, [slug]);
 
   // Persist to localStorage whenever items change — skip until after hydration
   // to prevent the persist effect from overwriting localStorage with [] on the
   // initial render before the hydrate effect's setItems has propagated.
   useEffect(() => {
-    if (!isHydrated.current) return;
+    if (!isHydrated) return;
     localStorage.setItem(`plaza_cart_${slug}`, JSON.stringify(items));
-  }, [items, slug]);
+  }, [items, slug, isHydrated]);
 
   const addItem = (
     newItem: Omit<CartItem, 'quantity'> & { stock?: number | null },

--- a/lib/dispatch/createDispatchDelivery.ts
+++ b/lib/dispatch/createDispatchDelivery.ts
@@ -47,22 +47,27 @@ export async function createDispatchDelivery(orderId: string): Promise<DispatchR
     const merchant = order.merchants
     const customer = order.customers
 
-    if (!merchant.location_lat || !merchant.location_lng) {
-      throw new Error('Merchant location coordinates missing — cannot dispatch')
-    }
-    if (!customer?.location_lat || !customer?.location_lng) {
-      throw new Error('Customer location coordinates missing — cannot dispatch')
-    }
     if (!merchant.city) {
       throw new Error('Merchant city missing — cannot match drivers')
     }
 
     // ── 2. Distance + duration ────────────────────────────────
-    const distanceKm = dispatchDistance(
-      merchant.location_lat, merchant.location_lng,
-      customer.location_lat, customer.location_lng,
-    )
-    const estimatedDurationMin = Math.ceil(distanceKm / 0.5) // ~30 km/h
+    const hasCoordinates =
+      merchant.location_lat != null &&
+      merchant.location_lng != null &&
+      customer?.location_lat != null &&
+      customer?.location_lng != null
+
+    const distanceKm = hasCoordinates
+      ? dispatchDistance(
+          merchant.location_lat!,
+          merchant.location_lng!,
+          customer!.location_lat!,
+          customer!.location_lng!,
+        )
+      : 0
+
+    const estimatedDurationMin = hasCoordinates ? Math.ceil(distanceKm / 0.5) : 0 // ~30 km/h
 
     // ── 3. Fetch dispatch config ──────────────────────────────
     const { data: config, error: configErr } = await service


### PR DESCRIPTION
## What this fixes

Two pre-launch blockers found by Saad in post-fix verification (2026-04-20).

### Fix A — CartProvider: `isHydrated` useRef → useState (SAAD-028 redux)

**Root cause:** `isHydrated = useRef(false)` caused the persist effect to fire in the same commit as the hydrate effect with `items = []`. React runs both effects sequentially after the initial render. The hydrate effect set `isHydrated.current = true` synchronously, then called `setItems(stored)` (async state update). The persist effect — running immediately after in the same commit — saw `isHydrated.current = true` but `items` still `[]`, and wrote `[]` to localStorage.

**Fix:** `useState(false)` instead of `useRef`. `setIsHydrated(true)` triggers a re-render. The persist effect only fires again after the re-render, by which point `items` is correctly populated from the hydrate `setItems` call.

**Files:** `app/store/[slug]/_components/CartProvider.tsx`

### Fix B — createDispatchDelivery: graceful fallback for null coordinates (SAAD-032 root cause)

**Root cause:** Lines 50–55 threw hard errors when `customer.location_lat` or `location_lng` was null. Any order placed with the text address fallback (no map pin selected) or any pre-PLZ-068 legacy order had null coordinates → dispatch silently failed → driver pool always empty for these orders.

**Fix:** `hasCoordinates` boolean gates the haversine call. When coordinates are absent: `distance_km = 0`, `estimated_duration_min = 0`, `driver_earnings_mad = base_fee` (zero-distance formula naturally resolves to base fee only). Delivery record is still created in the pool — driver gets the order, navigates manually.

**Files:** `lib/dispatch/createDispatchDelivery.ts`

## Test plan
- [ ] Cart survives full browser refresh (URL bar entry, F5) — items not cleared
- [ ] Merchant confirms an order → delivery appears in `/driver/livraisons` (both coordinate and no-coordinate orders)
- [ ] `tsc --noEmit` EXIT 0
- [ ] `npm run lint` EXIT 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)