### PR TITLE
fix(PLZ-076): merchant product onboarding — 3 fixes

### DIFF
--- a/app/dashboard/boutique/BoutiqueForm.tsx
+++ b/app/dashboard/boutique/BoutiqueForm.tsx
@@ -53,6 +53,7 @@ type Props = { merchant: Merchant; deliveryZones: DeliveryZone[] };
 export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   const t = useTranslations('boutique');
   const [isPending, startTransition] = useTransition();
+  const [savedIndicator, setSavedIndicator] = useState(false);
 
   // Identity
   const [storeName, setStoreName] = useState(merchant.store_name);
@@ -210,6 +211,8 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
     }
     startTransition(async () => {
       await updateBoutique(fd);
+      setSavedIndicator(true);
+      setTimeout(() => setSavedIndicator(false), 2000);
     });
   }
 
@@ -742,6 +745,9 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
       </div>
 
       <div className="fixed bottom-0 start-0 end-0 bg-white border-t border-[#E2E8F0] p-4 md:hidden">
+        {savedIndicator && (
+          <p className="text-center text-sm font-medium text-[#16A34A] mb-2">Enregistré ✓</p>
+        )}
         <button
           type="button"
           onClick={handleSave}
@@ -786,7 +792,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             {workingHoursSection}
             {paymentModesSection}
 
-            <div className="pt-2">
+            <div className="pt-2 flex items-center gap-4">
               <button
                 type="button"
                 onClick={handleSave}
@@ -796,6 +802,9 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
               >
                 {isPending ? t('saving') : t('save')}
               </button>
+              {savedIndicator && (
+                <span className="text-sm font-medium text-[#16A34A]">Enregistré ✓</span>
+              )}
             </div>
           </div>
 

--- a/app/dashboard/produits/ProductsClient.tsx
+++ b/app/dashboard/produits/ProductsClient.tsx
@@ -69,18 +69,6 @@ export function ProductsClient({ products: initialProducts }: Props) {
 
   return (
     <>
-      {/* Mobile top bar */}
-      <div className="md:hidden bg-white h-14 px-4 flex items-center justify-between shadow-sm border-b border-[#E2E8F0]">
-        <h1 className="text-[18px] font-semibold text-[#1C1917]">{t('title')}</h1>
-        <Link
-          href="/dashboard/produits/nouveau"
-          className="h-9 px-4 text-white text-sm rounded-lg hover:opacity-90 transition-opacity flex items-center"
-          style={{ backgroundColor: 'var(--color-primary)' }}
-        >
-          {t('add')}
-        </Link>
-      </div>
-
       {/* Search */}
       <div className="px-4 py-3 md:px-0 md:pt-0 md:pb-4">
         <div className="relative w-full md:w-[280px]">

--- a/app/dashboard/produits/actions.ts
+++ b/app/dashboard/produits/actions.ts
@@ -57,6 +57,7 @@ export async function createProduct(formData: FormData): Promise<void> {
   } as never);
 
   revalidatePath('/dashboard/produits');
+  revalidatePath('/dashboard');
   redirect('/dashboard/produits');
 }
 
@@ -99,6 +100,7 @@ export async function updateProduct(productId: string, formData: FormData): Prom
 
   revalidatePath('/dashboard/produits');
   revalidatePath(`/dashboard/produits/${productId}`);
+  revalidatePath('/dashboard');
   redirect('/dashboard/produits');
 }
 
@@ -113,6 +115,7 @@ export async function toggleProductVisibility(productId: string, isVisible: bool
     .eq('merchant_id', merchantId);
 
   revalidatePath('/dashboard/produits');
+  revalidatePath('/dashboard');
 }
 
 export async function deleteProduct(productId: string): Promise<void> {
@@ -126,5 +129,6 @@ export async function deleteProduct(productId: string): Promise<void> {
     .eq('merchant_id', merchantId);
 
   revalidatePath('/dashboard/produits');
+  revalidatePath('/dashboard');
   redirect('/dashboard/produits');
 }

--- a/app/dashboard/produits/page.tsx
+++ b/app/dashboard/produits/page.tsx
@@ -32,8 +32,8 @@ export default async function ProduitsPage() {
   return (
     <div className="min-h-screen bg-[#FAFAF9]">
       <div className="max-w-[1040px] mx-auto px-4 py-6 md:p-8">
-        {/* Desktop page header */}
-        <div className="hidden md:flex items-center justify-between mb-6">
+        {/* Page header */}
+        <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-semibold text-[#1C1917]">Mes produits</h1>
           <Link
             href="/dashboard/produits/nouveau"


### PR DESCRIPTION
## Summary

- **FIX 1 — Onboarding checklist stale (BLOCKER 2):** All 4 product server actions (createProduct, updateProduct, toggleProductVisibility, deleteProduct) now call revalidatePath("/dashboard") after revalidatePath("/dashboard/produits"). This matches the boutique actions pattern so the onboarding checklist reflects the real product count immediately.

- **FIX 2 — Add product button not visible (BLOCKER 3):** Removed "hidden" from "hidden md:flex" in page.tsx — the header with the Add button is now always rendered at all viewport sizes. Removed the redundant md:hidden mobile top bar from ProductsClient.tsx.

- **FIX 3 — Save indicator on boutique settings:** Added savedIndicator state to BoutiqueForm.tsx. After updateBoutique resolves inside startTransition a green "Enregistré" text appears for 2 seconds next to the Save button.

## Files changed
- app/dashboard/produits/actions.ts — +4 revalidatePath("/dashboard") calls
- app/dashboard/produits/page.tsx — hidden md:flex to flex
- app/dashboard/produits/ProductsClient.tsx — removed md:hidden mobile top bar
- app/dashboard/boutique/BoutiqueForm.tsx — savedIndicator state + UI

Generated with Claude Code