### PR TITLE
feat(PLZ-077): add data-testid - driver + admin (35 files)

### DIFF
--- a/app/admin/(shell)/drivers/[id]/DriverDetailClient.tsx
+++ b/app/admin/(shell)/drivers/[id]/DriverDetailClient.tsx
@@ -283,6 +283,7 @@ export function DriverDetailClient({ driver }: { driver: DriverDetail }) {
                   onClick={handleApprovePrimary}
                   disabled={pending}
                   className="h-11 w-full rounded-[6px] bg-[#2563EB] text-[14px] font-semibold text-white hover:bg-[#1D4ED8] disabled:cursor-not-allowed disabled:opacity-60"
+                  data-testid="admin-driver-dossier-approve-btn"
                 >
                   Approuver le dossier
                 </button>
@@ -293,6 +294,7 @@ export function DriverDetailClient({ driver }: { driver: DriverDetail }) {
                   type="button"
                   onClick={() => setDialog({ kind: 'reject-driver' })}
                   className="mt-3 h-11 w-full rounded-[6px] border border-[#DC2626] bg-white text-[14px] font-semibold text-[#DC2626] hover:bg-[#FEF2F2]"
+                  data-testid="admin-driver-dossier-reject-btn"
                 >
                   Rejeter le dossier
                 </button>
@@ -349,6 +351,7 @@ export function DriverDetailClient({ driver }: { driver: DriverDetail }) {
         cancelLabel="Annuler"
         confirmLabel="Confirmer l'approbation"
         onConfirm={handleApproveOverride}
+        testIdPrefix="admin-driver-dossier-approve-override"
       />
 
       {/* Reject driver */}
@@ -365,6 +368,7 @@ export function DriverDetailClient({ driver }: { driver: DriverDetail }) {
         cancelLabel="Annuler"
         confirmLabel="Confirmer le rejet"
         onConfirm={handleRejectDriver}
+        testIdPrefix="admin-driver-dossier-reject"
       />
 
       {/* Resubmit single doc */}
@@ -385,6 +389,7 @@ export function DriverDetailClient({ driver }: { driver: DriverDetail }) {
             handleRequestResubmit(dialog.doc, reason);
           }
         }}
+        testIdPrefix="admin-driver-dossier-resubmit-doc"
       />
 
       {/* Reject single doc */}
@@ -405,6 +410,7 @@ export function DriverDetailClient({ driver }: { driver: DriverDetail }) {
             handleRejectDoc(dialog.doc, reason);
           }
         }}
+        testIdPrefix="admin-driver-dossier-reject-doc"
       />
 
       {/* Toast */}
@@ -582,6 +588,7 @@ function MobileDetail({
                   onToggleMenu();
                 }}
                 className="block w-full px-4 py-3 text-left text-[14px] text-[#DC2626] hover:bg-[#FEF2F2]"
+                data-testid="admin-driver-dossier-reject-mobile-btn"
               >
                 Rejeter le dossier
               </button>
@@ -682,6 +689,7 @@ function MobileDetail({
           type="button"
           onClick={onApprovePrimary}
           className="h-12 w-full rounded-[6px] bg-[#2563EB] text-[15px] font-semibold text-white hover:bg-[#1D4ED8]"
+          data-testid="admin-driver-dossier-approve-mobile-btn"
         >
           Approuver le dossier
         </button>

--- a/app/admin/(shell)/drivers/pending/PendingQueueClient.tsx
+++ b/app/admin/(shell)/drivers/pending/PendingQueueClient.tsx
@@ -218,6 +218,7 @@ export function PendingQueueClient({
               type="button"
               onClick={handleRefresh}
               className="flex h-9 items-center gap-1.5 rounded-[6px] border border-[#E7E5E4] bg-white px-3 text-[13px] font-medium text-[#1C1917] hover:bg-[#F5F5F4]"
+              data-testid="admin-drivers-pending-refresh-btn"
             >
               <RefreshCw
                 className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`}
@@ -231,6 +232,7 @@ export function PendingQueueClient({
                 value: search,
                 onChange: setSearch,
                 placeholder: 'Rechercher par nom ou téléphone',
+                testId: 'admin-drivers-pending-search-input',
               }}
               chips={[
                 { key: 'all', label: 'Toutes les villes', active: cityFilter === 'all' },
@@ -249,6 +251,7 @@ export function PendingQueueClient({
             onRowClick={handleRowClick}
             emptyState={emptyState}
             ariaLabel="File d'attente des livreurs"
+            rowTestId="admin-drivers-pending-row"
           />
           <p className="mt-3 text-right text-[12px] text-[#78716C]">
             ↑↓ naviguer · Entrée ouvrir
@@ -320,6 +323,8 @@ function MobilePendingQueue({
                 type="button"
                 onClick={() => onRowClick(driver)}
                 className="flex w-full flex-col gap-3 rounded-[12px] border border-[#E7E5E4] bg-white p-4 text-left hover:bg-[#FAFAF9]"
+                data-testid="admin-drivers-pending-card"
+                data-id={driver.id}
               >
                 <div className="flex items-center gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#EFF6FF] text-[13px] font-semibold text-[#2563EB]">

--- a/app/admin/(shell)/page.tsx
+++ b/app/admin/(shell)/page.tsx
@@ -20,6 +20,7 @@ export default function AdminHomePage() {
           <Link
             href="/admin/drivers/pending"
             className="font-medium text-[#2563EB] hover:underline"
+            data-testid="admin-home-drivers-pending-link"
           >
             file d&apos;attente des livreurs
           </Link>{' '}

--- a/app/admin/_components/ConfirmDialog.tsx
+++ b/app/admin/_components/ConfirmDialog.tsx
@@ -11,6 +11,8 @@ type BaseProps = {
   body?: React.ReactNode;
   cancelLabel?: string;
   confirmLabel: string;
+  /** When set, dialog root gets `${testIdPrefix}-dialog`, textarea gets `${testIdPrefix}-reason-textarea`, buttons get `${testIdPrefix}-cancel-btn` / `${testIdPrefix}-confirm-btn`. */
+  testIdPrefix?: string;
 };
 
 type NeutralProps = BaseProps & {
@@ -46,6 +48,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     cancelLabel = 'Annuler',
     confirmLabel,
     variant,
+    testIdPrefix,
   } = props;
 
   const [reason, setReason] = useState('');
@@ -97,6 +100,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
+      data-testid={testIdPrefix ? `${testIdPrefix}-dialog` : undefined}
     >
       <div className="w-full max-w-[480px] rounded-[8px] bg-white p-6 shadow-[0_20px_40px_rgba(0,0,0,0.15)]">
         <div className="flex items-start justify-between gap-4">
@@ -146,6 +150,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
                   ? 'border-[#DC2626]'
                   : 'border-[#E7E5E4] focus:border-[#2563EB]',
               )}
+              data-testid={testIdPrefix ? `${testIdPrefix}-reason-textarea` : undefined}
             />
             <div className="mt-1 flex items-center justify-between text-[12px]">
               <span
@@ -168,6 +173,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
             type="button"
             onClick={onClose}
             className="h-10 rounded-[6px] border border-[#E7E5E4] bg-white px-4 text-[14px] font-medium text-[#1C1917] hover:bg-[#F5F5F4]"
+            data-testid={testIdPrefix ? `${testIdPrefix}-cancel-btn` : undefined}
           >
             {cancelLabel}
           </button>
@@ -181,6 +187,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
                 ? 'bg-[#DC2626] hover:bg-[#B91C1C] disabled:cursor-not-allowed disabled:bg-[#F5F5F4] disabled:text-[#A8A29E]'
                 : 'bg-[#2563EB] hover:bg-[#1D4ED8]',
             )}
+            data-testid={testIdPrefix ? `${testIdPrefix}-confirm-btn` : undefined}
           >
             {confirmLabel}
           </button>

--- a/app/admin/_components/DataTable.tsx
+++ b/app/admin/_components/DataTable.tsx
@@ -22,6 +22,8 @@ type Props<T extends { id: string }> = {
   emptyState?: React.ReactNode;
   skeletonRows?: number;
   ariaLabel?: string;
+  /** If set, each row gets `data-testid={rowTestId}` and `data-id={row.id}`. */
+  rowTestId?: string;
 };
 
 /**
@@ -40,6 +42,7 @@ export function DataTable<T extends { id: string }>({
   emptyState,
   skeletonRows = 6,
   ariaLabel,
+  rowTestId,
 }: Props<T>) {
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -137,6 +140,8 @@ export function DataTable<T extends { id: string }>({
                         selected && 'bg-[#F5F5F4] relative',
                       )}
                       style={{ height: rowHeight }}
+                      data-testid={rowTestId}
+                      data-id={rowTestId ? row.id : undefined}
                     >
                       {columns.map((col, colIndex) => (
                         <td

--- a/app/admin/_components/FilterBar.tsx
+++ b/app/admin/_components/FilterBar.tsx
@@ -15,6 +15,7 @@ type Props = {
     value: string;
     onChange: (value: string) => void;
     placeholder?: string;
+    testId?: string;
   };
   chips?: FilterChip[];
   onChipClick?: (key: string) => void;
@@ -68,6 +69,7 @@ export function FilterBar({
             onChange={(event) => search.onChange(event.target.value)}
             placeholder={search.placeholder ?? 'Rechercher'}
             className="h-9 w-full rounded-[6px] border border-[#E7E5E4] bg-white pl-9 pr-10 text-[14px] text-[#1C1917] placeholder:text-[#A8A29E] focus:border-[#2563EB] focus:outline-none focus:ring-2 focus:ring-[#EFF6FF]"
+            data-testid={search.testId}
           />
           <kbd className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded-[4px] bg-[#F5F5F4] px-1.5 py-0.5 text-[11px] text-[#78716C]">
             /

--- a/app/admin/login/LoginForm.tsx
+++ b/app/admin/login/LoginForm.tsx
@@ -88,6 +88,7 @@ export function LoginForm() {
         aria-invalid={state.kind === 'error'}
         aria-describedby={state.kind === 'error' ? 'admin-email-error' : undefined}
         className="mt-2 h-10 w-full rounded-[6px] border border-[#E7E5E4] px-3 text-[14px] text-[#1C1917] placeholder:text-[#A8A29E] focus:border-[#2563EB] focus:outline-none focus:ring-2 focus:ring-[#EFF6FF]"
+        data-testid="admin-login-email-input"
       />
       {usePassword && (
         <>
@@ -104,6 +105,7 @@ export function LoginForm() {
             onChange={(event) => setPassword(event.target.value)}
             autoComplete="current-password"
             className="mt-2 h-10 w-full rounded-[6px] border border-[#E7E5E4] px-3 text-[14px] text-[#1C1917] focus:border-[#2563EB] focus:outline-none focus:ring-2 focus:ring-[#EFF6FF]"
+            data-testid="admin-login-password-input"
           />
         </>
       )}
@@ -122,6 +124,7 @@ export function LoginForm() {
           checked={trustDevice}
           onChange={(event) => setTrustDevice(event.target.checked)}
           className="mt-0.5 h-4 w-4 rounded-[4px] border border-[#D6D3D1] text-[#2563EB] focus:ring-2 focus:ring-[#EFF6FF]"
+          data-testid="admin-login-trust-device-checkbox"
         />
         <div>
           <label
@@ -140,6 +143,7 @@ export function LoginForm() {
         disabled={pending}
         aria-disabled={pending}
         className="mt-5 h-10 w-full rounded-[6px] bg-[#2563EB] text-[14px] font-semibold text-white transition-colors hover:bg-[#1D4ED8] disabled:cursor-not-allowed disabled:bg-[#E7E5E4] disabled:text-[#A8A29E]"
+        data-testid="admin-login-submit-btn"
       >
         {pending
           ? usePassword ? 'Connexion…' : 'Envoi en cours…'
@@ -149,6 +153,7 @@ export function LoginForm() {
         type="button"
         onClick={() => { setUsePassword((v) => !v); setState({ kind: 'idle' }); }}
         className="mt-3 text-center text-[12px] text-[#78716C] hover:text-[#2563EB] hover:underline"
+        data-testid="admin-login-toggle-mode-btn"
       >
         {usePassword ? 'Revenir au lien magique' : 'Connexion par mot de passe'}
       </button>

--- a/app/driver/_components/BottomNav.tsx
+++ b/app/driver/_components/BottomNav.tsx
@@ -8,9 +8,9 @@ import { usePathname } from 'next/navigation';
 import { Package, Clock, User } from 'lucide-react';
 
 const TABS = [
-  { href: '/driver/livraisons', icon: Package, label: 'Livraisons' },
-  { href: '/driver/historique', icon: Clock,   label: 'Historique' },
-  { href: '/driver/profil',     icon: User,    label: 'Profil'     },
+  { href: '/driver/livraisons', icon: Package, label: 'Livraisons', testId: 'driver-nav-livraisons-link' },
+  { href: '/driver/historique', icon: Clock,   label: 'Historique', testId: 'driver-nav-historique-link' },
+  { href: '/driver/profil',     icon: User,    label: 'Profil',     testId: 'driver-nav-profil-link'     },
 ] as const;
 
 export function BottomNav() {
@@ -18,7 +18,7 @@ export function BottomNav() {
 
   return (
     <nav className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px] h-16 bg-white border-t border-gray-200 flex items-center z-40">
-      {TABS.map(({ href, icon: Icon, label }) => {
+      {TABS.map(({ href, icon: Icon, label, testId }) => {
         const isActive = href === '/driver/livraisons'
           ? pathname === '/driver/livraisons'
           : pathname.startsWith(href);
@@ -29,6 +29,7 @@ export function BottomNav() {
             href={href}
             className="flex-1 flex flex-col items-center justify-center gap-0.5 py-2"
             style={{ color: isActive ? 'var(--color-primary)' : '#78716C' }}
+            data-testid={testId}
           >
             <Icon className="w-5 h-5" />
             <span className="text-[11px] font-medium">{label}</span>

--- a/app/driver/_components/DocumentUpload.tsx
+++ b/app/driver/_components/DocumentUpload.tsx
@@ -11,9 +11,10 @@ type Props = {
   value: File | null;
   onChange: (file: File | null) => void;
   height?: number;
+  testId?: string;
 };
 
-export function DocumentUpload({ label, sublabel, value, onChange, height = 140 }: Props) {
+export function DocumentUpload({ label, sublabel, value, onChange, height = 140, testId }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const previewUrl = value ? URL.createObjectURL(value) : null;
 
@@ -54,6 +55,7 @@ export function DocumentUpload({ label, sublabel, value, onChange, height = 140 
         capture="environment"
         className="hidden"
         onChange={(e) => onChange(e.target.files?.[0] ?? null)}
+        data-testid={testId}
       />
     </div>
   );

--- a/app/driver/_components/LogoutButton.tsx
+++ b/app/driver/_components/LogoutButton.tsx
@@ -15,6 +15,7 @@ export function LogoutButton() {
       onClick={handleLogout}
       className="px-4 flex items-center gap-3 w-full text-left"
       style={{ height: 52 }}
+      data-testid="driver-profil-logout-btn"
     >
       <LogOut className="w-5 h-5 flex-shrink-0" style={{ color: '#DC2626' }} />
       <span className="flex-1 text-[15px]" style={{ color: '#DC2626' }}>Se déconnecter</span>

--- a/app/driver/_components/OfflineBanner.tsx
+++ b/app/driver/_components/OfflineBanner.tsx
@@ -13,6 +13,7 @@ export function OfflineBanner({ onGoOnline }: Props) {
         onClick={onGoOnline}
         className="text-[13px] font-semibold flex-shrink-0"
         style={{ color: 'var(--color-primary)' }}
+        data-testid="driver-livraisons-go-online-btn"
       >
         Aller en ligne
       </button>

--- a/app/driver/_components/OtpBoxes.tsx
+++ b/app/driver/_components/OtpBoxes.tsx
@@ -11,9 +11,10 @@ type Props = {
   onChange: (val: string[]) => void;
   state?: State;
   disabled?: boolean;
+  testIdPrefix?: string;    // if set, each box gets `${testIdPrefix}-digit-${i+1}-input`
 };
 
-export function OtpBoxes({ value, onChange, state = 'default', disabled = false }: Props) {
+export function OtpBoxes({ value, onChange, state = 'default', disabled = false, testIdPrefix }: Props) {
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
   function handleChange(index: number, raw: string) {
@@ -70,6 +71,7 @@ export function OtpBoxes({ value, onChange, state = 'default', disabled = false 
             handleChange(i, e.clipboardData.getData('text'));
           }}
           className={boxClass(i)}
+          data-testid={testIdPrefix ? `${testIdPrefix}-digit-${i + 1}-input` : undefined}
         />
       ))}
     </div>

--- a/app/driver/_components/PhotoCapture.tsx
+++ b/app/driver/_components/PhotoCapture.tsx
@@ -9,9 +9,10 @@ type Props = {
   value: File | null;
   onChange: (file: File | null) => void;
   height?: number;   // px, default 160
+  testId?: string;
 };
 
-export function PhotoCapture({ value, onChange, height = 160 }: Props) {
+export function PhotoCapture({ value, onChange, height = 160, testId }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const previewUrl = value ? URL.createObjectURL(value) : null;
 
@@ -41,6 +42,7 @@ export function PhotoCapture({ value, onChange, height = 160 }: Props) {
         accept="image/*"
         capture="environment"
         className="hidden"
+        data-testid={testId}
         onChange={(e) => {
           const file = e.target.files?.[0] ?? null;
           if (!file) { onChange(null); return; }

--- a/app/driver/_components/PinBoxes.tsx
+++ b/app/driver/_components/PinBoxes.tsx
@@ -11,9 +11,10 @@ type Props = {
   onChange: (val: string) => void;
   state?: State;
   disabled?: boolean;
+  testIdPrefix?: string;   // if set, each box gets `${testIdPrefix}-digit-${i+1}-input`
 };
 
-export function PinBoxes({ value, onChange, state = 'default', disabled = false }: Props) {
+export function PinBoxes({ value, onChange, state = 'default', disabled = false, testIdPrefix }: Props) {
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
   function handleChange(index: number, raw: string) {
@@ -60,6 +61,7 @@ export function PinBoxes({ value, onChange, state = 'default', disabled = false 
           onChange={(e) => handleChange(i, e.target.value)}
           onKeyDown={(e) => handleKeyDown(i, e)}
           className={boxClass(i)}
+          data-testid={testIdPrefix ? `${testIdPrefix}-digit-${i + 1}-input` : undefined}
         />
       ))}
     </div>

--- a/app/driver/_components/StickyCTA.tsx
+++ b/app/driver/_components/StickyCTA.tsx
@@ -8,9 +8,10 @@ type Props = {
   disabled?: boolean;
   loading?: boolean;
   variant?: 'primary' | 'danger';
+  testId?: string;
 };
 
-export function StickyCTA({ label, onClick, disabled, loading, variant = 'primary' }: Props) {
+export function StickyCTA({ label, onClick, disabled, loading, variant = 'primary', testId }: Props) {
   const bg = disabled
     ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
     : variant === 'danger'
@@ -24,6 +25,7 @@ export function StickyCTA({ label, onClick, disabled, loading, variant = 'primar
         disabled={disabled || loading}
         className={`w-full h-[52px] rounded-xl text-base font-bold flex items-center justify-center transition-all ${bg}`}
         style={!disabled && variant === 'primary' ? { backgroundColor: 'var(--color-primary)' } : {}}
+        data-testid={testId}
       >
         {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : label}
       </button>

--- a/app/driver/auth/otp/page.tsx
+++ b/app/driver/auth/otp/page.tsx
@@ -65,7 +65,7 @@ function OtpContent() {
         </p>
 
         <div className="mt-8 w-full">
-          <OtpBoxes value={otp} onChange={setOtp} state={error ? 'error' : 'default'} />
+          <OtpBoxes value={otp} onChange={setOtp} state={error ? 'error' : 'default'} testIdPrefix="driver-auth-otp" />
         </div>
 
         {error && (
@@ -91,6 +91,7 @@ function OtpContent() {
           disabled={!allFilled || loading}
           className="mt-8 w-full h-[52px] rounded-xl text-base font-bold text-white flex items-center justify-center transition-all disabled:bg-gray-200 disabled:text-gray-400"
           style={allFilled && !loading ? { backgroundColor: 'var(--color-primary)' } : {}}
+          data-testid="driver-auth-otp-submit-btn"
         >
           {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Vérifier le code'}
         </button>

--- a/app/driver/auth/phone/page.tsx
+++ b/app/driver/auth/phone/page.tsx
@@ -106,6 +106,7 @@ export default function DriverPhonePage() {
               onChange={(e) => setPhone(normalizeForDisplay(e.target.value))}
               className="flex-1 px-3 text-[15px] text-[#1C1917] outline-none bg-transparent"
               autoFocus
+              data-testid="driver-auth-phone-input"
             />
           </div>
 
@@ -118,6 +119,7 @@ export default function DriverPhonePage() {
             disabled={!isValid || loading}
             className="mt-4 w-full h-[52px] rounded-xl text-base font-bold text-white flex items-center justify-center gap-2 transition-all disabled:bg-gray-200 disabled:text-gray-400"
             style={isValid && !loading ? { backgroundColor: 'var(--color-primary)' } : {}}
+            data-testid="driver-auth-phone-submit-btn"
           >
             {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <>Recevoir un code <ArrowRight className="w-4 h-4" /></>}
           </button>

--- a/app/driver/auth/pin-setup/page.tsx
+++ b/app/driver/auth/pin-setup/page.tsx
@@ -73,7 +73,13 @@ function PinSetupContent() {
       </p>
 
       <div className={`mt-8 ${error ? 'animate-bounce' : ''}`}>
-        <PinBoxes value={current} onChange={step === 1 ? setPin : setConfirm} state={error ? 'error' : 'default'} disabled={loading} />
+        <PinBoxes
+          value={current}
+          onChange={step === 1 ? setPin : setConfirm}
+          state={error ? 'error' : 'default'}
+          disabled={loading}
+          testIdPrefix={step === 1 ? 'driver-pin-setup-create' : 'driver-pin-setup-confirm'}
+        />
       </div>
 
       {error && <p className="text-[13px] text-red-600 mt-3">Les codes ne correspondent pas</p>}

--- a/app/driver/auth/pin/page.tsx
+++ b/app/driver/auth/pin/page.tsx
@@ -68,7 +68,7 @@ function PinLoginContent() {
       <h1 className="text-[18px] font-semibold text-[#1C1917] mt-3">Saisissez votre code PIN</h1>
 
       <div className="mt-6">
-        <PinBoxes value={pin} onChange={setPin} state={error ? 'error' : locked ? 'error' : 'default'} disabled={locked || submitting} />
+        <PinBoxes value={pin} onChange={setPin} state={error ? 'error' : locked ? 'error' : 'default'} disabled={locked || submitting} testIdPrefix="driver-auth-pin" />
       </div>
 
       {error && !locked && (

--- a/app/driver/livraisons/[id]/_components/DeliveryDetailClient.tsx
+++ b/app/driver/livraisons/[id]/_components/DeliveryDetailClient.tsx
@@ -149,6 +149,7 @@ export function DeliveryDetailClient({ delivery }: { delivery: DriverDelivery })
       <StickyCTA
         label={ctaLabel}
         onClick={() => router.push(ctaHref)}
+        testId={isToCollect ? 'driver-delivery-confirm-collect-btn' : 'driver-delivery-confirm-deliver-btn'}
       />
     </div>
   );

--- a/app/driver/livraisons/[id]/collect/page.tsx
+++ b/app/driver/livraisons/[id]/collect/page.tsx
@@ -71,7 +71,7 @@ function CollectContent() {
             <span className="text-sm font-semibold text-[#1C1917]">Code de collecte</span>
           </div>
           <p className="text-[13px] text-[#78716C] mb-4">Saisissez le code à 6 chiffres</p>
-          <OtpBoxes value={code} onChange={handleCodeChange} state={codeState} />
+          <OtpBoxes value={code} onChange={handleCodeChange} state={codeState} testIdPrefix="driver-delivery-merchant-code" />
           {codeState === 'valid' && (
             <p className="text-[13px] text-green-600 text-center mt-3">✓ Code validé</p>
           )}
@@ -87,11 +87,11 @@ function CollectContent() {
         </div>
 
         <div className="bg-white rounded-2xl shadow-sm p-4">
-          <PhotoCapture value={photo} onChange={setPhoto} height={160} />
+          <PhotoCapture value={photo} onChange={setPhoto} height={160} testId="driver-delivery-collect-photo-input" />
         </div>
       </div>
 
-      <StickyCTA label="Confirmer la collecte" disabled={!canConfirm} loading={loading} onClick={handleConfirm} />
+      <StickyCTA label="Confirmer la collecte" disabled={!canConfirm} loading={loading} onClick={handleConfirm} testId="driver-delivery-collect-submit-btn" />
     </div>
   );
 }

--- a/app/driver/livraisons/[id]/deliver/page.tsx
+++ b/app/driver/livraisons/[id]/deliver/page.tsx
@@ -88,6 +88,7 @@ function DeliverContent() {
                   borderColor: '#E8632A',
                   backgroundColor: codChecked ? '#E8632A' : 'white',
                 }}
+                data-testid="driver-delivery-confirm-cod-checkbox"
               >
                 {codChecked && <span className="text-white text-sm font-bold">✓</span>}
               </div>
@@ -108,7 +109,7 @@ function DeliverContent() {
               ? `Demandez le code à ${delivery.order.customer.full_name}`
               : 'Demandez le code à 4 chiffres au client'}
           </p>
-          <PinBoxes value={pin} onChange={setPin} state={pinState === 'error' ? 'error' : pinState === 'valid' ? 'valid' : 'default'} />
+          <PinBoxes value={pin} onChange={setPin} state={pinState === 'error' ? 'error' : pinState === 'valid' ? 'valid' : 'default'} testIdPrefix="driver-delivery-customer-pin" />
           {pinState === 'error' && (
             <p className="text-[13px] text-red-600 text-center mt-3">
               Code incorrect — {pinAttempts > 0 ? `${pinAttempts} tentative${pinAttempts > 1 ? 's' : ''} restante${pinAttempts > 1 ? 's' : ''}` : 'contactez le support'}
@@ -120,17 +121,18 @@ function DeliverContent() {
         <div className="bg-white rounded-2xl shadow-sm p-4">
           <p className="text-sm font-bold text-[#1C1917] mb-1">Photo de livraison</p>
           <p className="text-xs text-red-600 mb-3">Obligatoire — colis remis au client</p>
-          <PhotoCapture value={photo} onChange={setPhoto} height={160} />
+          <PhotoCapture value={photo} onChange={setPhoto} height={160} testId="driver-delivery-deliver-photo-input" />
         </div>
 
         <button
           onClick={() => router.push(`/driver/livraisons/${id}/issue`)}
-          className="w-full h-11 rounded-xl border border-red-200 text-red-600 text-sm">
+          className="w-full h-11 rounded-xl border border-red-200 text-red-600 text-sm"
+          data-testid="driver-delivery-report-issue-btn">
           Signaler un problème →
         </button>
       </div>
 
-      <StickyCTA label="Confirmer la livraison" disabled={!canConfirm} loading={loading} onClick={handleConfirm} />
+      <StickyCTA label="Confirmer la livraison" disabled={!canConfirm} loading={loading} onClick={handleConfirm} testId="driver-delivery-deliver-submit-btn" />
     </div>
   );
 }

--- a/app/driver/livraisons/[id]/issue/page.tsx
+++ b/app/driver/livraisons/[id]/issue/page.tsx
@@ -69,6 +69,7 @@ function IssueContent() {
                   borderColor: active ? 'var(--color-primary)' : '#E2E8F0',
                   background: active ? 'color-mix(in srgb, var(--color-primary) 5%, white)' : 'white',
                 }}
+                data-testid={`driver-issue-${type.replace(/_/g, '-')}-btn`}
               >
                 <div className="w-10 h-10 rounded-full flex items-center justify-center mb-2"
                   style={active ? { backgroundColor: 'var(--color-primary)' } : { backgroundColor: '#F5F5F4' }}>
@@ -88,6 +89,7 @@ function IssueContent() {
             placeholder="Décrivez le problème..."
             rows={4}
             className="w-full border border-gray-300 rounded-xl p-3 text-sm text-[#1C1917] outline-none resize-none mb-4"
+            data-testid="driver-issue-notes-textarea"
           />
         )}
 
@@ -96,7 +98,7 @@ function IssueContent() {
             <p className="text-sm text-[#1C1917]">Ajouter une photo</p>
             <span className="text-xs text-[#78716C]">facultatif</span>
           </div>
-          <PhotoCapture value={photo} onChange={setPhoto} height={120} />
+          <PhotoCapture value={photo} onChange={setPhoto} height={120} testId="driver-issue-photo-input" />
         </div>
       </div>
 
@@ -106,6 +108,7 @@ function IssueContent() {
         disabled={!selected}
         loading={loading}
         onClick={handleSubmit}
+        testId="driver-issue-submit-btn"
       />
     </div>
   );

--- a/app/driver/livraisons/[id]/issue/success/page.tsx
+++ b/app/driver/livraisons/[id]/issue/success/page.tsx
@@ -27,6 +27,7 @@ export default function IssueSuccessPage({ params }: { params: { id: string } })
         href="/driver/livraisons"
         className="mt-8 block w-full h-[52px] rounded-xl text-base font-bold text-white flex items-center justify-center"
         style={{ backgroundColor: 'var(--color-primary)' }}
+        data-testid="driver-issue-success-return-link"
       >
         Retour aux livraisons
       </Link>

--- a/app/driver/livraisons/[id]/success/page.tsx
+++ b/app/driver/livraisons/[id]/success/page.tsx
@@ -37,6 +37,7 @@ export default function SuccessPage() {
           href="/driver/livraisons"
           className="block w-full h-[52px] rounded-xl text-base font-bold text-white flex items-center justify-center"
           style={{ backgroundColor: 'var(--color-primary)' }}
+          data-testid="driver-delivery-success-return-link"
         >
           Retour aux livraisons
         </Link>

--- a/app/driver/livraisons/_components/LivraisonsClient.tsx
+++ b/app/driver/livraisons/_components/LivraisonsClient.tsx
@@ -144,6 +144,7 @@ export function LivraisonsClient({ driver, initialDeliveries, initialPool }: Pro
           disabled={availabilityLoading}
           className="flex items-center gap-2 disabled:opacity-60"
           aria-label={isAvailable ? 'Passer hors ligne' : 'Passer en ligne'}
+          data-testid="driver-livraisons-online-toggle-btn"
         >
           {availabilityLoading ? (
             <Loader2 className="w-5 h-5 animate-spin text-[#78716C]" />
@@ -241,7 +242,12 @@ function DeliveryCard({ delivery, onClick }: { delivery: DriverDelivery; onClick
   const earnings = delivery.driver_earnings_mad ?? 0;
 
   return (
-    <button onClick={onClick} className="w-full bg-white rounded-2xl shadow-sm p-4 mb-3 text-left">
+    <button
+      onClick={onClick}
+      className="w-full bg-white rounded-2xl shadow-sm p-4 mb-3 text-left"
+      data-testid="driver-livraisons-delivery-card"
+      data-id={delivery.id}
+    >
       <div className="flex items-center justify-between mb-2">
         <span className="text-[15px] font-bold text-[#1C1917]">{delivery.order.order_number}</span>
         <div className="flex items-center gap-2">

--- a/app/driver/livraisons/_components/NewAssignmentOverlay.tsx
+++ b/app/driver/livraisons/_components/NewAssignmentOverlay.tsx
@@ -23,7 +23,7 @@ export function NewAssignmentOverlay({ delivery, onAccept, onDismiss }: Props) {
   const progress = (countdown / 30) * 100;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end">
+    <div className="fixed inset-0 z-50 flex items-end" data-testid="driver-livraisons-assignment-sheet">
       <div className="absolute inset-0 bg-black/50" onClick={onDismiss} />
       <div className="relative w-full max-w-[430px] mx-auto bg-white rounded-t-3xl shadow-2xl pb-8">
         {/* Drag handle */}
@@ -82,11 +82,13 @@ export function NewAssignmentOverlay({ delivery, onAccept, onDismiss }: Props) {
 
           <button onClick={onAccept}
             className="w-full h-[52px] rounded-xl text-base font-bold text-white mb-2"
-            style={{ backgroundColor: 'var(--color-primary)' }}>
+            style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="driver-livraisons-assignment-accept-btn">
             Voir la commande
           </button>
           <button onClick={onDismiss}
-            className="w-full h-11 rounded-xl border border-gray-200 text-[15px] text-[#78716C]">
+            className="w-full h-11 rounded-xl border border-gray-200 text-[15px] text-[#78716C]"
+            data-testid="driver-livraisons-assignment-dismiss-btn">
             Ignorer
           </button>
         </div>

--- a/app/driver/livraisons/_components/PoolCard.tsx
+++ b/app/driver/livraisons/_components/PoolCard.tsx
@@ -35,7 +35,7 @@ export function PoolCard({ delivery }: Props) {
   }
 
   return (
-    <div className="rounded-xl border border-blue-200 bg-blue-50 p-4">
+    <div className="rounded-xl border border-blue-200 bg-blue-50 p-4" data-testid="driver-livraisons-pool-card" data-id={delivery.id}>
       {/* Zones */}
       <div className="mb-3 flex items-center gap-2">
         <div className="flex-1 rounded-lg bg-white px-3 py-2 text-center">
@@ -83,6 +83,7 @@ export function PoolCard({ delivery }: Props) {
         onClick={handleAccept}
         disabled={loading}
         className="flex h-11 w-full items-center justify-center rounded-xl bg-[var(--color-primary)] font-semibold text-sm text-white disabled:opacity-60"
+        data-testid="driver-livraisons-pool-accept-btn"
       >
         {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Accepter'}
       </button>

--- a/app/driver/onboarding/identity/page.tsx
+++ b/app/driver/onboarding/identity/page.tsx
@@ -50,16 +50,16 @@ export default function IdentityPage() {
 
         <div className="mt-4 flex gap-3">
           <div className="flex-1">
-            <DocumentUpload label="Recto" value={front} onChange={setFront} height={140} />
+            <DocumentUpload label="Recto" value={front} onChange={setFront} height={140} testId="driver-onboarding-cine-front-upload-input" />
           </div>
           <div className="flex-1">
-            <DocumentUpload label="Verso" value={back} onChange={setBack} height={140} />
+            <DocumentUpload label="Verso" value={back} onChange={setBack} height={140} testId="driver-onboarding-cine-back-upload-input" />
           </div>
         </div>
         <p className="text-xs text-[#78716C] mt-2">Assurez-vous que les 4 coins de la carte sont visibles</p>
       </div>
 
-      <StickyCTA label="Soumettre mon dossier" disabled={!bothReady} loading={loading} onClick={handleSubmit} />
+      <StickyCTA label="Soumettre mon dossier" disabled={!bothReady} loading={loading} onClick={handleSubmit} testId="driver-onboarding-identity-submit-btn" />
     </main>
   );
 }

--- a/app/driver/onboarding/insurance/page.tsx
+++ b/app/driver/onboarding/insurance/page.tsx
@@ -40,12 +40,12 @@ export default function InsurancePage() {
         </div>
 
         <div className="mt-4">
-          <DocumentUpload label="Attestation d'assurance" sublabel="Vérifiez que la date d'expiration est visible" value={file} onChange={setFile} />
+          <DocumentUpload label="Attestation d'assurance" sublabel="Vérifiez que la date d'expiration est visible" value={file} onChange={setFile} testId="driver-onboarding-insurance-upload-input" />
         </div>
         <p className="text-xs text-[#78716C] mt-2">Votre assurance doit être en cours de validité</p>
       </div>
 
-      <StickyCTA label="Continuer" disabled={!file} loading={loading} onClick={handleContinue} />
+      <StickyCTA label="Continuer" disabled={!file} loading={loading} onClick={handleContinue} testId="driver-onboarding-insurance-continue-btn" />
     </main>
   );
 }

--- a/app/driver/onboarding/license/page.tsx
+++ b/app/driver/onboarding/license/page.tsx
@@ -45,13 +45,13 @@ export default function LicensePage() {
         </div>
 
         <div className="mt-4">
-          <DocumentUpload label="Permis de conduire" sublabel="Recto uniquement" value={file} onChange={setFile} />
+          <DocumentUpload label="Permis de conduire" sublabel="Recto uniquement" value={file} onChange={setFile} testId="driver-onboarding-license-upload-input" />
         </div>
         <p className="text-xs text-[#78716C] mt-2">Conseils: bonne lumière, texte lisible, pas de reflet</p>
         {error && <p className="text-xs text-red-600 mt-2">{error}</p>}
       </div>
 
-      <StickyCTA label="Continuer" disabled={!file} loading={loading} onClick={handleContinue} />
+      <StickyCTA label="Continuer" disabled={!file} loading={loading} onClick={handleContinue} testId="driver-onboarding-license-continue-btn" />
     </main>
   );
 }

--- a/app/driver/onboarding/pending/page.tsx
+++ b/app/driver/onboarding/pending/page.tsx
@@ -82,6 +82,7 @@ export default async function PendingPage() {
         <Link
           href="/driver/onboarding/identity"
           className="mt-6 inline-flex h-12 items-center justify-center rounded-[12px] bg-[#2563EB] px-6 text-[14px] font-semibold text-white hover:bg-[#1D4ED8]"
+          data-testid="driver-onboarding-pending-resubmit-link"
         >
           {t('resubmit.cta')}
         </Link>

--- a/app/driver/onboarding/vehicle/page.tsx
+++ b/app/driver/onboarding/vehicle/page.tsx
@@ -42,6 +42,7 @@ export default function VehiclePage() {
                   borderColor: active ? 'var(--color-primary)' : '#E2E8F0',
                   background: active ? 'color-mix(in srgb, var(--color-primary) 5%, white)' : 'white',
                 }}
+                data-testid={`driver-onboarding-vehicle-${type}-btn`}
               >
                 <div className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0"
                   style={active ? { backgroundColor: 'var(--color-primary)' } : { backgroundColor: '#F5F5F4' }}>
@@ -67,6 +68,7 @@ export default function VehiclePage() {
         disabled={!selected}
         loading={loading}
         onClick={() => { if (selected) { setLoading(true); saveVehicleTypeAction(selected); } }}
+        testId="driver-onboarding-vehicle-continue-btn"
       />
     </main>
   );

--- a/app/driver/profil/horaires/page.tsx
+++ b/app/driver/profil/horaires/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { saveScheduleAction, getScheduleAction } from './actions'
 
 const DAY_LABELS = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
+const DAY_SLUGS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
 
 type DaySchedule = {
   day_of_week: number
@@ -74,6 +75,7 @@ export default function HorairesPage() {
                 <button
                   onClick={() => updateDay(i, { is_active: !day.is_active })}
                   className={`relative h-5 w-9 rounded-full transition-colors ${day.is_active ? 'bg-[var(--color-primary)]' : 'bg-gray-300'}`}
+                  data-testid={`driver-horaires-${DAY_SLUGS[i]}-toggle-btn`}
                 >
                   <span
                     className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${day.is_active ? 'translate-x-4' : 'translate-x-0.5'}`}
@@ -88,6 +90,7 @@ export default function HorairesPage() {
                       value={day.start_time}
                       onChange={e => updateDay(i, { start_time: e.target.value })}
                       className="rounded-lg border border-gray-300 px-2 py-1 text-[13px] text-gray-900"
+                      data-testid={`driver-horaires-${DAY_SLUGS[i]}-start-input`}
                     />
                     <span className="text-gray-400">—</span>
                     <input
@@ -95,6 +98,7 @@ export default function HorairesPage() {
                       value={day.end_time}
                       onChange={e => updateDay(i, { end_time: e.target.value })}
                       className="rounded-lg border border-gray-300 px-2 py-1 text-[13px] text-gray-900"
+                      data-testid={`driver-horaires-${DAY_SLUGS[i]}-end-input`}
                     />
                   </div>
                 ) : (
@@ -109,6 +113,7 @@ export default function HorairesPage() {
           onClick={handleSave}
           disabled={isPending}
           className="mt-6 flex h-13 w-full items-center justify-center rounded-xl bg-[var(--color-primary)] font-semibold text-white disabled:opacity-60"
+          data-testid="driver-horaires-save-btn"
         >
           {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : saved ? 'Enregistré ✓' : 'Enregistrer'}
         </button>

--- a/app/driver/profil/page.tsx
+++ b/app/driver/profil/page.tsx
@@ -92,13 +92,14 @@ export default async function ProfilPage() {
 
         <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
           {[
-            { Icon: Calendar,   label: 'Mes horaires',   color: 'var(--color-primary)', href: '/driver/profil/horaires' },
-            { Icon: Settings,   label: 'Paramètres',     color: '#78716C', href: '#' },
-            { Icon: HelpCircle, label: 'Aide & Support', color: '#78716C', href: '#' },
-          ].map(({ Icon, label, color, href }) => (
+            { Icon: Calendar,   label: 'Mes horaires',   color: 'var(--color-primary)', href: '/driver/profil/horaires', testId: 'driver-profil-horaires-link' },
+            { Icon: Settings,   label: 'Paramètres',     color: '#78716C', href: '#', testId: undefined },
+            { Icon: HelpCircle, label: 'Aide & Support', color: '#78716C', href: '#', testId: undefined },
+          ].map(({ Icon, label, color, href, testId }) => (
             <a key={label} href={href}
               className="px-4 flex items-center gap-3 border-b border-gray-100"
-              style={{ height: 52 }}>
+              style={{ height: 52 }}
+              data-testid={testId}>
               <Icon className="w-5 h-5 flex-shrink-0" style={{ color }} />
               <span className="flex-1 text-[15px]" style={{ color }}>{label}</span>
               <ChevronRight className="w-4 h-4 text-gray-300" />


### PR DESCRIPTION
## Summary

PLZ-077 — adds `data-testid` attributes to every driver-facing and admin-facing interactive element so QA can drive Playwright scenarios without brittle selectors. **Zero functional changes** — only attributes and optional props on shared components.

- **Driver scope (27 files):** auth (phone/otp/pin/pin-setup), onboarding (vehicle/license/insurance/identity/pending), livraisons list + assignment overlay + pool card, delivery detail + collect + deliver + issue + both success pages, profil + horaires, bottom nav, offline banner, logout.
- **Admin scope (8 files):** login, home, drivers/pending (refresh, search, rows + mobile cards), drivers/[id] (approve/reject desktop + mobile, plus 4 `ConfirmDialog` flows: approve-override, reject, resubmit-doc, reject-doc).

## Shared-component contracts added (all optional, backward compatible)

- `PinBoxes` / `OtpBoxes` → new `testIdPrefix?: string`, expands to `{prefix}-digit-{n}-input`.
- `StickyCTA`, `DocumentUpload`, `PhotoCapture` → new `testId?: string` forwarded to underlying control.
- `ConfirmDialog` → new `testIdPrefix?: string`, expands to `{prefix}-dialog`, `{prefix}-reason-textarea` (when `requireReason`), `{prefix}-cancel-btn`, `{prefix}-confirm-btn`.
- `DataTable` → new `rowTestId?: string`; rows get `data-testid={rowTestId}` + `data-id={row.id}` (QA uses `[data-testid="…-row"][data-id="…"]`).
- `FilterBar` → `search.testId?: string` forwarded to the `<input>`.

Mehdi's parallel branch `feat/PLZ-077-testids-merchant-customer` can adopt these same props without conflict — they are purely additive.

## Naming convention

All testids match:

```
^(driver|admin)-[a-z0-9-]+-(btn|input|select|checkbox|textarea|link|dialog|sheet|row|card|field|badge|toast)$
```

Each testid carries page-flow context (e.g. `driver-onboarding-license-upload-input`, `admin-driver-dossier-reject-btn`). Dynamic collections (PIN/OTP digits, vehicle types, issue chips, day-of-week toggles) use template expansion from a prefix — runtime cardinality is ~120+ while the static string count is ~46.

## Verification

- `npx tsc --noEmit` → clean, 0 errors.
- `npm run lint` → clean; only pre-existing `<img>` warnings in `app/store/**` (untouched by this PR).
- No changes to `messages/fr.json` / `messages/ar.json`.
- No changes outside `app/driver/**` and `app/admin/**`.
- No functional changes (handlers, state, routing untouched).
- All testids verified against the regex above.

## Observed during PLZ-077

None — no functional bugs surfaced while adding testids.

## Test plan

- [ ] Run `npm run lint` and `npx tsc --noEmit` locally — both clean.
- [ ] Smoke-test driver flow (phone → OTP → PIN setup → onboarding vehicle → livraisons → delivery detail → collect → deliver) to confirm no runtime regression from the attribute additions.
- [ ] Smoke-test admin flow (login → pending drivers → driver dossier → approve + reject ConfirmDialog) to confirm dialogs, table rows, and FilterBar still behave identically.
- [ ] (Follow-up QA) Write Playwright selectors using the new testids to confirm every element is reachable.

/cc @anas for merge review.

Closes PLZ-077 (driver + admin scope). Merchant + customer scope tracked on `feat/PLZ-077-testids-merchant-customer`.
