### PR TITLE
feat(PLZ-077): add data-testid — merchant + customer (198 elements)

### DIFF
--- a/app/auth/forgot-pin/page.tsx
+++ b/app/auth/forgot-pin/page.tsx
@@ -25,6 +25,7 @@ function ForgotPINContent() {
           onClick={() => router.back()}
           className="w-11 h-11 flex items-center justify-center hover:bg-[#F5F5F4] rounded-lg transition-colors mt-4 ms-4 md:mt-0 md:ms-0"
           aria-label="Retour"
+          data-testid="merchant-forgot-pin-back-btn"
         >
           <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
         </button>
@@ -59,12 +60,14 @@ function ForgotPINContent() {
             onClick={handleSendOTP}
             className="h-14 w-full rounded-xl text-white text-base font-semibold hover:opacity-90 transition-opacity"
             style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="merchant-forgot-pin-send-sms-btn"
           >
             {t('sendSms')}
           </button>
           <button
             onClick={() => router.push('/auth/recovery')}
             className="text-[13px] text-[#78716C] text-center mt-4 w-full"
+            data-testid="merchant-forgot-pin-wrong-number-btn"
           >
             {t('wrongNumber')}
           </button>

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -94,6 +94,7 @@ export default function PhoneEntryPage() {
               className="flex-1 h-full px-4 text-base bg-transparent outline-none text-[#1C1917]"
               inputMode="numeric"
               autoComplete="tel"
+              data-testid="merchant-login-phone-input"
             />
           </div>
           <div className={`text-xs mt-2 ${error ? 'text-[#DC2626]' : 'text-[#78716C]'}`}>
@@ -112,6 +113,7 @@ export default function PhoneEntryPage() {
                 : 'bg-[#E2E8F0] text-[#A8A29E] cursor-not-allowed'
             }`}
             style={isValid && !loading ? { backgroundColor: 'var(--color-primary)' } : undefined}
+            data-testid="merchant-login-continue-btn"
           >
             {t('continue')}
           </button>
@@ -126,6 +128,7 @@ export default function PhoneEntryPage() {
             href="/auth/pin-login"
             className="text-sm font-medium hover:underline"
             style={{ color: 'var(--color-primary)' }}
+            data-testid="merchant-login-signin-link"
           >
             Se connecter
           </a>

--- a/app/auth/otp/page.tsx
+++ b/app/auth/otp/page.tsx
@@ -108,6 +108,7 @@ function OTPContent() {
           onClick={() => router.back()}
           className="w-11 h-11 flex items-center justify-center hover:bg-[#F5F5F4] rounded-lg transition-colors -ms-2 mb-4"
           aria-label="Retour"
+          data-testid="merchant-otp-back-btn"
         >
           <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
         </button>
@@ -143,6 +144,7 @@ function OTPContent() {
                   ? 'bg-[#F8FAFC] border border-[#E2E8F0]'
                   : 'border-2 border-[var(--color-primary)] ring-2 ring-[var(--color-primary)]/20'
               } ${isLocked ? 'bg-[#F5F5F4] text-[#A8A29E]' : 'text-[#1C1917]'}`}
+              data-testid={`merchant-otp-digit-${index + 1}-input`}
             />
           ))}
         </div>
@@ -184,6 +186,7 @@ function OTPContent() {
                 onClick={handleResend}
                 className="text-[13px] underline"
                 style={{ color: 'var(--color-primary)' }}
+                data-testid="merchant-otp-resend-btn"
               >
                 {t('resend')}
               </button>
@@ -191,7 +194,7 @@ function OTPContent() {
           </div>
         )}
 
-        <button className="text-[13px] text-[#78716C] text-center mt-4 w-full">
+        <button className="text-[13px] text-[#78716C] text-center mt-4 w-full" data-testid="merchant-otp-wrong-number-btn">
           {t('wrongNumber')}
         </button>
 

--- a/app/auth/pin-login/page.tsx
+++ b/app/auth/pin-login/page.tsx
@@ -130,6 +130,7 @@ function PINLoginContent() {
                 className={`w-12 h-12 text-center text-xl border-2 rounded-lg outline-none transition-all ${
                   isLocked ? 'border-[#E2E8F0] bg-[#F5F5F4]' : error ? 'border-[#DC2626]' : 'border-[#E2E8F0] focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20'
                 } disabled:opacity-50 disabled:cursor-not-allowed`}
+                data-testid={`merchant-pin-login-digit-${index + 1}-input`}
               />
             ))}
           </div>
@@ -157,6 +158,7 @@ function PINLoginContent() {
                   className={`h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all ${
                     isLocked || isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
                   }`}
+                  data-testid={`merchant-pin-login-numpad-${num}-btn`}
                 >
                   {num}
                 </button>
@@ -168,6 +170,7 @@ function PINLoginContent() {
                 className={`h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all ${
                   isLocked || isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
                 }`}
+                data-testid="merchant-pin-login-numpad-0-btn"
               >
                 0
               </button>
@@ -179,6 +182,7 @@ function PINLoginContent() {
                   isLocked || isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
                 }`}
                 aria-label="Effacer"
+                data-testid="merchant-pin-login-backspace-btn"
               >
                 <Delete className="w-5 h-5 text-[#1C1917]" />
               </button>
@@ -189,6 +193,7 @@ function PINLoginContent() {
             onClick={() => router.push('/auth/forgot-pin')}
             className="text-[13px] text-center mt-4 w-full"
             style={{ color: 'var(--color-primary)' }}
+            data-testid="merchant-pin-login-forgot-pin-btn"
           >
             {t('forgotPin')}
           </button>
@@ -201,6 +206,7 @@ function PINLoginContent() {
               href="/auth/login"
               className="text-sm font-medium hover:underline"
               style={{ color: 'var(--color-primary)' }}
+              data-testid="merchant-pin-login-signup-link"
             >
               S&apos;inscrire
             </a>
@@ -208,6 +214,7 @@ function PINLoginContent() {
           <button
             onClick={() => router.push('/auth/login')}
             className="text-xs text-[#A8A29E]"
+            data-testid="merchant-pin-login-switch-account-btn"
           >
             {t('switchAccount')}
           </button>

--- a/app/auth/pin-setup/page.tsx
+++ b/app/auth/pin-setup/page.tsx
@@ -93,6 +93,7 @@ function PINSetupContent() {
               step === 1 ? 'invisible' : ''
             }`}
             aria-label="Retour"
+            data-testid="merchant-pin-setup-back-btn"
           >
             <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
           </button>
@@ -157,6 +158,7 @@ function PINSetupContent() {
               className={`w-12 h-12 text-center text-xl border-2 rounded-lg outline-none transition-all ${
                 error ? 'border-[#DC2626]' : 'border-[#E2E8F0] focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20'
               }`}
+              data-testid={`merchant-pin-setup-digit-${index + 1}-input`}
             />
           ))}
         </div>
@@ -173,6 +175,7 @@ function PINSetupContent() {
                 key={num}
                 onClick={() => handleNumberPress(num.toString())}
                 className="h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all"
+                data-testid={`merchant-pin-setup-numpad-${num}-btn`}
               >
                 {num}
               </button>
@@ -182,6 +185,7 @@ function PINSetupContent() {
             <button
               onClick={() => handleNumberPress('0')}
               className="h-16 rounded-2xl bg-white border border-[#E2E8F0] text-xl font-medium text-[#1C1917] hover:bg-[#F0F4FF] active:scale-95 transition-all"
+              data-testid="merchant-pin-setup-numpad-0-btn"
             >
               0
             </button>
@@ -190,6 +194,7 @@ function PINSetupContent() {
               onClick={handleBackspace}
               className="h-16 rounded-2xl bg-white border border-[#E2E8F0] flex items-center justify-center hover:bg-[#F0F4FF] active:scale-95 transition-all"
               aria-label="Effacer"
+              data-testid="merchant-pin-setup-backspace-btn"
             >
               <Delete className="w-5 h-5 text-[#1C1917]" />
             </button>

--- a/app/auth/recovery/page.tsx
+++ b/app/auth/recovery/page.tsx
@@ -35,6 +35,7 @@ export default function PhoneRecoveryPage() {
             onClick={() => router.back()}
             className="w-11 h-11 flex items-center justify-center hover:bg-[#F5F5F4] rounded-lg transition-colors mt-4 ms-4 md:mt-0 md:ms-0"
             aria-label="Retour"
+            data-testid="merchant-recovery-back-btn"
           >
             <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
           </button>
@@ -60,6 +61,7 @@ export default function PhoneRecoveryPage() {
               }}
               className="text-[13px] mt-6"
             style={{ color: 'var(--color-primary)' }}
+              data-testid="merchant-recovery-resend-btn"
             >
               {t('resend')}
             </button>
@@ -77,6 +79,7 @@ export default function PhoneRecoveryPage() {
           onClick={() => router.back()}
           className="w-11 h-11 flex items-center justify-center hover:bg-[#F5F5F4] rounded-lg transition-colors mt-4 ms-4 md:mt-0 md:ms-0"
           aria-label="Retour"
+          data-testid="merchant-recovery-back-btn"
         >
           <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
         </button>
@@ -108,6 +111,7 @@ export default function PhoneRecoveryPage() {
               className={`h-12 w-full border rounded-xl px-4 text-sm text-[#1C1917] outline-none transition-colors ${
                 error ? 'border-[#DC2626]' : 'border-[#E2E8F0] focus:border-[var(--color-primary)]'
               }`}
+              data-testid="merchant-recovery-email-input"
             />
             {error && (
               <div className="text-[13px] text-[#DC2626] mt-2">{t('emailError')}</div>
@@ -125,12 +129,13 @@ export default function PhoneRecoveryPage() {
                 : 'bg-[#E2E8F0] text-[#A8A29E] cursor-not-allowed'
             }`}
             style={email ? { backgroundColor: 'var(--color-primary)' } : undefined}
+            data-testid="merchant-recovery-submit-btn"
           >
             {t('submit')}
           </button>
           <div className="text-xs text-[#78716C] text-center mt-4">
             {t('noEmailNote')}{' '}
-            <button className="text-[#E8632A]">{t('contactSupport')}</button>
+            <button className="text-[#E8632A]" data-testid="merchant-recovery-contact-support-btn">{t('contactSupport')}</button>
           </div>
         </div>
       </div>

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -58,6 +58,7 @@ export default function SignupPage() {
             <Link
               href="/auth/login"
               className="font-medium underline underline-offset-2 hover:text-amber-900"
+              data-testid="merchant-signup-deprecation-link"
             >
               {ts('deprecationLink')} {isRtl ? '←' : '→'}
             </Link>
@@ -80,6 +81,7 @@ export default function SignupPage() {
               required
               autoComplete="organization"
               disabled={loading}
+              data-testid="merchant-signup-store-name-input"
             />
           </div>
 
@@ -93,6 +95,7 @@ export default function SignupPage() {
               required
               autoComplete="email"
               disabled={loading}
+              data-testid="merchant-signup-email-input"
             />
           </div>
 
@@ -107,6 +110,7 @@ export default function SignupPage() {
               minLength={8}
               autoComplete="new-password"
               disabled={loading}
+              data-testid="merchant-signup-password-input"
             />
           </div>
 
@@ -116,14 +120,14 @@ export default function SignupPage() {
             </p>
           )}
 
-          <Button type="submit" className="w-full" disabled={loading}>
+          <Button type="submit" className="w-full" disabled={loading} data-testid="merchant-signup-submit-btn">
             {loading ? tc('loading') : t('signUp')}
           </Button>
         </form>
 
         <p className="text-center text-sm text-muted-foreground">
           {t('alreadyHaveAccount')}{' '}
-          <Link href="/auth/login" className="font-medium text-primary underline-offset-4 hover:underline">
+          <Link href="/auth/login" className="font-medium text-primary underline-offset-4 hover:underline" data-testid="merchant-signup-signin-link">
             {t('signIn')}
           </Link>
         </p>

--- a/app/dashboard/CopyButton.tsx
+++ b/app/dashboard/CopyButton.tsx
@@ -25,6 +25,7 @@ export function CopyButton({ url }: Props) {
       type="button"
       onClick={handleCopy}
       className="w-full h-9 border border-[#E2E8F0] text-[#1C1917] rounded-lg text-sm font-medium hover:bg-[#F8FAFC] transition-colors flex items-center justify-center gap-2"
+      data-testid="merchant-dashboard-copy-link-btn"
     >
       {copied ? (
         <>

--- a/app/dashboard/boutique/BoutiqueForm.tsx
+++ b/app/dashboard/boutique/BoutiqueForm.tsx
@@ -230,7 +230,15 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   const ex2Commission = ex2Price * 0.05;
   const ex2Revenue = ex2Price - ex2Commission - 30;
 
-  const Toggle = ({ checked, onChange }: { checked: boolean; onChange: () => void }) => (
+  const Toggle = ({
+    checked,
+    onChange,
+    testId,
+  }: {
+    checked: boolean;
+    onChange: () => void;
+    testId?: string;
+  }) => (
     <button
       type="button"
       role="switch"
@@ -239,6 +247,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
       className={`relative w-11 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 ${
         checked ? 'bg-[#16A34A]' : 'bg-[#E2E8F0]'
       }`}
+      data-testid={testId}
     >
       <span
         className={`absolute top-0.5 start-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
@@ -263,6 +272,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             value={storeName}
             onChange={(e) => setStoreName(e.target.value)}
             className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+            data-testid="merchant-boutique-store-name-input"
           />
         </div>
         <div>
@@ -274,6 +284,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
               setStoreSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'))
             }
             className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+            data-testid="merchant-boutique-store-slug-input"
           />
           <p className="text-xs text-[#78716C] mt-1.5">plaza.ma/store/{storeSlug}</p>
         </div>
@@ -284,6 +295,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             className="w-full px-3 py-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] resize-none"
+            data-testid="merchant-boutique-description-textarea"
           />
         </div>
         <div>
@@ -292,6 +304,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             value={category}
             onChange={(e) => setCategory(e.target.value)}
             className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+            data-testid="merchant-boutique-category-select"
           >
             <option value="" disabled>Choisir une catégorie…</option>
             {STORE_CATEGORIES.map((cat) => (
@@ -332,6 +345,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             onChange={(e) => setLocationDescription(e.target.value)}
             placeholder="Ex: 2ème étage, porte bleue, en face du café..."
             className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+            data-testid="merchant-boutique-location-description-input"
           />
         </div>
       </div>
@@ -356,6 +370,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
               const file = e.target.files?.[0];
               if (file) uploadFile(file, setUploadingLogo, setLogoUrl);
             }}
+            data-testid="merchant-boutique-logo-input"
           />
           <div
             onClick={() => !uploadingLogo && logoInputRef.current?.click()}
@@ -393,6 +408,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                       ? '2.5px solid #1C1917'
                       : '2px solid transparent',
                 }}
+                data-testid={`merchant-boutique-color-${opt.value.replace('#', '').toLowerCase()}-btn`}
               />
             ))}
           </div>
@@ -410,6 +426,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
               const file = e.target.files?.[0];
               if (file) uploadFile(file, setUploadingBanner, setBannerUrl);
             }}
+            data-testid="merchant-boutique-banner-input"
           />
           <div
             onClick={() => !uploadingBanner && bannerInputRef.current?.click()}
@@ -458,7 +475,11 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             <div className="text-sm font-medium text-[#1C1917]">{t('freeDeliveryToggle')}</div>
             <div className="text-xs text-[#78716C] mt-0.5">{t('freeDeliverySubtitle')}</div>
           </div>
-          <Toggle checked={freeDeliveryEnabled} onChange={() => setFreeDeliveryEnabled((v) => !v)} />
+          <Toggle
+            checked={freeDeliveryEnabled}
+            onChange={() => setFreeDeliveryEnabled((v) => !v)}
+            testId="merchant-boutique-free-delivery-toggle-checkbox"
+          />
         </div>
 
         {freeDeliveryEnabled && (
@@ -472,6 +493,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                 value={freeDeliveryThreshold}
                 onChange={(e) => setFreeDeliveryThreshold(e.target.value)}
                 className="w-[120px] h-12 px-3 text-center text-xl font-semibold border-2 border-[#E2E8F0] rounded-lg focus:outline-none focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20"
+                data-testid="merchant-boutique-free-delivery-threshold-input"
               />
               <span className="text-base text-[#78716C]">MAD</span>
             </div>
@@ -583,7 +605,11 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             {isOnline ? t('online') : t('offline')}
           </span>
         </div>
-        <Toggle checked={isOnline} onChange={handleToggleOnline} />
+        <Toggle
+          checked={isOnline}
+          onChange={handleToggleOnline}
+          testId="merchant-boutique-online-toggle-checkbox"
+        />
       </div>
       {!isOnline && (
         <p className="text-xs text-[#78716C] mt-2">{t('offlineNote')}</p>
@@ -614,6 +640,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
               setTerminalEnabled(next);
               startTransition(() => updateTerminalEnabled(next));
             }}
+            testId="merchant-boutique-terminal-toggle-checkbox"
           />
         </div>
 
@@ -754,6 +781,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           disabled={isPending || uploadingLogo || uploadingBanner}
           className="w-full h-12 text-white text-base font-semibold rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
           style={{ backgroundColor: 'var(--color-primary)' }}
+          data-testid="merchant-boutique-save-btn"
         >
           {isPending ? t('saving') : t('save')}
         </button>
@@ -799,6 +827,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                 disabled={isPending || uploadingLogo || uploadingBanner}
                 className="w-[200px] h-12 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
                 style={{ backgroundColor: 'var(--color-primary)' }}
+                data-testid="merchant-boutique-save-btn"
               >
                 {isPending ? t('saving') : t('save')}
               </button>
@@ -826,6 +855,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           role="dialog"
           aria-modal="true"
           aria-labelledby="incomplete-modal-title"
+          data-testid="merchant-boutique-incomplete-dialog"
         >
           <div className="w-full max-w-sm bg-white rounded-2xl shadow-xl p-6">
             <h2
@@ -853,6 +883,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
               type="button"
               onClick={() => setShowIncompleteModal(false)}
               className="w-full h-10 rounded-xl border border-[#E2E8F0] text-sm font-medium text-[#1C1917] hover:bg-[#F8FAFC] transition-colors"
+              data-testid="merchant-boutique-incomplete-close-btn"
             >
               Fermer
             </button>

--- a/app/dashboard/commandes/OrderDetailSheet.tsx
+++ b/app/dashboard/commandes/OrderDetailSheet.tsx
@@ -201,6 +201,7 @@ function ActionBar({
             onClick={() => run(confirmOrderAction)}
             className="w-full h-12 text-white text-[14px] font-semibold rounded-lg hover:opacity-90 transition-opacity"
             style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="merchant-order-confirm-btn"
           >
             Confirmer la commande
           </button>
@@ -210,6 +211,7 @@ function ActionBar({
           <button
             onClick={onReportOpen}
             className="w-full h-12 border border-[#E2E8F0] text-[#78716C] rounded-lg text-[14px] font-medium hover:bg-[#F5F5F4] transition-colors"
+            data-testid="merchant-order-report-issue-btn"
           >
             Signaler un problème
           </button>
@@ -238,7 +240,10 @@ export function OrderDetailSheet({ order, onClose }: Props) {
       />
 
       {/* Drawer panel */}
-      <div className="fixed end-0 top-0 h-screen w-full max-w-[560px] bg-white shadow-xl z-50 flex flex-col">
+      <div
+        className="fixed end-0 top-0 h-screen w-full max-w-[560px] bg-white shadow-xl z-50 flex flex-col"
+        data-testid="merchant-order-detail-sheet"
+      >
 
         {/* Header */}
         <div className="h-16 border-b border-[#E2E8F0] px-6 flex items-center justify-between flex-shrink-0">

--- a/app/dashboard/commandes/OrdersClient.tsx
+++ b/app/dashboard/commandes/OrdersClient.tsx
@@ -77,6 +77,7 @@ export function OrdersClient({ orders }: Props) {
                   ? 'bg-[var(--color-primary)] text-white'
                   : 'bg-white text-[#78716C] border border-[#E2E8F0] hover:bg-[#F8FAFC]'
               }`}
+              data-testid={`merchant-orders-filter-${f.id}-btn`}
             >
               {f.label} ({countFor(f.id)})
             </button>
@@ -102,6 +103,8 @@ export function OrdersClient({ orders }: Props) {
               key={order.id}
               onClick={() => setSelectedOrder(order)}
               className="h-14 px-4 flex items-center border-b border-[#F3F4F6] hover:bg-[#F8FAFC] cursor-pointer transition-colors last:border-b-0"
+              data-testid="merchant-orders-row"
+              data-id={order.id}
             >
               <div className="w-[130px] text-sm font-medium text-[#1C1917]">
                 {order.order_number}
@@ -149,6 +152,8 @@ export function OrdersClient({ orders }: Props) {
               key={order.id}
               href={`/dashboard/commandes/${order.id}`}
               className="block bg-white rounded-xl p-3 shadow-sm hover:shadow-md transition-shadow"
+              data-testid="merchant-orders-row"
+              data-id={order.id}
             >
               <div className="flex items-start justify-between mb-2">
                 <div>

--- a/app/dashboard/commandes/ReportIssueSheet.tsx
+++ b/app/dashboard/commandes/ReportIssueSheet.tsx
@@ -42,7 +42,10 @@ export function ReportIssueSheet({ order, onClose }: Props) {
       <div className="fixed inset-0 bg-black/30 z-[60]" onClick={onClose} />
 
       {/* Sheet */}
-      <div className="fixed end-0 top-0 h-screen w-full max-w-[480px] bg-white shadow-xl z-[70] flex flex-col">
+      <div
+        className="fixed end-0 top-0 h-screen w-full max-w-[480px] bg-white shadow-xl z-[70] flex flex-col"
+        data-testid="merchant-order-report-issue-sheet"
+      >
 
         {/* Header */}
         <div className="h-16 border-b border-[#E2E8F0] px-6 flex items-center justify-between flex-shrink-0">
@@ -90,6 +93,7 @@ export function ReportIssueSheet({ order, onClose }: Props) {
                   placeholder="Décrivez le problème rencontré avec cette commande…"
                   rows={6}
                   className="w-full px-3 py-2.5 border border-[#E2E8F0] rounded-lg text-sm resize-none focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                  data-testid="merchant-order-report-issue-description-textarea"
                 />
                 <div className="text-xs text-[#A8A29E] text-end mt-1">
                   {description.length}/{MAX_DESC}
@@ -107,6 +111,7 @@ export function ReportIssueSheet({ order, onClose }: Props) {
               onClick={handleSubmit}
               className="w-full h-11 text-white text-sm font-semibold rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center justify-center gap-2"
               style={{ backgroundColor: 'var(--color-primary)' }}
+              data-testid="merchant-order-report-issue-submit-btn"
             >
               {isPending && <Loader2 className="w-4 h-4 animate-spin" />}
               Créer le ticket

--- a/app/dashboard/commandes/[id]/OrderDetailClient.tsx
+++ b/app/dashboard/commandes/[id]/OrderDetailClient.tsx
@@ -145,6 +145,7 @@ export function OrderDetailClient({ order }: Props) {
           <button
             onClick={() => router.back()}
             className="absolute start-4 p-2 -ms-2"
+            data-testid="merchant-order-detail-back-btn"
           >
             <ArrowLeft size={20} className="text-[#1C1917]" />
           </button>
@@ -335,6 +336,7 @@ export function OrderDetailClient({ order }: Props) {
                   onClick={() => run(confirmOrderAction)}
                   className="w-full h-12 text-white text-[14px] font-semibold rounded-lg hover:opacity-90 transition-opacity"
                   style={{ backgroundColor: 'var(--color-primary)' }}
+                  data-testid="merchant-order-confirm-btn"
                 >
                   Confirmer la commande
                 </button>
@@ -342,6 +344,7 @@ export function OrderDetailClient({ order }: Props) {
               <button
                 onClick={() => setReportOpen(true)}
                 className="w-full h-12 border border-[#E2E8F0] text-[#78716C] text-[14px] font-medium rounded-lg hover:bg-[#F5F5F4] transition-colors"
+                data-testid="merchant-order-report-issue-btn"
               >
                 Signaler un problème
               </button>

--- a/app/dashboard/compte/CompteClient.tsx
+++ b/app/dashboard/compte/CompteClient.tsx
@@ -110,6 +110,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                data-testid="merchant-account-full-name-input"
               />
             </div>
             <div>
@@ -119,6 +120,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
                 value={mail}
                 onChange={(e) => setMail(e.target.value)}
                 className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                data-testid="merchant-account-email-input"
               />
               <p className="text-xs text-[#78716C] mt-1">{t('emailNote')}</p>
             </div>
@@ -130,6 +132,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
                 value={tel}
                 onChange={(e) => setTel(e.target.value)}
                 className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                data-testid="merchant-account-phone-input"
               />
             </div>
 
@@ -139,6 +142,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
               onClick={() => setShowPasswordForm((v) => !v)}
               className="w-full h-12 flex items-center justify-between px-4 border border-[#E2E8F0] rounded-lg text-sm hover:bg-[#F8FAFC] transition-colors"
               style={{ color: 'var(--color-primary)' }}
+              data-testid="merchant-account-change-password-btn"
             >
               <span>{t('changePassword')}</span>
               {showPasswordForm ? (
@@ -159,6 +163,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
                       onChange={(e) => setPassword(e.target.value)}
                       placeholder={t('passwordPlaceholder')}
                       className="w-full h-10 px-3 pr-10 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                      data-testid="merchant-account-new-password-input"
                     />
                     <button
                       type="button"
@@ -177,6 +182,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
                   disabled={isPasswordPending}
                   className="h-9 px-4 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
                   style={{ backgroundColor: 'var(--color-primary)' }}
+                  data-testid="merchant-account-save-password-btn"
                 >
                   {isPasswordPending ? t('saving') : t('savePassword')}
                 </button>
@@ -195,6 +201,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
           disabled={isPending}
           className="w-full h-11 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
           style={{ backgroundColor: 'var(--color-primary)' }}
+          data-testid="merchant-account-save-btn"
         >
           {isPending ? t('saving') : t('save')}
         </button>

--- a/app/dashboard/finances/FinancesClient.tsx
+++ b/app/dashboard/finances/FinancesClient.tsx
@@ -111,6 +111,7 @@ export function FinancesClient({ metrics, period }: Props) {
                   ? 'bg-[var(--color-primary)] text-white'
                   : 'bg-white text-[#78716C] border border-[#E2E8F0] hover:bg-[#F8FAFC]'
               }`}
+              data-testid={`merchant-finances-period-${p.id}-btn`}
             >
               {p.label}
             </button>
@@ -299,6 +300,8 @@ export function FinancesClient({ metrics, period }: Props) {
                             <Link
                               href={`/dashboard/produits/${p.product_id}`}
                               className="text-sm font-medium text-[#1C1917] truncate hover:text-[var(--color-primary)] block"
+                              data-testid="merchant-finances-top-product-link"
+                              data-id={p.product_id}
                             >
                               {p.name_fr}
                             </Link>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -114,7 +114,7 @@ export default async function DashboardPage() {
       {/* Mobile top bar */}
       <div className="md:hidden bg-white px-4 py-4 flex items-center justify-between border-b border-[#E2E8F0]">
         <div className="font-bold text-xl" style={{ color: 'var(--color-primary)' }}>Plaza</div>
-        <Link href="/dashboard/compte">
+        <Link href="/dashboard/compte" data-testid="merchant-dashboard-account-link">
           <div className="w-10 h-10 rounded-full flex items-center justify-center font-semibold text-sm" style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, white)', color: 'var(--color-primary)' }}>
             {merchant.store_name.slice(0, 2).toUpperCase()}
           </div>
@@ -176,7 +176,7 @@ export default async function DashboardPage() {
             </div>
           </div>
 
-          <Link href="/dashboard/commandes?filter=pending" className="block">
+          <Link href="/dashboard/commandes?filter=pending" className="block" data-testid="merchant-dashboard-pending-orders-link">
             <div className="bg-white rounded-xl shadow-sm p-4 md:p-5 h-full cursor-pointer hover:shadow-md transition-shadow">
               <div className="flex items-start justify-between mb-3">
                 <div className="w-10 h-10 rounded-full bg-[#FFFBEB] flex items-center justify-center">
@@ -223,6 +223,8 @@ export default async function DashboardPage() {
                     key={order.id}
                     href={`/dashboard/commandes/${order.id}`}
                     className="block bg-white rounded-xl p-3 shadow-sm hover:shadow-md transition-shadow"
+                    data-testid="merchant-dashboard-recent-order-row"
+                    data-id={order.id}
                   >
                     <div className="flex items-start justify-between mb-2">
                       <div>
@@ -266,6 +268,8 @@ export default async function DashboardPage() {
                     key={order.id}
                     href={`/dashboard/commandes/${order.id}`}
                     className="h-12 px-4 flex items-center border-b border-[#F3F4F6] hover:bg-[#F8FAFC] cursor-pointer transition-colors"
+                    data-testid="merchant-dashboard-recent-order-row"
+                    data-id={order.id}
                   >
                     <div className="w-[130px] text-sm font-medium text-[#1C1917]">
                       {order.order_number}
@@ -310,6 +314,7 @@ export default async function DashboardPage() {
                 rel="noopener noreferrer"
                 className="btn-primary-outline-hover w-full h-9 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
                 style={{ border: '1px solid var(--color-primary)', color: 'var(--color-primary)' }}
+                data-testid="merchant-dashboard-view-store-link"
               >
                 <ExternalLink className="w-4 h-4" />
                 Voir la boutique

--- a/app/dashboard/parametres/ParametresClient.tsx
+++ b/app/dashboard/parametres/ParametresClient.tsx
@@ -21,11 +21,11 @@ export function ParametresClient() {
   const [twoFactor, _setTwoFactor] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-  const notifItems: { id: NotifKey; label: string }[] = [
-    { id: 'newOrders', label: t('notifNewOrders') },
-    { id: 'delivered', label: t('notifDelivered') },
-    { id: 'support', label: t('notifSupport') },
-    { id: 'promotions', label: t('notifPromotions') },
+  const notifItems: { id: NotifKey; slug: string; label: string }[] = [
+    { id: 'newOrders', slug: 'new-orders', label: t('notifNewOrders') },
+    { id: 'delivered', slug: 'delivered', label: t('notifDelivered') },
+    { id: 'support', slug: 'support', label: t('notifSupport') },
+    { id: 'promotions', slug: 'promotions', label: t('notifPromotions') },
   ];
 
   function handleDeleteAccount() {
@@ -87,7 +87,7 @@ export function ParametresClient() {
                   onChange={() =>
                     setNotifications((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
                   }
-                  testId={`merchant-settings-notif-${item.id}-toggle-checkbox`}
+                  testId={`merchant-settings-notif-${item.slug}-toggle-checkbox`}
                 />
               </div>
             ))}

--- a/app/dashboard/parametres/ParametresClient.tsx
+++ b/app/dashboard/parametres/ParametresClient.tsx
@@ -36,13 +36,14 @@ export function ParametresClient() {
     });
   }
 
-  const Toggle = ({ checked, onChange, disabled = false }: { checked: boolean; onChange: () => void; disabled?: boolean }) => (
+  const Toggle = ({ checked, onChange, disabled = false, testId }: { checked: boolean; onChange: () => void; disabled?: boolean; testId?: string }) => (
     <button
       type="button"
       role="switch"
       aria-checked={checked}
       onClick={onChange}
       disabled={disabled}
+      data-testid={testId}
       className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
         checked ? 'bg-[var(--color-primary)]' : 'bg-[#E2E8F0]'
       }`}
@@ -86,6 +87,7 @@ export function ParametresClient() {
                   onChange={() =>
                     setNotifications((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
                   }
+                  testId={`merchant-settings-notif-${item.id}-toggle-checkbox`}
                 />
               </div>
             ))}
@@ -147,6 +149,7 @@ export function ParametresClient() {
             type="button"
             onClick={() => setShowDeleteModal(true)}
             className="w-full h-11 bg-white border-[1.5px] border-[#DC2626] text-[#DC2626] rounded-lg text-sm font-medium hover:bg-[#FEF2F2] transition-colors"
+            data-testid="merchant-settings-delete-account-btn"
           >
             {t('deleteAccount')}
           </button>
@@ -156,7 +159,7 @@ export function ParametresClient() {
 
       {/* Delete confirmation modal */}
       {showDeleteModal && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" data-testid="merchant-settings-delete-dialog">
           <div className="bg-white rounded-xl p-6 max-w-sm w-full shadow-xl">
             <h3 className="text-lg font-semibold text-[#1C1917] mb-2">{t('deleteAccountTitle')}</h3>
             <p className="text-sm text-[#78716C] mb-6">{t('deleteAccountBody')}</p>
@@ -166,6 +169,7 @@ export function ParametresClient() {
                 onClick={() => setShowDeleteModal(false)}
                 disabled={isDeleting}
                 className="flex-1 h-10 border border-[#E2E8F0] text-[#1C1917] text-sm font-medium rounded-lg hover:bg-[#F5F5F4] transition-colors disabled:opacity-50"
+                data-testid="merchant-settings-delete-cancel-btn"
               >
                 {t('deleteCancel')}
               </button>
@@ -174,6 +178,7 @@ export function ParametresClient() {
                 onClick={handleDeleteAccount}
                 disabled={isDeleting}
                 className="flex-1 h-10 bg-[#DC2626] text-white text-sm font-medium rounded-lg hover:bg-[#b91c1c] transition-colors disabled:opacity-50"
+                data-testid="merchant-settings-delete-confirm-btn"
               >
                 {isDeleting ? '…' : t('deleteConfirm')}
               </button>

--- a/app/dashboard/produits/ProductForm.tsx
+++ b/app/dashboard/produits/ProductForm.tsx
@@ -201,6 +201,7 @@ export function ProductForm({ product }: Props) {
           className={`relative w-11 h-6 rounded-full transition-colors focus:outline-none ${
             discountActive ? 'bg-[#E8632A]' : 'bg-[#E2E8F0]'
           }`}
+          data-testid="merchant-product-form-discount-toggle-checkbox"
         >
           <span className={`absolute top-0.5 start-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
             discountActive ? 'translate-x-5' : 'translate-x-0'
@@ -219,6 +220,7 @@ export function ProductForm({ product }: Props) {
               value={originalPrice}
               onChange={(e) => setOriginalPrice(e.target.value)}
               className="w-full h-14 px-4 pr-16 border border-[#E2E8F0] rounded-lg text-2xl font-semibold text-[#1C1917] focus:outline-none focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 transition-all"
+              data-testid="merchant-product-form-original-price-input"
             />
             <span className="absolute end-4 top-1/2 -translate-y-1/2 text-base text-[#78716C]">MAD</span>
           </div>
@@ -242,6 +244,7 @@ export function ProductForm({ product }: Props) {
                 ? 'border-[#DC2626] focus:border-[#DC2626] focus:ring-2 focus:ring-[#DC2626]/20'
                 : 'border-[#E2E8F0] focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20'
             }`}
+            data-testid="merchant-product-form-price-input"
           />
           <span className="absolute end-4 top-1/2 -translate-y-1/2 text-base text-[#78716C]">MAD</span>
         </div>
@@ -287,6 +290,7 @@ export function ProductForm({ product }: Props) {
         accept="image/jpeg,image/png,image/webp"
         className="hidden"
         onChange={handleImageChange}
+        data-testid="merchant-product-form-photo-input"
       />
       <div
         onClick={() => !uploading && fileInputRef.current?.click()}
@@ -331,6 +335,7 @@ export function ProductForm({ product }: Props) {
           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 ${
             isVisible ? 'bg-[var(--color-primary)]' : 'bg-[#E2E8F0]'
           }`}
+          data-testid="merchant-product-form-visibility-toggle-checkbox"
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
@@ -352,6 +357,7 @@ export function ProductForm({ product }: Props) {
         type="button"
         onClick={() => setShowDeleteModal(true)}
         className="w-full h-10 bg-white border-[1.5px] border-[#DC2626] text-[#DC2626] rounded-lg text-sm font-medium hover:bg-[#FEF2F2] transition-colors"
+        data-testid="merchant-product-form-delete-btn"
       >
         {t('formDelete')}
       </button>
@@ -368,6 +374,7 @@ export function ProductForm({ product }: Props) {
         <Link
           href="/dashboard/produits"
           className="absolute start-4 p-2 -ms-2 text-[#1C1917]"
+          data-testid="merchant-product-form-back-link"
         >
           <ArrowLeft size={20} />
         </Link>
@@ -399,6 +406,7 @@ export function ProductForm({ product }: Props) {
                   ? 'border-[#DC2626] focus:border-[#DC2626]'
                   : 'border-[#E2E8F0] focus:border-[var(--color-primary)]'
               }`}
+              data-testid="merchant-product-form-name-input"
             />
             {errors.nameFr && (
               <p className="text-xs text-[#DC2626] mt-1">{errors.nameFr}</p>
@@ -415,6 +423,7 @@ export function ProductForm({ product }: Props) {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               className="w-full px-3 py-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] resize-none"
+              data-testid="merchant-product-form-description-textarea"
             />
           </div>
 
@@ -427,6 +436,7 @@ export function ProductForm({ product }: Props) {
               value={catL1}
               onChange={(e) => { setCatL1(e.target.value); setCatL2(''); setCatL3(''); }}
               className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
+              data-testid="merchant-product-form-category-l1-select"
             >
               <option value="">Sélectionner une catégorie</option>
               {Object.keys(PRODUCT_CATEGORIES).map((l1) => (
@@ -439,6 +449,7 @@ export function ProductForm({ product }: Props) {
                 value={catL2}
                 onChange={(e) => { setCatL2(e.target.value); setCatL3(''); }}
                 className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
+                data-testid="merchant-product-form-category-l2-select"
               >
                 <option value="">Sous-catégorie</option>
                 {Object.keys(PRODUCT_CATEGORIES[catL1]).map((l2) => (
@@ -452,6 +463,7 @@ export function ProductForm({ product }: Props) {
                 value={catL3}
                 onChange={(e) => setCatL3(e.target.value)}
                 className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+                data-testid="merchant-product-form-category-l3-select"
               >
                 <option value="">Type (optionnel)</option>
                 {(PRODUCT_CATEGORIES[catL1][catL2]).map((l3) => (
@@ -471,6 +483,7 @@ export function ProductForm({ product }: Props) {
               value={stock}
               onChange={(e) => setStock(Math.max(0, parseInt(e.target.value) || 0))}
               className="w-full h-11 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)]"
+              data-testid="merchant-product-form-stock-input"
             />
             <p className="text-xs text-[#78716C] mt-1">
               Stock = 0 signifie rupture de stock — le produit sera visible mais non commandable.
@@ -488,6 +501,7 @@ export function ProductForm({ product }: Props) {
               className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                 isVisible ? 'bg-[var(--color-primary)]' : 'bg-[#E2E8F0]'
               }`}
+              data-testid="merchant-product-form-visibility-toggle-checkbox"
             >
               <span
                 className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
@@ -513,6 +527,7 @@ export function ProductForm({ product }: Props) {
           disabled={isPending || uploading}
           className="w-full h-12 text-white text-base font-semibold rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
           style={{ backgroundColor: 'var(--color-primary)' }}
+          data-testid="merchant-product-form-publish-btn"
         >
           {isPending
             ? isEdit ? t('formSaving') : t('formPublishing')
@@ -544,6 +559,7 @@ export function ProductForm({ product }: Props) {
             disabled={isPending || uploading}
             className="h-10 px-4 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
             style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="merchant-product-form-publish-btn"
           >
             {isPending
               ? isEdit ? t('formSaving') : t('formPublishing')
@@ -572,6 +588,7 @@ export function ProductForm({ product }: Props) {
                         ? 'border-[#DC2626] focus:border-[#DC2626] focus:ring-[#DC2626]'
                         : 'border-[#E2E8F0] focus:border-[var(--color-primary)] focus:ring-[var(--color-primary)]'
                     }`}
+                    data-testid="merchant-product-form-name-input"
                   />
                   {errors.nameFr && (
                     <p className="text-xs text-[#DC2626] mt-1">{errors.nameFr}</p>
@@ -586,6 +603,7 @@ export function ProductForm({ product }: Props) {
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
                     className="w-full px-3 py-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] resize-none"
+                    data-testid="merchant-product-form-description-textarea"
                   />
                 </div>
 
@@ -598,6 +616,7 @@ export function ProductForm({ product }: Props) {
                     value={catL1}
                     onChange={(e) => { setCatL1(e.target.value); setCatL2(''); setCatL3(''); }}
                     className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
+                    data-testid="merchant-product-form-category-l1-select"
                   >
                     <option value="">Sélectionner une catégorie</option>
                     {Object.keys(PRODUCT_CATEGORIES).map((l1) => (
@@ -610,6 +629,7 @@ export function ProductForm({ product }: Props) {
                       value={catL2}
                       onChange={(e) => { setCatL2(e.target.value); setCatL3(''); }}
                       className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
+                      data-testid="merchant-product-form-category-l2-select"
                     >
                       <option value="">Sous-catégorie</option>
                       {Object.keys(PRODUCT_CATEGORIES[catL1]).map((l2) => (
@@ -623,6 +643,7 @@ export function ProductForm({ product }: Props) {
                       value={catL3}
                       onChange={(e) => setCatL3(e.target.value)}
                       className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+                      data-testid="merchant-product-form-category-l3-select"
                     >
                       <option value="">Type (optionnel)</option>
                       {(PRODUCT_CATEGORIES[catL1][catL2]).map((l3) => (
@@ -640,6 +661,7 @@ export function ProductForm({ product }: Props) {
                       type="button"
                       onClick={() => setStock((s) => Math.max(0, s - 1))}
                       className="w-8 h-8 border border-[#E2E8F0] rounded text-[#78716C] hover:bg-[#F8FAFC] text-lg leading-none"
+                      data-testid="merchant-product-form-stock-decrement-btn"
                     >
                       −
                     </button>
@@ -648,11 +670,13 @@ export function ProductForm({ product }: Props) {
                       value={stock}
                       onChange={(e) => setStock(Math.max(0, parseInt(e.target.value) || 0))}
                       className="w-24 h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm text-center focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                      data-testid="merchant-product-form-stock-input"
                     />
                     <button
                       type="button"
                       onClick={() => setStock((s) => s + 1)}
                       className="w-8 h-8 border border-[#E2E8F0] rounded text-[#78716C] hover:bg-[#F8FAFC] text-lg leading-none"
+                      data-testid="merchant-product-form-stock-increment-btn"
                     >
                       +
                     </button>
@@ -680,7 +704,10 @@ export function ProductForm({ product }: Props) {
   // ─── Delete modal ──────────────────────────────────────────────────────────
 
   const deleteModal = showDeleteModal ? (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+      data-testid="merchant-product-form-delete-dialog"
+    >
       <div className="bg-white rounded-xl p-6 max-w-sm w-full shadow-xl">
         <h3 className="text-lg font-semibold text-[#1C1917] mb-2">{t('formDeleteTitle')}</h3>
         <p className="text-sm text-[#78716C] mb-6">{t('formDeleteBody')}</p>
@@ -690,6 +717,7 @@ export function ProductForm({ product }: Props) {
             onClick={() => setShowDeleteModal(false)}
             disabled={isDeleting}
             className="flex-1 h-10 border border-[#E2E8F0] text-[#1C1917] text-sm font-medium rounded-lg hover:bg-[#F5F5F4] transition-colors disabled:opacity-50"
+            data-testid="merchant-product-form-delete-cancel-btn"
           >
             {t('formDeleteCancel')}
           </button>
@@ -698,6 +726,7 @@ export function ProductForm({ product }: Props) {
             onClick={handleDelete}
             disabled={isDeleting}
             className="flex-1 h-10 bg-[#DC2626] text-white text-sm font-medium rounded-lg hover:bg-[#b91c1c] transition-colors disabled:opacity-50"
+            data-testid="merchant-product-form-delete-confirm-btn"
           >
             {isDeleting ? t('loading') : t('formDeleteConfirm')}
           </button>

--- a/app/dashboard/produits/ProductsClient.tsx
+++ b/app/dashboard/produits/ProductsClient.tsx
@@ -79,6 +79,7 @@ export function ProductsClient({ products: initialProducts }: Props) {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full h-10 ps-10 pe-4 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+            data-testid="merchant-products-search-input"
           />
         </div>
       </div>
@@ -94,6 +95,7 @@ export function ProductsClient({ products: initialProducts }: Props) {
                 ? 'bg-[var(--color-primary)] text-white'
                 : 'bg-white text-[#78716C] border border-[#E2E8F0] hover:bg-[#F8FAFC]'
             }`}
+            data-testid={`merchant-products-filter-${f.id}-btn`}
           >
             {f.label}
           </button>
@@ -106,7 +108,7 @@ export function ProductsClient({ products: initialProducts }: Props) {
           <EmptyState hasProducts={initialProducts.length > 0} />
         ) : (
           filtered.map((product) => (
-            <Link key={product.id} href={`/dashboard/produits/${product.id}`}>
+            <Link key={product.id} href={`/dashboard/produits/${product.id}`} data-testid="merchant-products-row" data-id={product.id}>
               <div className="bg-white rounded-xl p-3 shadow-sm flex gap-3 hover:shadow-md transition-shadow">
                 {product.image_url ? (
                   // eslint-disable-next-line @next/next/no-img-element
@@ -169,6 +171,8 @@ export function ProductsClient({ products: initialProducts }: Props) {
             <div
               key={product.id}
               className="min-h-16 px-4 flex items-center border-b border-[#F3F4F6] hover:bg-[#F8FAFC] transition-colors"
+              data-testid="merchant-products-row"
+              data-id={product.id}
             >
               <div className="w-16">
                 {product.image_url ? (
@@ -219,6 +223,8 @@ export function ProductsClient({ products: initialProducts }: Props) {
                   className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 disabled:opacity-60 ${
                     product.is_visible ? 'bg-[var(--color-primary)]' : 'bg-[#E2E8F0]'
                   }`}
+                  data-testid="merchant-products-visibility-toggle-checkbox"
+                  data-id={product.id}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
@@ -233,6 +239,8 @@ export function ProductsClient({ products: initialProducts }: Props) {
                   href={`/dashboard/produits/${product.id}`}
                   className="p-1 text-[#78716C] hover:text-[var(--color-primary)] transition-colors"
                   title={t('editButton')}
+                  data-testid="merchant-products-edit-link"
+                  data-id={product.id}
                 >
                   <Edit2 className="w-5 h-5" />
                 </Link>
@@ -241,6 +249,8 @@ export function ProductsClient({ products: initialProducts }: Props) {
                   onClick={() => setDeleteModal({ id: product.id, name: product.name_fr })}
                   className="p-1 text-[#78716C] hover:text-[#DC2626] transition-colors"
                   title={t('formDelete')}
+                  data-testid="merchant-products-delete-btn"
+                  data-id={product.id}
                 >
                   <Trash2 className="w-5 h-5" />
                 </button>
@@ -252,7 +262,7 @@ export function ProductsClient({ products: initialProducts }: Props) {
 
       {/* Delete confirmation modal */}
       {deleteModal && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" data-testid="merchant-products-delete-dialog">
           <div className="bg-white rounded-xl p-6 max-w-sm w-full shadow-xl">
             <h3 className="text-lg font-semibold text-[#1C1917] mb-2">{t('formDeleteTitle')}</h3>
             <p className="text-sm text-[#78716C] mb-6">
@@ -264,6 +274,7 @@ export function ProductsClient({ products: initialProducts }: Props) {
                 onClick={() => setDeleteModal(null)}
                 disabled={isPending}
                 className="flex-1 h-10 border border-[#E2E8F0] text-[#1C1917] text-sm font-medium rounded-lg hover:bg-[#F5F5F4] transition-colors disabled:opacity-50"
+                data-testid="merchant-products-delete-cancel-btn"
               >
                 {t('formDeleteCancel')}
               </button>
@@ -272,6 +283,7 @@ export function ProductsClient({ products: initialProducts }: Props) {
                 onClick={() => handleDeleteConfirm(deleteModal.id)}
                 disabled={isPending}
                 className="flex-1 h-10 bg-[#DC2626] text-white text-sm font-medium rounded-lg hover:bg-[#b91c1c] transition-colors disabled:opacity-50"
+                data-testid="merchant-products-delete-confirm-btn"
               >
                 {isPending ? '…' : t('formDeleteConfirm')}
               </button>
@@ -306,6 +318,7 @@ function EmptyState({ hasProducts }: { hasProducts: boolean }) {
         href="/dashboard/produits/nouveau"
         className="inline-flex items-center gap-2 h-9 px-4 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity"
         style={{ backgroundColor: 'var(--color-primary)' }}
+        data-testid="merchant-products-empty-add-btn"
       >
         <Plus className="w-4 h-4" />
         {t('addButton')}

--- a/app/dashboard/produits/page.tsx
+++ b/app/dashboard/produits/page.tsx
@@ -39,6 +39,7 @@ export default async function ProduitsPage() {
             href="/dashboard/produits/nouveau"
             className="h-10 px-4 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity flex items-center gap-2"
             style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="merchant-products-new-product-btn"
           >
             <Plus className="w-5 h-5" />
             Ajouter un produit

--- a/app/dashboard/support/NewTicketSheet.tsx
+++ b/app/dashboard/support/NewTicketSheet.tsx
@@ -53,7 +53,10 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
       <div className="fixed inset-0 bg-black/30 z-40" onClick={onClose} />
 
       {/* Sheet */}
-      <div className="fixed end-0 top-0 h-screen w-full max-w-[480px] bg-white shadow-xl z-50 flex flex-col">
+      <div
+        className="fixed end-0 top-0 h-screen w-full max-w-[480px] bg-white shadow-xl z-50 flex flex-col"
+        data-testid="merchant-support-new-ticket-sheet"
+      >
 
         {/* Header */}
         <div className="h-16 border-b border-[#E2E8F0] px-6 flex items-center justify-between flex-shrink-0">
@@ -88,6 +91,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
                   value={category}
                   onChange={(e) => setCategory(e.target.value as TicketCategory)}
                   className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+                  data-testid="merchant-support-new-ticket-category-select"
                 >
                   {CATEGORIES.map((c) => (
                     <option key={c.value} value={c.value}>{c.label}</option>
@@ -106,6 +110,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
                   onChange={(e) => setSubject(e.target.value)}
                   placeholder={t('sheet_subject_placeholder')}
                   className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                  data-testid="merchant-support-new-ticket-subject-input"
                 />
               </div>
 
@@ -121,6 +126,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
                     onChange={(e) => setOrderId(e.target.value)}
                     placeholder="PLZ-042"
                     className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                    data-testid="merchant-support-new-ticket-order-id-input"
                   />
                 </div>
               )}
@@ -136,6 +142,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
                   placeholder={t('sheet_description_placeholder')}
                   rows={5}
                   className="w-full px-3 py-2.5 border border-[#E2E8F0] rounded-lg text-sm resize-none focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                  data-testid="merchant-support-new-ticket-description-textarea"
                 />
                 <div className="text-xs text-[#A8A29E] text-end mt-1">
                   {description.length}/{MAX_DESC}
@@ -168,6 +175,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
               onClick={handleSubmit}
               className="w-full h-11 text-white text-sm font-semibold rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center justify-center gap-2"
               style={{ backgroundColor: 'var(--color-primary)' }}
+              data-testid="merchant-support-new-ticket-submit-btn"
             >
               {isPending && <Loader2 className="w-4 h-4 animate-spin" />}
               {t('sheet_submit')}

--- a/app/dashboard/support/SupportClient.tsx
+++ b/app/dashboard/support/SupportClient.tsx
@@ -170,11 +170,13 @@ function ChatPanel({
           onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSend()}
           className="flex-1 h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
           disabled={isSending}
+          data-testid="merchant-support-reply-input"
         />
         <button
           onClick={handleSend}
           disabled={!content.trim() || isSending}
           className="w-10 h-10 bg-[var(--color-primary)] text-white rounded-full flex items-center justify-center hover:opacity-90 disabled:opacity-50 transition-colors"
+          data-testid="merchant-support-send-btn"
         >
           {isSending ? (
             <Loader2 className="w-4 h-4 animate-spin" />
@@ -268,6 +270,7 @@ export function SupportClient({ tickets }: Props) {
               <button
                 onClick={() => setShowNewTicket(true)}
                 className="h-9 px-3 bg-[var(--color-primary)] text-white rounded-lg text-sm font-medium hover:opacity-90 transition-colors"
+                data-testid="merchant-support-new-ticket-btn"
               >
                 {t('new_ticket')}
               </button>
@@ -289,6 +292,8 @@ export function SupportClient({ tickets }: Props) {
                         ? 'bg-[#F8FAFC]'
                         : 'hover:bg-[#F8FAFC]'
                     }`}
+                    data-testid="merchant-support-ticket-row"
+                    data-id={ticket.id}
                   >
                     <div className="flex items-start justify-between mb-1">
                       <span className="text-[13px] font-bold text-[#1C1917]">
@@ -353,6 +358,7 @@ export function SupportClient({ tickets }: Props) {
           <button
             onClick={() => setShowNewTicket(true)}
             className="h-9 px-3 bg-[var(--color-primary)] text-white rounded-lg text-sm font-medium flex items-center gap-1.5 hover:opacity-90 transition-colors"
+            data-testid="merchant-support-new-ticket-btn"
           >
             <Plus className="w-4 h-4" />
             {t('new_ticket_mobile')}
@@ -376,6 +382,8 @@ export function SupportClient({ tickets }: Props) {
                 key={ticket.id}
                 href={`/dashboard/support/${ticket.id}`}
                 className="block bg-white rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow"
+                data-testid="merchant-support-ticket-row"
+                data-id={ticket.id}
               >
                 <div className="flex items-start justify-between mb-2">
                   <div className="text-[14px] font-semibold text-[#1C1917]">

--- a/app/dashboard/support/[id]/TicketDetailClient.tsx
+++ b/app/dashboard/support/[id]/TicketDetailClient.tsx
@@ -68,6 +68,7 @@ export function TicketDetailClient({ ticket }: Props) {
           <button
             onClick={() => router.back()}
             className="p-2 -ml-2"
+            data-testid="merchant-support-ticket-back-btn"
           >
             <ArrowLeft size={20} className="text-[#1C1917]" />
           </button>
@@ -183,11 +184,13 @@ export function TicketDetailClient({ ticket }: Props) {
               onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSend()}
               disabled={isSending}
               className="flex-1 h-10 px-3 border border-[#E2E8F0] rounded-lg text-[14px] focus:outline-none focus:border-[var(--color-primary)]"
+              data-testid="merchant-support-reply-input"
             />
             <button
               onClick={handleSend}
               disabled={!content.trim() || isSending}
               className="w-10 h-10 rounded-full bg-[var(--color-primary)] flex items-center justify-center text-white hover:opacity-90 disabled:opacity-50 transition-opacity"
+              data-testid="merchant-support-send-btn"
             >
               {isSending ? (
                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/app/onboarding/StepStoreDetails.tsx
+++ b/app/onboarding/StepStoreDetails.tsx
@@ -70,6 +70,7 @@ export function StepStoreDetails({
           placeholder={t('storeNamePlaceholder')}
           required
           autoFocus
+          data-testid="merchant-onboarding-store-name-input"
         />
       </div>
 
@@ -86,6 +87,7 @@ export function StepStoreDetails({
             placeholder={t('storeSlugPlaceholder')}
             className="ps-[7.5rem]"
             required
+            data-testid="merchant-onboarding-store-slug-input"
           />
         </div>
         <div className="min-h-[1.25rem]">{slugIndicator}</div>
@@ -99,6 +101,7 @@ export function StepStoreDetails({
           onChange={(e) => onDescription(e.target.value)}
           placeholder={t('descriptionPlaceholder')}
           rows={3}
+          data-testid="merchant-onboarding-description-textarea"
         />
       </div>
 
@@ -111,6 +114,7 @@ export function StepStoreDetails({
           onChange={(e) => { const f = e.target.files?.[0]; if (f) onLogoFile(f); }}
           disabled={logoUploading}
           className="cursor-pointer file:me-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-1 file:text-sm file:font-medium file:text-primary-foreground"
+          data-testid="merchant-onboarding-logo-input"
         />
         {logoUploading && (
           <p className="text-xs text-muted-foreground">{t('uploading')}</p>
@@ -120,7 +124,7 @@ export function StepStoreDetails({
       {error && (
         <p className="text-sm text-destructive text-center">{error}</p>
       )}
-      <Button type="submit" className="w-full" disabled={!canContinue || submitting}>
+      <Button type="submit" className="w-full" disabled={!canContinue || submitting} data-testid="merchant-onboarding-finish-btn">
         {submitting ? '…' : t('finish')}
       </Button>
     </form>

--- a/app/store/[slug]/_components/BottomTabBar.tsx
+++ b/app/store/[slug]/_components/BottomTabBar.tsx
@@ -21,10 +21,10 @@ export function BottomTabBar({ slug, onInfoClick, onCartClick }: BottomTabBarPro
   const handleInfo = onInfoClick ?? (() => {});
 
   const tabs = [
-    { name: 'Accueil', icon: Home, href: `/store/${slug}` as const, onClick: undefined as (() => void) | undefined, badge: 0 },
-    { name: 'Produits', icon: Grid3X3, href: `/store/${slug}#produits` as const, onClick: undefined as (() => void) | undefined, badge: 0 },
-    { name: 'Panier', icon: ShoppingBag, href: null, onClick: handleCart, badge: cartCount },
-    { name: 'Infos', icon: Info, href: null, onClick: handleInfo, badge: 0 },
+    { name: 'Accueil', icon: Home, href: `/store/${slug}` as const, onClick: undefined as (() => void) | undefined, badge: 0, testId: 'customer-store-tab-home-link' },
+    { name: 'Produits', icon: Grid3X3, href: `/store/${slug}#produits` as const, onClick: undefined as (() => void) | undefined, badge: 0, testId: 'customer-store-tab-products-link' },
+    { name: 'Panier', icon: ShoppingBag, href: null, onClick: handleCart, badge: cartCount, testId: 'customer-store-tab-cart-btn' },
+    { name: 'Infos', icon: Info, href: null, onClick: handleInfo, badge: 0, testId: 'customer-store-tab-info-btn' },
   ];
 
   return (
@@ -73,6 +73,7 @@ export function BottomTabBar({ slug, onInfoClick, onCartClick }: BottomTabBarPro
               key={tab.name}
               onClick={tab.onClick}
               className="flex flex-col items-center justify-center gap-1 relative flex-1"
+              data-testid={tab.testId}
             >
               {content}
               {label}
@@ -85,6 +86,7 @@ export function BottomTabBar({ slug, onInfoClick, onCartClick }: BottomTabBarPro
             key={tab.name}
             href={tab.href!}
             className="flex flex-col items-center justify-center gap-1 relative flex-1"
+            data-testid={tab.testId}
           >
             {content}
             {label}

--- a/app/store/[slug]/_components/CartDrawer.tsx
+++ b/app/store/[slug]/_components/CartDrawer.tsx
@@ -54,6 +54,7 @@ function CartContent({
         <button
           onClick={onClose}
           className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100"
+          data-testid="customer-cart-close-btn"
         >
           <X className="w-5 h-5 text-[#78716C]" />
         </button>
@@ -78,7 +79,7 @@ function CartContent({
             {items.map((item) => {
               const atMax = item.stock != null && item.quantity >= item.stock;
               return (
-                <div key={item.id} className="flex gap-3">
+                <div key={item.id} className="flex gap-3" data-testid="customer-cart-item-row" data-id={item.id}>
                   {item.image ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
@@ -98,6 +99,7 @@ function CartContent({
                         <button
                           onClick={() => updateQuantity(item.id, item.quantity - 1, item.stock ?? null)}
                           className="w-7 h-7 flex items-center justify-center hover:bg-gray-50"
+                          data-testid="customer-cart-item-qty-decrement-btn"
                         >
                           <Minus className="w-3.5 h-3.5 text-[#78716C]" />
                         </button>
@@ -108,6 +110,7 @@ function CartContent({
                           onClick={() => updateQuantity(item.id, item.quantity + 1, item.stock ?? null)}
                           disabled={atMax}
                           className="w-7 h-7 flex items-center justify-center hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                          data-testid="customer-cart-item-qty-increment-btn"
                         >
                           <Plus className="w-3.5 h-3.5 text-[#78716C]" />
                         </button>
@@ -124,6 +127,7 @@ function CartContent({
                   <button
                     onClick={() => removeItem(item.id)}
                     className="text-[#DC2626] hover:bg-red-50 p-1.5 rounded-lg flex-shrink-0"
+                    data-testid="customer-cart-item-remove-btn"
                   >
                     <Trash2 className="w-4 h-4" />
                   </button>
@@ -172,6 +176,7 @@ function CartContent({
             disabled={items.length === 0}
             className="w-full text-white font-semibold py-3.5 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="customer-cart-checkout-btn"
           >
             Passer la commande — {finalTotal.toFixed(0)} MAD
           </button>
@@ -180,6 +185,7 @@ function CartContent({
             onClick={onClose}
             className="w-full text-sm font-semibold py-1"
             style={{ color: 'var(--color-primary)' }}
+            data-testid="customer-cart-continue-btn"
           >
             Continuer mes achats
           </button>

--- a/app/store/[slug]/_components/DateTimePicker.tsx
+++ b/app/store/[slug]/_components/DateTimePicker.tsx
@@ -91,6 +91,7 @@ export default function DateTimePicker({ value, onChange, workingHours }: DateTi
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="w-full h-12 px-4 bg-[#FAFAF9] border border-[#E2E8F0] rounded-lg text-[15px] flex items-center justify-between hover:border-[var(--color-primary)] transition-colors"
+        data-testid="customer-checkout-datetime-open-btn"
       >
         <div className="flex items-center gap-3">
           <CalendarIcon className="w-5 h-5 text-[#78716C]" />
@@ -165,6 +166,8 @@ export default function DateTimePicker({ value, onChange, workingHours }: DateTi
                               : 'bg-gray-100 text-gray-400 cursor-not-allowed'
                         }`}
                         style={selectedTime === time ? { backgroundColor: 'var(--color-primary)' } : {}}
+                        data-testid="customer-checkout-datetime-slot-btn"
+                        data-slot={time}
                       >
                         {time}
                       </button>
@@ -188,6 +191,7 @@ export default function DateTimePicker({ value, onChange, workingHours }: DateTi
                     onClick={() => setIsOpen(false)}
                     className="px-4 py-2 text-white rounded-lg text-[14px] font-medium hover:opacity-90 transition-opacity"
                     style={{ backgroundColor: 'var(--color-primary)' }}
+                    data-testid="customer-checkout-datetime-confirm-btn"
                   >
                     Confirmer
                   </button>

--- a/app/store/[slug]/_components/FloatingCartBar.tsx
+++ b/app/store/[slug]/_components/FloatingCartBar.tsx
@@ -31,6 +31,7 @@ export function FloatingCartBar({ onClick, onOpenCart }: FloatingCartBarProps) {
           <button
             onClick={handleClick}
             className="w-full bg-white border border-[#E2E8F0] rounded-xl px-4 py-3 flex items-center justify-between shadow-lg"
+            data-testid="customer-floating-cart-btn"
           >
             <div className="flex items-center gap-3 text-[#1C1917]">
               <span className="text-sm">

--- a/app/store/[slug]/_components/MapLocationPicker.tsx
+++ b/app/store/[slug]/_components/MapLocationPicker.tsx
@@ -153,6 +153,7 @@ export function MapLocationPicker({ onLocationSelect }: Props) {
             }}
             placeholder="Ex : 12 rue Mohamed V, Casablanca"
             className="w-full px-3 py-2.5 border border-[#E2E8F0] rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] text-[15px]"
+            data-testid="customer-checkout-address-input"
           />
         </div>
         {textAddress.trim() && (
@@ -172,6 +173,7 @@ export function MapLocationPicker({ onLocationSelect }: Props) {
           disabled={locating}
           className="absolute top-3 right-3 z-10 bg-white rounded-lg shadow-md p-2 hover:bg-stone-50 disabled:opacity-60"
           title="Ma position"
+          data-testid="customer-checkout-locate-btn"
         >
           {locating ? (
             <div className="w-5 h-5 border-2 border-stone-400 border-t-transparent rounded-full animate-spin" />

--- a/app/store/[slug]/_components/OrderStatusClient.tsx
+++ b/app/store/[slug]/_components/OrderStatusClient.tsx
@@ -147,6 +147,7 @@ export function OrderStatusClient({ order, merchantPhone }: Props) {
         <button
           onClick={() => router.back()}
           className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100"
+          data-testid="customer-order-status-back-btn"
         >
           <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
         </button>
@@ -157,6 +158,7 @@ export function OrderStatusClient({ order, merchantPhone }: Props) {
           onClick={handleRefresh}
           disabled={refreshing}
           className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 disabled:opacity-50"
+          data-testid="customer-order-status-refresh-btn"
         >
           <RefreshCw className={`w-5 h-5 text-[#78716C] ${refreshing ? 'animate-spin' : ''}`} />
         </button>
@@ -400,6 +402,7 @@ export function OrderStatusClient({ order, merchantPhone }: Props) {
               rel="noopener noreferrer"
               className="w-full py-3.5 border-2 rounded-lg font-semibold flex items-center justify-center gap-2 hover:opacity-90 transition-opacity"
               style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+              data-testid="customer-order-status-whatsapp-link"
             >
               <Phone className="w-4 h-4" />
               Contacter la boutique
@@ -420,6 +423,7 @@ export function OrderStatusClient({ order, merchantPhone }: Props) {
           <a
             href="mailto:support@plaza.ma"
             className="text-[13px] text-[#78716C] underline mt-2 block"
+            data-testid="customer-order-status-support-link"
           >
             Besoin d&apos;aide ? Contacter Plaza
           </a>

--- a/app/store/[slug]/_components/ProductCard.tsx
+++ b/app/store/[slug]/_components/ProductCard.tsx
@@ -70,7 +70,7 @@ export function ProductCard({ product, slug }: ProductCardProps) {
   }
 
   return (
-    <Link href={`/store/${slug}/produit/${product.id}`} className="flex flex-col h-full">
+    <Link href={`/store/${slug}/produit/${product.id}`} className="flex flex-col h-full" data-testid="customer-store-product-card" data-id={product.id}>
       <motion.div
         whileHover={!outOfStock ? { y: -4 } : {}}
         className={`w-full flex flex-col h-full bg-white rounded-xl overflow-hidden transition-all shadow-[0_2px_8px_rgba(0,0,0,0.08)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.12)] ${
@@ -151,6 +151,7 @@ export function ProductCard({ product, slug }: ProductCardProps) {
                   ? { backgroundColor: 'var(--color-primary)' }
                   : {}
               }
+              data-testid="customer-product-card-add-to-cart-btn"
             >
               {outOfStock ? (
                 'Rupture de stock'
@@ -172,6 +173,7 @@ export function ProductCard({ product, slug }: ProductCardProps) {
                 outOfStock ? 'bg-gray-200 text-gray-400 cursor-not-allowed' : ''
               }`}
               style={!outOfStock && !buyingNow ? { backgroundColor: 'var(--color-primary)' } : {}}
+              data-testid="customer-product-card-buy-now-btn"
             >
               {buyingNow ? (
                 <span className="flex items-center justify-center gap-1.5">

--- a/app/store/[slug]/_components/ProductDetailClient.tsx
+++ b/app/store/[slug]/_components/ProductDetailClient.tsx
@@ -136,6 +136,7 @@ export function ProductDetailClient({
         <button
           onClick={() => router.back()}
           className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100"
+          data-testid="customer-product-detail-back-btn"
         >
           <ArrowLeft className="w-5 h-5 text-[#1C1917]" />
         </button>
@@ -145,6 +146,7 @@ export function ProductDetailClient({
         <button
           onClick={() => setCartOpen(true)}
           className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 relative"
+          data-testid="customer-product-detail-cart-btn"
         >
           <ShoppingCart className="w-5 h-5 text-[#78716C]" />
           {cartCount > 0 && (
@@ -254,6 +256,7 @@ export function ProductDetailClient({
                 <button
                   onClick={() => setQuantity(Math.max(1, quantity - 1))}
                   className="w-12 h-12 flex items-center justify-center hover:bg-gray-50"
+                  data-testid="customer-product-detail-qty-decrement-btn"
                 >
                   <Minus className="w-5 h-5 text-[#78716C]" />
                 </button>
@@ -267,6 +270,7 @@ export function ProductDetailClient({
                   }}
                   disabled={atStockLimit}
                   className="w-12 h-12 flex items-center justify-center hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                  data-testid="customer-product-detail-qty-increment-btn"
                 >
                   <Plus className="w-5 h-5 text-[#78716C]" />
                 </button>
@@ -292,6 +296,7 @@ export function ProductDetailClient({
                   ? { borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }
                   : {}
               }
+              data-testid="customer-product-detail-add-to-cart-btn"
             >
               Ajouter au panier
             </button>
@@ -302,6 +307,7 @@ export function ProductDetailClient({
                 outOfStock ? 'bg-gray-300 cursor-not-allowed' : ''
               }`}
               style={!outOfStock && !buyingNow ? { backgroundColor: 'var(--color-primary)' } : {}}
+              data-testid="customer-product-detail-buy-now-btn"
             >
               {buyingNow ? (
                 <span className="flex items-center justify-center gap-1.5">
@@ -449,6 +455,7 @@ export function ProductDetailClient({
                 ? { borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }
                 : {}
             }
+            data-testid="customer-product-detail-add-to-cart-btn"
           >
             Ajouter au panier
           </button>
@@ -459,6 +466,7 @@ export function ProductDetailClient({
               outOfStock ? 'bg-gray-300 cursor-not-allowed' : buyingNow ? '' : 'active:scale-[0.97]'
             }`}
             style={!outOfStock && !buyingNow ? { backgroundColor: 'var(--color-primary)' } : {}}
+            data-testid="customer-product-detail-buy-now-btn"
           >
             {buyingNow ? (
               <span className="flex items-center justify-center gap-1.5">

--- a/app/store/[slug]/_components/StoreHomeClient.tsx
+++ b/app/store/[slug]/_components/StoreHomeClient.tsx
@@ -103,6 +103,8 @@ export function StoreHomeClient({
                     ? { backgroundColor: 'var(--color-primary)' }
                     : {}
                 }
+                data-testid="customer-store-category-btn"
+                data-category={category}
               >
                 {category}
               </button>

--- a/app/store/[slug]/_components/StoreInfoSheet.tsx
+++ b/app/store/[slug]/_components/StoreInfoSheet.tsx
@@ -165,6 +165,7 @@ export function StoreInfoSheet({
                 href={`tel:${merchant.phone}`}
                 className="w-full h-12 border-2 rounded-lg font-medium flex items-center justify-center gap-2 hover:opacity-90 transition-opacity"
                 style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+                data-testid="customer-store-info-call-link"
               >
                 <Phone className="w-4 h-4" />
                 Appeler la boutique

--- a/app/store/[slug]/_components/TopNavBar.tsx
+++ b/app/store/[slug]/_components/TopNavBar.tsx
@@ -30,9 +30,9 @@ export function TopNavBar({
   const initials = merchant.store_name.slice(0, 2).toUpperCase();
 
   const navLinks = [
-    { name: 'Accueil', path: `/store/${slug}`, onClick: undefined as (() => void) | undefined },
-    { name: 'Suivre ma commande', path: '/track', onClick: undefined as (() => void) | undefined },
-    { name: 'Infos', path: '#', onClick: onInfoClick },
+    { name: 'Accueil', path: `/store/${slug}`, onClick: undefined as (() => void) | undefined, testId: 'customer-store-nav-home-link' },
+    { name: 'Suivre ma commande', path: '/track', onClick: undefined as (() => void) | undefined, testId: 'customer-store-nav-track-link' },
+    { name: 'Infos', path: '#', onClick: onInfoClick, testId: 'customer-store-nav-info-btn' },
   ];
 
   return (
@@ -66,6 +66,7 @@ export function TopNavBar({
                           : 'text-[#78716C] hover:text-[#1C1917]'
                       }`}
                       style={isActive ? { color: 'var(--color-primary)' } : {}}
+                      data-testid={link.testId}
                     >
                       {link.name}
                       {isActive && (
@@ -87,6 +88,7 @@ export function TopNavBar({
                         : 'text-[#78716C] hover:text-[#1C1917]'
                     }`}
                     style={isActive ? { color: 'var(--color-primary)' } : {}}
+                    data-testid={link.testId}
                   >
                     {link.name}
                     {isActive && (
@@ -111,6 +113,7 @@ export function TopNavBar({
                 value={searchQuery}
                 onChange={(e) => onSearchChange(e.target.value)}
                 className="w-full h-9 bg-[#F5F5F4] rounded-full pl-10 pr-10 text-sm placeholder:text-[#A8A29E] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20"
+                data-testid="customer-store-search-input"
               />
               {searchQuery && (
                 <button
@@ -128,6 +131,7 @@ export function TopNavBar({
             <button
               onClick={onCartClick}
               className="relative hover:opacity-70 transition-opacity"
+              data-testid="customer-store-cart-btn"
             >
               <ShoppingBag className="w-[22px] h-[22px] text-[#1C1917]" />
               {cartCount > 0 && (

--- a/app/store/[slug]/commande/page.tsx
+++ b/app/store/[slug]/commande/page.tsx
@@ -281,6 +281,7 @@ export default function CheckoutPage() {
         <button
           onClick={() => router.back()}
           className="w-10 h-10 flex items-center justify-center -ml-2"
+          data-testid="customer-checkout-back-btn"
         >
           <ArrowLeft className="w-5 h-5" />
         </button>
@@ -317,6 +318,7 @@ export default function CheckoutPage() {
               placeholder="Entrez votre nom complet"
               className="w-full px-3 py-2.5 border border-[#E2E8F0] rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] text-[15px]"
               required
+              data-testid="customer-checkout-name-input"
             />
           </div>
           <div>
@@ -335,6 +337,7 @@ export default function CheckoutPage() {
                   : 'border-[#E2E8F0]'
               }`}
               required
+              data-testid="customer-checkout-phone-input"
             />
             {phoneBlurred && phone.trim() && !isPhoneValid(phone) && (
               <p className="text-xs text-[#DC2626] mt-1">
@@ -416,6 +419,7 @@ export default function CheckoutPage() {
               value={addressNotes}
               onChange={(e) => setAddressNotes(e.target.value)}
               className="w-full px-3 py-2.5 border border-[#E2E8F0] rounded-lg text-[15px] placeholder:text-[#A8A29E] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] resize-none"
+              data-testid="customer-checkout-address-notes-textarea"
             />
           </div>
         </div>
@@ -450,6 +454,7 @@ export default function CheckoutPage() {
               onChange={() => setPaymentMethod('cash')}
               className="w-4 h-4"
               style={{ accentColor: 'var(--color-primary)' }}
+              data-testid="customer-checkout-payment-cash-input"
             />
             <Banknote className="w-5 h-5 text-[#78716C]" />
             <span className="font-medium text-[#1C1917]">Paiement à la livraison</span>
@@ -472,6 +477,7 @@ export default function CheckoutPage() {
                 onChange={() => setPaymentMethod('card-delivery')}
                 className="w-4 h-4"
                 style={{ accentColor: 'var(--color-primary)' }}
+                data-testid="customer-checkout-payment-card-delivery-input"
               />
               <CreditCard className="w-5 h-5 text-[#78716C]" />
               <span className="font-medium text-[#1C1917]">Carte à la livraison</span>
@@ -495,6 +501,7 @@ export default function CheckoutPage() {
                 onChange={() => setPaymentMethod('online')}
                 className="w-4 h-4"
                 style={{ accentColor: 'var(--color-primary)' }}
+                data-testid="customer-checkout-payment-online-input"
               />
               <Smartphone className="w-5 h-5 text-[#78716C]" />
               <span className="font-medium text-[#1C1917]">Paiement en ligne (via CMI)</span>
@@ -571,6 +578,7 @@ export default function CheckoutPage() {
             whileTap={{ scale: 0.98 }}
             className="w-full h-14 text-white rounded-lg font-medium text-[16px] transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
             style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="customer-checkout-submit-btn"
           >
             {loading ? (
               <span className="flex items-center gap-2">

--- a/app/store/[slug]/confirmation/page.tsx
+++ b/app/store/[slug]/confirmation/page.tsx
@@ -276,6 +276,7 @@ export default function ConfirmationPage() {
             <button
               onClick={handleCopy}
               className="p-2 rounded-lg transition-colors hover:opacity-80"
+              data-testid="customer-confirmation-copy-order-btn"
             >
               {copied ? (
                 <CheckCheck className="w-5 h-5 text-[#16A34A]" />
@@ -461,6 +462,7 @@ export default function ConfirmationPage() {
               href={`/store/${slug}/commande/${order.orderId}`}
               className="w-full h-12 rounded-xl text-white font-semibold text-sm flex items-center justify-center transition-colors"
               style={{ backgroundColor: 'var(--color-primary)' }}
+              data-testid="customer-confirmation-track-link"
             >
               Suivre ma commande
             </Link>
@@ -469,6 +471,7 @@ export default function ConfirmationPage() {
               href={`/track?order=${orderNumber}`}
               className="w-full h-12 rounded-xl text-white font-semibold text-sm flex items-center justify-center transition-colors"
               style={{ backgroundColor: 'var(--color-primary)' }}
+              data-testid="customer-confirmation-track-link"
             >
               Suivre ma commande
             </Link>
@@ -476,6 +479,7 @@ export default function ConfirmationPage() {
           <Link
             href={`/store/${slug}`}
             className="w-full h-12 rounded-xl border-2 border-[#E2E8F0] text-[#78716C] font-semibold text-sm flex items-center justify-center hover:bg-gray-50 transition-colors"
+            data-testid="customer-confirmation-return-link"
           >
             Retour à la boutique
           </Link>

--- a/app/store/[slug]/verification/page.tsx
+++ b/app/store/[slug]/verification/page.tsx
@@ -312,6 +312,7 @@ export default function VerificationPage() {
         <button
           onClick={() => router.back()}
           className="w-10 h-10 flex items-center justify-center -ml-2"
+          data-testid="customer-verification-back-btn"
         >
           <ArrowLeft className="w-5 h-5" />
         </button>
@@ -371,6 +372,8 @@ export default function VerificationPage() {
                         : 'border-[#E2E8F0] bg-white'
                   }`}
                   style={!error && digit ? { borderColor: 'var(--color-primary)', backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, transparent)' } : {}}
+                  data-testid="customer-verification-otp-input"
+                  data-index={index}
                 />
               ))}
             </div>
@@ -402,6 +405,7 @@ export default function VerificationPage() {
             disabled={loading || otp.join('').length !== 6}
             className="w-full h-14 text-white rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="customer-verification-verify-btn"
           >
             {loading ? (
               <>
@@ -421,6 +425,7 @@ export default function VerificationPage() {
               onClick={handleResend}
               className="text-[14px] font-medium hover:underline"
               style={{ color: 'var(--color-primary)' }}
+              data-testid="customer-verification-resend-btn"
             >
               Renvoyer le code
             </button>

--- a/app/track/page.tsx
+++ b/app/track/page.tsx
@@ -96,6 +96,7 @@ export default function TrackOrderPage() {
                       ? 'border-[#DC2626] bg-red-50'
                       : 'border-[#E2E8F0] bg-white focus:border-[var(--color-primary)]'
                   }`}
+                  data-testid="customer-track-order-number-input"
                 />
                 <Search className="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[#A8A29E]" />
               </div>
@@ -115,6 +116,7 @@ export default function TrackOrderPage() {
               disabled={loading}
               className="w-full h-14 text-white rounded-lg font-medium text-[16px] hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center justify-center gap-2"
               style={{ backgroundColor: 'var(--color-primary)' }}
+              data-testid="customer-track-submit-btn"
             >
               {loading ? (
                 <>
@@ -140,6 +142,7 @@ export default function TrackOrderPage() {
               onClick={() => router.back()}
               className="text-[14px] hover:underline"
               style={{ color: 'var(--color-primary)' }}
+              data-testid="customer-track-back-btn"
             >
               ← Retour
             </button>

--- a/components/onboarding/OnboardingChecklist.tsx
+++ b/components/onboarding/OnboardingChecklist.tsx
@@ -240,6 +240,7 @@ export function OnboardingChecklist({ data }: Props) {
             <button
               onClick={handleShare}
               className="h-9 px-4 bg-[#2563EB] text-white rounded-lg text-sm font-medium hover:bg-[#1d4ed8] transition-colors"
+              data-testid="merchant-onboarding-share-link-btn"
             >
               {t('published_share_cta')}
             </button>
@@ -340,6 +341,7 @@ export function OnboardingChecklist({ data }: Props) {
                         <button
                           onClick={handleShare}
                           className="h-8 px-3 rounded-lg text-xs font-medium border border-[#BFDBFE] bg-[#EFF6FF] text-[#2563EB] hover:bg-[#DBEAFE] transition-colors"
+                          data-testid={`merchant-checklist-step-${step.id}-btn`}
                         >
                           {step.cta}
                         </button>
@@ -347,6 +349,7 @@ export function OnboardingChecklist({ data }: Props) {
                         <Link
                           href={step.href}
                           className="inline-flex h-8 px-3 items-center rounded-lg text-xs font-medium border border-[#BFDBFE] bg-[#EFF6FF] text-[#2563EB] hover:bg-[#DBEAFE] transition-colors"
+                          data-testid={`merchant-checklist-step-${step.id}-link`}
                         >
                           {step.cta}
                         </Link>
@@ -370,6 +373,7 @@ export function OnboardingChecklist({ data }: Props) {
                 ? 'bg-[#2563EB] text-white hover:bg-[#1d4ed8]'
                 : 'bg-[#F0F0EF] text-[#A8A29E] cursor-not-allowed'
             }`}
+            data-testid="merchant-onboarding-publish-btn"
           >
             {isPending ? t('publishing') : t('publish_cta')}
           </button>


### PR DESCRIPTION
## Summary

Adds `data-testid` attributes to every merchant-facing and customer-facing interactive element for Saad's e2e test suite. This is the merchant+customer half of PLZ-077; the driver+admin half shipped in #69.

**Stats**
- 40 files changed, 253 insertions, 27 deletions
- **198 `data-testid` additions** (181 string literals + 17 template-literal testids)
- **159 unique testid values**
- **Zero functional changes** — pure attribute additions

**Convention (all testids conform)**
```
^(merchant|customer)-[a-z0-9-]+-(btn|input|select|checkbox|textarea|link|dialog|sheet|row|card|field|badge|toast)$
```
- Dynamic rows: stable testid + `data-id={item.id}` (DB ids never embedded in testid strings)
- Custom components (Toggle) accept `testId?: string` prop and forward via `data-testid`

## Per-page breakdown

**Merchant (130 testids)**
- `auth/` — signup, login, otp, pin-login, pin-setup, forgot-pin, recovery
- `dashboard/` — home/checklist, CopyButton
- `dashboard/boutique/` — BoutiqueForm (including color picker)
- `dashboard/produits/` — ProductsClient, ProductForm, page filters
- `dashboard/commandes/` — OrdersClient, OrderDetailSheet, [id]/OrderDetailClient, ReportIssueSheet
- `dashboard/finances/` — FinancesClient (period filters)
- `dashboard/support/` — SupportClient, NewTicketSheet, [id]/TicketDetailClient
- `dashboard/compte/` — CompteClient
- `dashboard/parametres/` — ParametresClient (notification toggles + delete flow)
- `onboarding/` — StepStoreDetails + components/onboarding/OnboardingChecklist

**Customer (51 testids)**
- `store/[slug]/` — TopNavBar, BottomTabBar, CartDrawer, FloatingCartBar, StoreInfoSheet, StoreHomeClient, ProductCard, ProductDetailClient, OrderStatusClient, DateTimePicker, MapLocationPicker
- `store/[slug]/commande/` — checkout form + payment methods
- `store/[slug]/verification/` — OTP verification
- `store/[slug]/confirmation/` — copy order, track, return links
- `track/` — order tracking page

## Verification

- `npm run lint` — **0 errors** (pre-existing `<img>` warnings only, unchanged by this PR)
- `npx tsc --noEmit` — **0 errors** (clean)

## Test plan

- [ ] Saad wires up e2e test suite using these testids
- [ ] Spot-check dynamic rows render with `data-id` attributes populated
- [ ] Confirm ParametresClient Toggle testids work on all 4 notification rows
- [ ] No visual/functional regressions on dashboard, store, checkout, verification flows

cc @anas-plz

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
