### PR TITLE
feat(PLZ-079, PLZ-080): dedupe form JSX + fix desktop save indicator + products.uploading

### DIFF
--- a/app/dashboard/boutique/BoutiqueForm.tsx
+++ b/app/dashboard/boutique/BoutiqueForm.tsx
@@ -727,80 +727,34 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
     </div>
   );
 
-  // ─── Mobile layout ─────────────────────────────────────────────────────────
-
-  const mobileLayout = (
-    <div className="md:hidden bg-[#FAFAF9] min-h-screen pb-24">
-      <div className="bg-white h-14 px-4 flex items-center justify-between border-b border-[#E2E8F0]">
-        <h1 className="text-base font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
-        <a
-          href={`/store/${storeSlug}`}
-          target="_blank"
-          rel="noreferrer"
-          className="text-sm"
-          style={{ color: 'var(--color-primary)' }}
-        >
-          {t('viewStore')}
-        </a>
-      </div>
-
-      {/* Link preview */}
-      <div className="bg-white mx-4 mt-4 rounded-xl shadow-sm p-4">
-        <p className="text-xs text-[#78716C] uppercase mb-1">{t('storeLink')}</p>
-        <div className="flex items-center gap-2">
-          <span className="text-sm flex-1 truncate" style={{ color: 'var(--color-primary)' }}>
-            plaza.ma/store/{storeSlug}
-          </span>
-          <button type="button" onClick={copyLink} className="p-1.5">
-            {copied ? (
-              <Check className="w-4 h-4 text-[#16A34A]" />
-            ) : (
-              <Copy className="w-4 h-4 text-[#78716C]" />
-            )}
-          </button>
-        </div>
-      </div>
-
-      <div className="p-4 space-y-3">
-        {identitySection}
-        {appearanceSection}
-        {deliverySection}
-        <DeliveryZones initialZones={deliveryZones} />
-        {statusSection}
-        {workingHoursSection}
-        {paymentModesSection}
-      </div>
-
-      <div className="fixed bottom-0 start-0 end-0 bg-white border-t border-[#E2E8F0] p-4 md:hidden">
-        {savedIndicator && (
-          <p className="text-center text-sm font-medium text-[#16A34A] mb-2">Enregistré ✓</p>
-        )}
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={isPending || uploadingLogo || uploadingBanner}
-          className="w-full h-12 text-white text-base font-semibold rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
-          style={{ backgroundColor: 'var(--color-primary)' }}
-          data-testid="merchant-boutique-save-btn"
-        >
-          {isPending ? t('saving') : t('save')}
-        </button>
-      </div>
-    </div>
-  );
-
-  // ─── Desktop layout ────────────────────────────────────────────────────────
-
-  const desktopLayout = (
-    <div className="hidden md:block bg-[#FAFAF9] min-h-screen">
-      <div className="max-w-[1280px] mx-auto p-8">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
+  // ─── Unified layout (mobile + desktop via responsive classes) ─────────────
+  // PLZ-079: removed the previous `md:hidden` / `hidden md:block` fork so each
+  // testid (save button, inputs, selects) resolves to exactly one DOM element
+  // at any breakpoint. The "Enregistré ✓" indicator now lives in the single
+  // save-button row, fixing SAAD-003 (indicator invisible on desktop).
+  return (
+    <>
+      <div className="bg-[#FAFAF9] min-h-screen pb-24 md:pb-0">
+        {/* Top bar — mobile: compact h-14 with text link.
+                      desktop: bordered ExternalLink button. */}
+        <div className="bg-white md:bg-transparent h-14 md:h-auto px-4 md:px-0 flex items-center justify-between border-b md:border-b-0 border-[#E2E8F0] md:pt-8 md:mb-6 md:max-w-[1280px] md:mx-auto md:w-full md:px-8">
+          <h1 className="text-base md:text-2xl font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
+          {/* Mobile variant: plain text link. */}
           <a
             href={`/store/${storeSlug}`}
             target="_blank"
             rel="noreferrer"
-            className="h-10 px-4 rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
+            className="text-sm md:hidden"
+            style={{ color: 'var(--color-primary)' }}
+          >
+            {t('viewStore')}
+          </a>
+          {/* Desktop variant: bordered button with ExternalLink icon. */}
+          <a
+            href={`/store/${storeSlug}`}
+            target="_blank"
+            rel="noreferrer"
+            className="hidden md:flex h-10 px-4 rounded-lg text-sm font-medium transition-colors items-center gap-2"
             style={{ border: '1px solid var(--color-primary)', color: 'var(--color-primary)', backgroundColor: 'transparent' }}
             onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--color-primary) 8%, white)')}
             onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
@@ -810,8 +764,26 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           </a>
         </div>
 
-        <div className="flex gap-6">
-          <div className="flex-1 max-w-[640px] space-y-3">
+        {/* Mobile-only link preview card (desktop has it inside the preview panel). */}
+        <div className="md:hidden bg-white mx-4 mt-4 rounded-xl shadow-sm p-4">
+          <p className="text-xs text-[#78716C] uppercase mb-1">{t('storeLink')}</p>
+          <div className="flex items-center gap-2">
+            <span className="text-sm flex-1 truncate" style={{ color: 'var(--color-primary)' }}>
+              plaza.ma/store/{storeSlug}
+            </span>
+            <button type="button" onClick={copyLink} className="p-1.5">
+              {copied ? (
+                <Check className="w-4 h-4 text-[#16A34A]" />
+              ) : (
+                <Copy className="w-4 h-4 text-[#78716C]" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Main content: single-column on mobile, 2-column on desktop with preview aside. */}
+        <div className="max-w-[1280px] mx-auto md:px-8 md:flex md:gap-6">
+          <div className="flex-1 md:max-w-[640px] p-4 md:p-0 space-y-3">
             {identitySection}
             {appearanceSection}
             {deliverySection}
@@ -820,19 +792,24 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             {workingHoursSection}
             {paymentModesSection}
 
-            <div className="pt-2 flex items-center gap-4">
+            {/* Save row — single element, positioned fixed bottom on mobile,
+                static inline on desktop. `flex-col-reverse` on mobile puts the
+                indicator ABOVE the button (DOM order is button → indicator). */}
+            <div className="fixed md:static bottom-0 start-0 end-0 z-10 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:pt-2 flex flex-col-reverse md:flex-row md:items-center md:gap-4">
               <button
                 type="button"
                 onClick={handleSave}
                 disabled={isPending || uploadingLogo || uploadingBanner}
-                className="w-[200px] h-12 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+                className="w-full md:w-[200px] h-12 text-white text-base md:text-sm font-semibold md:font-medium rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
                 style={{ backgroundColor: 'var(--color-primary)' }}
                 data-testid="merchant-boutique-save-btn"
               >
                 {isPending ? t('saving') : t('save')}
               </button>
               {savedIndicator && (
-                <span className="text-sm font-medium text-[#16A34A]">Enregistré ✓</span>
+                <span className="text-center md:text-start text-sm font-medium text-[#16A34A] mb-2 md:mb-0">
+                  Enregistré ✓
+                </span>
               )}
             </div>
           </div>
@@ -840,13 +817,6 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           {previewPanel}
         </div>
       </div>
-    </div>
-  );
-
-  return (
-    <>
-      {mobileLayout}
-      {desktopLayout}
 
       {/* ── Checklist gate modal ─────────────────────────────────────────────── */}
       {showIncompleteModal && (

--- a/app/dashboard/produits/ProductForm.tsx
+++ b/app/dashboard/produits/ProductForm.tsx
@@ -365,343 +365,162 @@ export function ProductForm({ product }: Props) {
     </div>
   ) : null;
 
-  // ─── Mobile layout ─────────────────────────────────────────────────────────
+  // ─── Info form (name / description / categories / stock) ────────────────
+  // Rendered once. Inputs share responsive classes (mobile h-11 / desktop h-10).
+  // Stock has desktop-only ± stepper buttons — those testids only exist once.
+  const infoForm = (
+    <div className="bg-white rounded-xl shadow-sm p-4 md:p-6 space-y-4">
+      <h2 className="hidden md:block text-base font-semibold text-[#1C1917] mb-4">
+        {t('formInfoTitle')}
+      </h2>
 
-  const mobileLayout = (
-    <div className="md:hidden bg-[#FAFAF9] min-h-screen pb-24">
-      {/* Top bar */}
-      <div className="bg-white h-14 px-4 flex items-center justify-center relative border-b border-[#E2E8F0]">
-        <Link
-          href="/dashboard/produits"
-          className="absolute start-4 p-2 -ms-2 text-[#1C1917]"
-          data-testid="merchant-product-form-back-link"
+      {/* Name FR */}
+      <div>
+        <label className="block text-sm md:text-[13px] font-medium md:font-normal text-[#1C1917] md:text-[#78716C] mb-2 md:mb-1.5">
+          {t('formNameFr')}
+        </label>
+        <input
+          type="text"
+          value={nameFr}
+          onChange={(e) => {
+            setNameFr(e.target.value);
+            setErrors((prev) => ({ ...prev, nameFr: '' }));
+          }}
+          className={`w-full h-11 md:h-10 px-3 border rounded-lg text-sm focus:outline-none md:focus:ring-1 ${
+            errors.nameFr
+              ? 'border-[#DC2626] focus:border-[#DC2626] md:focus:ring-[#DC2626]'
+              : 'border-[#E2E8F0] focus:border-[var(--color-primary)] md:focus:ring-[var(--color-primary)]'
+          }`}
+          data-testid="merchant-product-form-name-input"
+        />
+        {errors.nameFr && (
+          <p className="text-xs text-[#DC2626] mt-1">{errors.nameFr}</p>
+        )}
+      </div>
+
+      {/* Description */}
+      <div>
+        <label className="block text-sm md:text-[13px] font-medium md:font-normal text-[#1C1917] md:text-[#78716C] mb-2 md:mb-1.5">
+          {t('formDescription')}
+        </label>
+        <textarea
+          rows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full px-3 py-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] md:focus:ring-1 md:focus:ring-[var(--color-primary)] resize-none md:min-h-[104px]"
+          data-testid="merchant-product-form-description-textarea"
+        />
+      </div>
+
+      {/* Product categories — 3 levels */}
+      <div>
+        <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">
+          Catégorie
+        </label>
+        <select
+          value={catL1}
+          onChange={(e) => { setCatL1(e.target.value); setCatL2(''); setCatL3(''); }}
+          className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
+          data-testid="merchant-product-form-category-l1-select"
         >
-          <ArrowLeft size={20} />
-        </Link>
-        <h1 className="text-base font-semibold text-[#1C1917]">
-          {isEdit ? t('editProduct') : t('newProduct')}
-        </h1>
+          <option value="">Sélectionner une catégorie</option>
+          {Object.keys(PRODUCT_CATEGORIES).map((l1) => (
+            <option key={l1} value={l1}>{l1}</option>
+          ))}
+        </select>
+
+        {catL1 && Object.keys(PRODUCT_CATEGORIES[catL1] ?? {}).length > 0 && (
+          <select
+            value={catL2}
+            onChange={(e) => { setCatL2(e.target.value); setCatL3(''); }}
+            className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
+            data-testid="merchant-product-form-category-l2-select"
+          >
+            <option value="">Sous-catégorie</option>
+            {Object.keys(PRODUCT_CATEGORIES[catL1]).map((l2) => (
+              <option key={l2} value={l2}>{l2}</option>
+            ))}
+          </select>
+        )}
+
+        {catL1 && catL2 && (PRODUCT_CATEGORIES[catL1]?.[catL2] ?? []).length > 0 && (
+          <select
+            value={catL3}
+            onChange={(e) => setCatL3(e.target.value)}
+            className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+            data-testid="merchant-product-form-category-l3-select"
+          >
+            <option value="">Type (optionnel)</option>
+            {(PRODUCT_CATEGORIES[catL1][catL2]).map((l3) => (
+              <option key={l3} value={l3}>{l3}</option>
+            ))}
+          </select>
+        )}
       </div>
 
-      <div className="p-4 space-y-3">
-        {/* Photo */}
-        {photoCard}
-
-        {/* Info form */}
-        <div className="bg-white rounded-xl shadow-sm p-4 space-y-4">
-          {/* Name FR */}
-          <div>
-            <label className="block text-sm font-medium text-[#1C1917] mb-2">
-              {t('formNameFr')}
-            </label>
-            <input
-              type="text"
-              value={nameFr}
-              onChange={(e) => {
-                setNameFr(e.target.value);
-                setErrors((prev) => ({ ...prev, nameFr: '' }));
-              }}
-              className={`w-full h-11 px-3 border rounded-lg text-sm focus:outline-none ${
-                errors.nameFr
-                  ? 'border-[#DC2626] focus:border-[#DC2626]'
-                  : 'border-[#E2E8F0] focus:border-[var(--color-primary)]'
-              }`}
-              data-testid="merchant-product-form-name-input"
-            />
-            {errors.nameFr && (
-              <p className="text-xs text-[#DC2626] mt-1">{errors.nameFr}</p>
-            )}
-          </div>
-
-          {/* Description */}
-          <div>
-            <label className="block text-sm font-medium text-[#1C1917] mb-2">
-              {t('formDescription')}
-            </label>
-            <textarea
-              rows={3}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              className="w-full px-3 py-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] resize-none"
-              data-testid="merchant-product-form-description-textarea"
-            />
-          </div>
-
-          {/* Product categories — 3 levels */}
-          <div>
-            <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">
-              Catégorie
-            </label>
-            <select
-              value={catL1}
-              onChange={(e) => { setCatL1(e.target.value); setCatL2(''); setCatL3(''); }}
-              className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
-              data-testid="merchant-product-form-category-l1-select"
-            >
-              <option value="">Sélectionner une catégorie</option>
-              {Object.keys(PRODUCT_CATEGORIES).map((l1) => (
-                <option key={l1} value={l1}>{l1}</option>
-              ))}
-            </select>
-
-            {catL1 && Object.keys(PRODUCT_CATEGORIES[catL1] ?? {}).length > 0 && (
-              <select
-                value={catL2}
-                onChange={(e) => { setCatL2(e.target.value); setCatL3(''); }}
-                className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
-                data-testid="merchant-product-form-category-l2-select"
-              >
-                <option value="">Sous-catégorie</option>
-                {Object.keys(PRODUCT_CATEGORIES[catL1]).map((l2) => (
-                  <option key={l2} value={l2}>{l2}</option>
-                ))}
-              </select>
-            )}
-
-            {catL1 && catL2 && (PRODUCT_CATEGORIES[catL1]?.[catL2] ?? []).length > 0 && (
-              <select
-                value={catL3}
-                onChange={(e) => setCatL3(e.target.value)}
-                className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
-                data-testid="merchant-product-form-category-l3-select"
-              >
-                <option value="">Type (optionnel)</option>
-                {(PRODUCT_CATEGORIES[catL1][catL2]).map((l3) => (
-                  <option key={l3} value={l3}>{l3}</option>
-                ))}
-              </select>
-            )}
-          </div>
-
-          {/* Stock */}
-          <div>
-            <label className="block text-sm font-medium text-[#1C1917] mb-2">
-              {t('formStock')}
-            </label>
-            <input
-              type="number"
-              value={stock}
-              onChange={(e) => setStock(Math.max(0, parseInt(e.target.value) || 0))}
-              className="w-full h-11 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)]"
-              data-testid="merchant-product-form-stock-input"
-            />
-            <p className="text-xs text-[#78716C] mt-1">
-              Stock = 0 signifie rupture de stock — le produit sera visible mais non commandable.
-            </p>
-          </div>
-
-          {/* Visibility */}
-          <div className="flex items-center justify-between py-2">
-            <label className="text-sm font-medium text-[#1C1917]">{t('formVisible')}</label>
-            <button
-              type="button"
-              onClick={() => setIsVisible((v) => !v)}
-              role="switch"
-              aria-checked={isVisible}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                isVisible ? 'bg-[var(--color-primary)]' : 'bg-[#E2E8F0]'
-              }`}
-              data-testid="merchant-product-form-visibility-toggle-checkbox"
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                  isVisible ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </div>
-        </div>
-
-        {/* Price calculator */}
-        {priceCalculator}
-
-        {/* Danger zone (edit only) */}
-        {dangerCard}
-      </div>
-
-      {/* Sticky CTA */}
-      <div className="fixed bottom-0 start-0 end-0 bg-white border-t border-[#E2E8F0] p-4 md:hidden">
-        <button
-          type="button"
-          onClick={handleSubmit}
-          disabled={isPending || uploading}
-          className="w-full h-12 text-white text-base font-semibold rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
-          style={{ backgroundColor: 'var(--color-primary)' }}
-          data-testid="merchant-product-form-publish-btn"
-        >
-          {isPending
-            ? isEdit ? t('formSaving') : t('formPublishing')
-            : isEdit ? t('formSave') : t('formPublish')}
-        </button>
-      </div>
-    </div>
-  );
-
-  // ─── Desktop layout ────────────────────────────────────────────────────────
-
-  const desktopLayout = (
-    <div className="hidden md:block bg-[#FAFAF9] min-h-screen">
-      <div className="max-w-[1040px] mx-auto p-8">
-        {/* Breadcrumb */}
-        <div className="text-xs text-[#78716C] mb-6">
-          <Link href="/dashboard/produits" className="hover:underline">
-            {t('title')}
-          </Link>
-          {' > '}
-          <span>{isEdit ? (product?.name_fr ?? t('editProduct')) : t('newProduct')}</span>
-        </div>
-
-        {/* Action bar */}
-        <div className="flex justify-end mb-6">
+      {/* Stock — desktop shows ± stepper buttons around the input, mobile shows plain input. */}
+      <div>
+        <label className="block text-sm md:text-[13px] font-medium md:font-normal text-[#1C1917] md:text-[#78716C] mb-2 md:mb-1.5">
+          {t('formStock')}
+        </label>
+        <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={handleSubmit}
-            disabled={isPending || uploading}
-            className="h-10 px-4 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
-            style={{ backgroundColor: 'var(--color-primary)' }}
-            data-testid="merchant-product-form-publish-btn"
+            onClick={() => setStock((s) => Math.max(0, s - 1))}
+            className="hidden md:inline-flex items-center justify-center w-8 h-8 border border-[#E2E8F0] rounded text-[#78716C] hover:bg-[#F8FAFC] text-lg leading-none"
+            data-testid="merchant-product-form-stock-decrement-btn"
           >
-            {isPending
-              ? isEdit ? t('formSaving') : t('formPublishing')
-              : isEdit ? t('formSave') : t('formPublish')}
+            −
+          </button>
+          <input
+            type="number"
+            value={stock}
+            onChange={(e) => setStock(Math.max(0, parseInt(e.target.value) || 0))}
+            className="w-full md:w-24 h-11 md:h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm md:text-center focus:outline-none focus:border-[var(--color-primary)] md:focus:ring-1 md:focus:ring-[var(--color-primary)]"
+            data-testid="merchant-product-form-stock-input"
+          />
+          <button
+            type="button"
+            onClick={() => setStock((s) => s + 1)}
+            className="hidden md:inline-flex items-center justify-center w-8 h-8 border border-[#E2E8F0] rounded text-[#78716C] hover:bg-[#F8FAFC] text-lg leading-none"
+            data-testid="merchant-product-form-stock-increment-btn"
+          >
+            +
           </button>
         </div>
-
-        <div className="flex gap-6">
-          {/* Left: info card */}
-          <div className="flex-1">
-            <div className="bg-white rounded-xl shadow-sm p-6">
-              <h2 className="text-base font-semibold text-[#1C1917] mb-4">{t('formInfoTitle')}</h2>
-              <div className="space-y-4">
-                {/* Name FR */}
-                <div>
-                  <label className="block text-[13px] text-[#78716C] mb-1.5">{t('formNameFr')}</label>
-                  <input
-                    type="text"
-                    value={nameFr}
-                    onChange={(e) => {
-                      setNameFr(e.target.value);
-                      setErrors((prev) => ({ ...prev, nameFr: '' }));
-                    }}
-                    className={`w-full h-10 px-3 border rounded-lg text-sm focus:outline-none focus:ring-1 ${
-                      errors.nameFr
-                        ? 'border-[#DC2626] focus:border-[#DC2626] focus:ring-[#DC2626]'
-                        : 'border-[#E2E8F0] focus:border-[var(--color-primary)] focus:ring-[var(--color-primary)]'
-                    }`}
-                    data-testid="merchant-product-form-name-input"
-                  />
-                  {errors.nameFr && (
-                    <p className="text-xs text-[#DC2626] mt-1">{errors.nameFr}</p>
-                  )}
-                </div>
-
-                {/* Description */}
-                <div>
-                  <label className="block text-[13px] text-[#78716C] mb-1.5">{t('formDescription')}</label>
-                  <textarea
-                    rows={4}
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    className="w-full px-3 py-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] resize-none"
-                    data-testid="merchant-product-form-description-textarea"
-                  />
-                </div>
-
-                {/* Product categories — 3 levels */}
-                <div>
-                  <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">
-                    Catégorie
-                  </label>
-                  <select
-                    value={catL1}
-                    onChange={(e) => { setCatL1(e.target.value); setCatL2(''); setCatL3(''); }}
-                    className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
-                    data-testid="merchant-product-form-category-l1-select"
-                  >
-                    <option value="">Sélectionner une catégorie</option>
-                    {Object.keys(PRODUCT_CATEGORIES).map((l1) => (
-                      <option key={l1} value={l1}>{l1}</option>
-                    ))}
-                  </select>
-
-                  {catL1 && Object.keys(PRODUCT_CATEGORIES[catL1] ?? {}).length > 0 && (
-                    <select
-                      value={catL2}
-                      onChange={(e) => { setCatL2(e.target.value); setCatL3(''); }}
-                      className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white mb-2"
-                      data-testid="merchant-product-form-category-l2-select"
-                    >
-                      <option value="">Sous-catégorie</option>
-                      {Object.keys(PRODUCT_CATEGORIES[catL1]).map((l2) => (
-                        <option key={l2} value={l2}>{l2}</option>
-                      ))}
-                    </select>
-                  )}
-
-                  {catL1 && catL2 && (PRODUCT_CATEGORIES[catL1]?.[catL2] ?? []).length > 0 && (
-                    <select
-                      value={catL3}
-                      onChange={(e) => setCatL3(e.target.value)}
-                      className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
-                      data-testid="merchant-product-form-category-l3-select"
-                    >
-                      <option value="">Type (optionnel)</option>
-                      {(PRODUCT_CATEGORIES[catL1][catL2]).map((l3) => (
-                        <option key={l3} value={l3}>{l3}</option>
-                      ))}
-                    </select>
-                  )}
-                </div>
-
-                {/* Stock with stepper */}
-                <div>
-                  <label className="block text-[13px] text-[#78716C] mb-1.5">{t('formStock')}</label>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setStock((s) => Math.max(0, s - 1))}
-                      className="w-8 h-8 border border-[#E2E8F0] rounded text-[#78716C] hover:bg-[#F8FAFC] text-lg leading-none"
-                      data-testid="merchant-product-form-stock-decrement-btn"
-                    >
-                      −
-                    </button>
-                    <input
-                      type="number"
-                      value={stock}
-                      onChange={(e) => setStock(Math.max(0, parseInt(e.target.value) || 0))}
-                      className="w-24 h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm text-center focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
-                      data-testid="merchant-product-form-stock-input"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setStock((s) => s + 1)}
-                      className="w-8 h-8 border border-[#E2E8F0] rounded text-[#78716C] hover:bg-[#F8FAFC] text-lg leading-none"
-                      data-testid="merchant-product-form-stock-increment-btn"
-                    >
-                      +
-                    </button>
-                  </div>
-                  <p className="text-xs text-[#78716C] mt-1.5">
-                    Stock = 0 signifie rupture de stock — le produit sera visible mais non commandable.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Right: price + photo + visibility + danger */}
-          <div className="w-[320px] space-y-4">
-            {priceCalculator}
-            {photoCard}
-            {visibilityCard}
-            {dangerCard}
-          </div>
-        </div>
+        <p className="text-xs text-[#78716C] mt-1 md:mt-1.5">
+          Stock = 0 signifie rupture de stock — le produit sera visible mais non commandable.
+        </p>
       </div>
     </div>
   );
 
-  // ─── Delete modal ──────────────────────────────────────────────────────────
+  // ─── Unified layout (mobile + desktop via responsive classes) ─────────────
+  // PLZ-079: collapsed the previous `md:hidden` / `hidden md:block` fork so
+  // each testid (publish-btn, name-input, description-textarea, category
+  // selects, stock-input, visibility toggle) resolves to exactly one DOM
+  // element at any breakpoint. Cards use responsive `order-*` classes to
+  // reposition themselves between the mobile stack and desktop 2-column grid.
+  //
+  // The single publish button below is positioned via its wrapper:
+  //  - mobile: `fixed bottom-0` sticky footer across the viewport.
+  //  - desktop: `static` inline top-right action bar.
+  const publishRow = (
+    <div className="fixed md:static bottom-0 start-0 end-0 z-10 md:z-0 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:mb-6 flex justify-stretch md:justify-end">
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={isPending || uploading}
+        className="w-full md:w-auto h-12 md:h-10 md:px-4 text-white text-base md:text-sm font-semibold md:font-medium rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
+        style={{ backgroundColor: 'var(--color-primary)' }}
+        data-testid="merchant-product-form-publish-btn"
+      >
+        {isPending
+          ? isEdit ? t('formSaving') : t('formPublishing')
+          : isEdit ? t('formSave') : t('formPublish')}
+      </button>
+    </div>
+  );
 
   const deleteModal = showDeleteModal ? (
     <div
@@ -737,8 +556,71 @@ export function ProductForm({ product }: Props) {
 
   return (
     <>
-      {mobileLayout}
-      {desktopLayout}
+      <div className="bg-[#FAFAF9] min-h-screen pb-24 md:pb-0">
+        {/* Mobile top bar (back link + title) — hidden on desktop. */}
+        <div className="md:hidden bg-white h-14 px-4 flex items-center justify-center relative border-b border-[#E2E8F0]">
+          <Link
+            href="/dashboard/produits"
+            className="absolute start-4 p-2 -ms-2 text-[#1C1917]"
+            data-testid="merchant-product-form-back-link"
+          >
+            <ArrowLeft size={20} />
+          </Link>
+          <h1 className="text-base font-semibold text-[#1C1917]">
+            {isEdit ? t('editProduct') : t('newProduct')}
+          </h1>
+        </div>
+
+        <div className="max-w-[1040px] mx-auto md:p-8">
+          {/* Desktop breadcrumb — hidden on mobile. */}
+          <div className="hidden md:block text-xs text-[#78716C] mb-6">
+            <Link href="/dashboard/produits" className="hover:underline">
+              {t('title')}
+            </Link>
+            {' > '}
+            <span>{isEdit ? (product?.name_fr ?? t('editProduct')) : t('newProduct')}</span>
+          </div>
+
+          {/* Single publish button. Its wrapper handles positioning:
+              mobile: `fixed bottom-0` sticky footer.
+              desktop: `static` inline top-right. */}
+          {publishRow}
+
+          {/* Main content: single column on mobile, 2-column grid on desktop.
+              `order-*` classes reposition cards between breakpoints:
+              mobile: photo → info → price → visibility → danger
+              desktop left col: info
+              desktop right col: price → photo → visibility → danger */}
+          <div className="p-4 md:p-0 md:grid md:grid-cols-[1fr_320px] md:gap-6 md:items-start space-y-3 md:space-y-0">
+            {/* Photo — mobile first, desktop second in right column. */}
+            <div className="order-1 md:order-3 md:col-start-2">
+              {photoCard}
+            </div>
+
+            {/* Info form — mobile second, desktop first (left column). */}
+            <div className="order-2 md:order-1 md:col-start-1 md:row-start-1 md:row-span-4">
+              {infoForm}
+            </div>
+
+            {/* Price calculator — mobile third, desktop second in right column. */}
+            <div className="order-3 md:order-2 md:col-start-2 md:row-start-1">
+              {priceCalculator}
+            </div>
+
+            {/* Visibility card — mobile fourth, desktop fourth in right column. */}
+            <div className="order-4 md:order-4 md:col-start-2">
+              {visibilityCard}
+            </div>
+
+            {/* Danger zone (edit only) — mobile fifth, desktop last in right column. */}
+            {dangerCard && (
+              <div className="order-5 md:order-5 md:col-start-2">
+                {dangerCard}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
       {deleteModal}
     </>
   );

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -253,7 +253,8 @@
     "formPublishing": "جارٍ النشر…",
     "formSave": "حفظ",
     "formSaving": "جارٍ الحفظ…",
-    "loading": "جارٍ التحميل…"
+    "loading": "جارٍ التحميل…",
+    "uploading": "جارٍ الرفع…"
   },
   "nav": {
     "home": "الرئيسية",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -265,7 +265,8 @@
     "formPublishing": "Publication…",
     "formSave": "Enregistrer",
     "formSaving": "Enregistrement…",
-    "loading": "Chargement…"
+    "loading": "Chargement…",
+    "uploading": "Téléversement…"
   },
   "nav": {
     "home": "Accueil",


### PR DESCRIPTION
## Summary

**PLZ-079 (SAAD-003 fix + dedupe)**
- Fixes founder's 2026-04-21 critical: the "Enregistré ✓" save indicator was invisible on desktop because it was nested inside an `md:hidden` container. Indicator now lifted out of the fork into a single save row that renders at all breakpoints.
- Collapses forked mobile/desktop JSX trees in `app/dashboard/boutique/BoutiqueForm.tsx` and `app/dashboard/produits/ProductForm.tsx` to a single tree using responsive Tailwind classes (`fixed md:static`, `md:grid-cols-[1fr_320px]`, `order-*` repositioning, etc.).
- Enforces testid-convention.md rule: one logical element = one testid at all breakpoints.

**PLZ-080**
- Adds `products.uploading` translation in `messages/fr.json` (`"Téléversement…"`) and `messages/ar.json` (`"جارٍ الرفع…"`) — fixes Saad SAAD-004 (IntlError: MISSING_MESSAGE).

Saad's report: `.agents/saad/reports/2026-04-21-flow-a-fresh-merchant.md`

## Grep-verified testid uniqueness

Every testid appears exactly once in each file (all counts = 1):

**ProductForm.tsx** — 19 unique testids, 1 occurrence each:
- `merchant-product-form-back-link`, `category-l1/l2/l3-select`, `delete-btn/cancel-btn/confirm-btn/dialog`, `description-textarea`, `discount-toggle-checkbox`, `name-input`, `original-price-input`, `photo-input`, `price-input`, `publish-btn`, `stock-decrement-btn/increment-btn/input`, `visibility-toggle-checkbox`

**BoutiqueForm.tsx** — 11 unique testids, 1 occurrence each:
- `merchant-boutique-banner-input`, `category-select`, `description-textarea`, `free-delivery-threshold-input`, `incomplete-close-btn/dialog`, `location-description-input`, `logo-input`, `save-btn`, `store-name-input`, `store-slug-input`

Also verified at runtime via Playwright `document.querySelectorAll` — each testid resolves to exactly 1 DOM element at both 1280×720 desktop and 375×812 mobile.

## Verification

- `npx tsc --noEmit` → clean (0 errors)
- `npm run lint` → clean for modified files (only pre-existing `<img>` warnings in unrelated storefront files)
- Desktop 1280×720 browser verify: ONE `merchant-boutique-save-btn` in DOM at (272, 672, 200x48). Edited description → clicked save → "Enregistré ✓" indicator confirmed rendering at (488, 686, 82x20) after ~3s (server action round-trip). **SAAD-003 fix confirmed on desktop.**
- Mobile 375×812 browser verify: ONE save btn in DOM (fixed at bottom, y=732). Indicator renders at (16, 704, 328x20) after save — above the fixed save row in flex-col-reverse.
- `/dashboard/produits/nouveau` loads with 0 console errors → **PLZ-080 IntlError gone.**
- Screenshots: `.agents/mehdi/plz-079-verify/`

## Test plan

- [ ] Anas: verify grep count = 1 for every testid in both files
- [ ] Anas: `npx tsc --noEmit` + `npm run lint` pass
- [ ] Anas: desktop save flow shows indicator after save (fixes SAAD-003 founder blocker)
- [ ] Anas: no IntlError MISSING_MESSAGE: products.uploading on `/dashboard/produits/nouveau`
- [ ] Anas: no visual regressions in product form or boutique form at 1280+ and 375+ viewports

Do not self-approve/merge. Anas reviews and merges.

---

PLZ-079 + PLZ-080 combined. Net diff: -146 LOC (4 files changed, +261 -407).