### PR TITLE
feat(PLZ-083): driver PIN-setup keypad testids + click fix

### DIFF
--- a/app/driver/auth/pin-setup/page.tsx
+++ b/app/driver/auth/pin-setup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Key, Delete, Loader2 } from 'lucide-react';
 import { PinBoxes } from '../../_components/PinBoxes';
@@ -19,12 +19,21 @@ function PinSetupContent() {
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
 
+  // Synchronous step mirror — `press()` reads this to route to pin vs confirm
+  // without waiting for React to flush the `step` state. Without it, rapid
+  // successive clicks (including programmatic `.click()`) that arrive during
+  // the 300 ms pin→confirm transition or within the same React batch silently
+  // drop, because the closure still sees step === 1 && pin.length === 4.
+  const stepRef = useRef<1 | 2>(1);
+
   useEffect(() => {
     if (pin.length === 4 && step === 1) {
       const t = setTimeout(() => setStep(2), 300);
       return () => clearTimeout(t);
     }
   }, [pin, step]);
+
+  useEffect(() => { stepRef.current = step; }, [step]);
 
   useEffect(() => {
     if (confirm.length === 4) {
@@ -51,12 +60,27 @@ function PinSetupContent() {
 
   function press(n: string) {
     if (loading) return;
-    if (step === 1 && pin.length < 4) setPin(p => p + n);
-    else if (step === 2 && confirm.length < 4) setConfirm(c => c + n);
+    // Route via stepRef so rapid clicks see the latest routing target.
+    // Functional updaters guarantee we always append to the latest buffer
+    // and never exceed 4 digits even if multiple clicks land in one React batch.
+    if (stepRef.current === 1) {
+      setPin(prev => {
+        if (prev.length >= 4) return prev;
+        const next = prev + n;
+        // Flip routing synchronously the moment pin fills, so the next
+        // click in the same event-loop tick routes to confirm, not a
+        // dropped-on-the-floor pin append.
+        if (next.length === 4) stepRef.current = 2;
+        return next;
+      });
+    } else {
+      setConfirm(prev => (prev.length < 4 ? prev + n : prev));
+    }
   }
 
   function del() {
-    if (step === 1) setPin(p => p.slice(0, -1));
+    if (loading) return;
+    if (stepRef.current === 1) setPin(p => p.slice(0, -1));
     else setConfirm(c => c.slice(0, -1));
   }
 
@@ -89,16 +113,19 @@ function PinSetupContent() {
       <div className="grid grid-cols-3 gap-3 mt-8 w-[280px]">
         {NUMPAD.map(n => (
           <button key={n} onClick={() => press(String(n))} disabled={loading}
+            data-testid={`driver-pin-setup-keypad-${n}-btn`}
             className="h-16 rounded-2xl bg-white border border-gray-200 text-xl font-medium text-[#1C1917] hover:bg-gray-50 active:scale-95 transition-all disabled:opacity-50">
             {n}
           </button>
         ))}
         <div />
         <button onClick={() => press('0')} disabled={loading}
+          data-testid="driver-pin-setup-keypad-0-btn"
           className="h-16 rounded-2xl bg-white border border-gray-200 text-xl font-medium text-[#1C1917] hover:bg-gray-50 active:scale-95 transition-all disabled:opacity-50">
           0
         </button>
         <button onClick={del} disabled={loading}
+          data-testid="driver-pin-setup-keypad-backspace-btn"
           className="h-16 rounded-2xl bg-white border border-gray-200 flex items-center justify-center hover:bg-gray-50 active:scale-95 transition-all disabled:opacity-50"
           aria-label="Effacer">
           <Delete className="w-5 h-5 text-[#1C1917]" />


### PR DESCRIPTION
## Root cause analysis

`press()` in `app/driver/auth/pin-setup/page.tsx` gated its buffer-append on the closure-captured `step` and `pin.length`. The `step` state only flips from `1` to `2` inside a `setTimeout(..., 300)` callback in a `useEffect`. Any keypad click landing between the 4th create-digit and that 300 ms flush still saw `step === 1 && pin.length === 4` in its closure — so the if/else branches both evaluated false and the click was silently dropped.

Programmatic `.click()` sequences (Saad's test harness) fire all 8 digits in effectively one event-loop tick, so the first 4 register on create (the closure still sees `pin.length === 0` because React hasn't re-rendered yet — the `p => p + n` functional updater carries each click through correctly), but clicks 5–8 hit the updated render where `pin.length === 4` and `step === 1`, and are dropped. That's why Saad observed the UI advance to the confirm screen but then report "Les codes ne correspondent pas" on the 'same' PIN — `confirm` was actually empty (or partial) at the moment the 300 ms timer fired and `setStep(2)` landed. Mouse users rarely trigger this because their clicks are naturally spaced past the 300 ms window.

## Fix summary

- Add a `stepRef = useRef<1|2>(1)` that is flipped **synchronously** inside the `setPin` functional updater the moment `pin` reaches 4 digits. `press()` now routes via `stepRef.current`, not the stale closure `step`, so the 5th rapid click correctly routes into `confirm`.
- Replace both length gates with functional updaters (`prev => prev.length < 4 ? prev + n : prev`) so multiple clicks landing in the same React batch cannot overflow the buffer.
- Mirror `step` into `stepRef` via a separate `useEffect` for all non-rapid transitions (e.g., when confirm is reset after mismatch — step stays 2, ref stays 2).
- Add `driver-pin-setup-keypad-{0..9}-btn` and `driver-pin-setup-keypad-backspace-btn` testids on each keypad `<button>` (per `.agents/shared/testid-convention.md`). No submit testid: the keypad has no submit button — confirm auto-submits when `confirm.length === 4`.

## Testid uniqueness proof

`grep -oE 'data-testid="driver-pin-setup-keypad-[^"]*"' app/driver/auth/pin-setup/page.tsx` plus the template-literal variant:

```
data-testid={`driver-pin-setup-keypad-${n}-btn`}    # expands to 1..9 at runtime (one template, 9 rendered)
data-testid="driver-pin-setup-keypad-0-btn"
data-testid="driver-pin-setup-keypad-backspace-btn"
```

Three source occurrences — one template literal covering 1–9 (NUMPAD has 9 entries, rendered exactly once each via key={n}), one literal `0`, one `backspace`. Eleven total rendered keypad testids, every one unique. Regex guard `grep -oE 'data-testid="driver-pin-setup-keypad-[^"]*"' | grep -vE '^data-testid="driver-pin-setup-keypad-[a-z0-9]+-btn"$'` prints nothing.

## Verification

- `npx tsc --noEmit`: clean.
- `npm run lint`: no new errors (only pre-existing warnings in `./app/store/*` about `<img>` usage — unrelated).
- Programmatic click-through: a throwaway Playwright spec at `tests/e2e/fixtures/driverKeypadSmoke.spec.ts` exercised 8 `getByTestId(...).click()` calls through both screens. Three assertions passed in 4.6 s: (1) matching 1234+1234 — no mismatch error; (2) mismatched 1234+5678 — "Les codes ne correspondent pas" appears (this is the definitive proof — it only renders when `confirm.length === 4`, i.e. all four confirm-screen clicks registered); (3) backspace testid works. Spec deleted before commit per brief.
- Mouse-click regression: Playwright `.click()` dispatches real mousedown/mouseup/click via CDP, which is a superset of raw JS `.click()` dispatch. The same 3 tests pass that way, so mouse behavior is preserved.

## Blast radius

The same `NUMPAD` + `.grid.grid-cols-3.gap-3.mt-8.w-[280px]` keypad pattern exists in `app/driver/auth/pin/page.tsx` (driver PIN login). That file is **out of scope** for this ticket. It has the same structural duplication but a simpler handler (`setPin(p => p + n)` only, no step transition), so the exact bug fixed here does not apply to it — pin-login has no step race. Recommend a follow-up ticket to add matching `driver-auth-pin-keypad-{0..9,backspace}-btn` testids there if Saad needs to programmatically drive the login screen.

`PinBoxes.tsx` (shared by pin-setup, pin-login, delivery/confirm) is untouched.

## References

- Saad's report: `.agents/saad/reports/2026-04-21-flow-a-retest-plus-admin.md` — see SAAD-005.
- Testid convention: `.agents/shared/testid-convention.md`.

Do NOT merge — Anas QA merges per process.
