### PR TITLE
chore(PLZ-084): commit PLZ-059 drivers migrations to source control

### DIFF
--- a/supabase/migrations/20260416000001_plz059_drivers_phone_unique.sql
+++ b/supabase/migrations/20260416000001_plz059_drivers_phone_unique.sql
@@ -1,0 +1,17 @@
+-- PLZ-059: Ensure drivers.phone has a unique constraint.
+-- The original CREATE TABLE IF NOT EXISTS was skipped on remote because
+-- the drivers table already existed, leaving the unique constraint unset.
+-- This migration adds it idempotently.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_constraint
+    WHERE  conrelid = 'drivers'::regclass
+    AND    contype  = 'u'
+    AND    conname  = 'drivers_phone_unique'
+  ) THEN
+    ALTER TABLE drivers ADD CONSTRAINT drivers_phone_unique UNIQUE (phone);
+  END IF;
+END $$;

--- a/supabase/migrations/20260416000002_plz059_drivers_city.sql
+++ b/supabase/migrations/20260416000002_plz059_drivers_city.sql
@@ -1,0 +1,4 @@
+-- PLZ-059: Add city column to drivers table.
+-- Used by the dispatch engine (PLZ-058) to match drivers to delivery zones.
+ALTER TABLE drivers ADD COLUMN IF NOT EXISTS city text;
+CREATE INDEX IF NOT EXISTS drivers_city_idx ON drivers (city);


### PR DESCRIPTION
## Summary

Both PLZ-059 drivers migrations existed as untracked files on disk for weeks but were never committed. This PR commits them so the repo reflects schema reality.

## Live DB state (verified via Management API today)

| Migration | File | Live state | Action |
|---|---|---|---|
| `drivers.city` | `20260416000002_plz059_drivers_city.sql` | ✓ Already applied (manual during PLZ-059) | Commit only |
| `drivers_phone_unique` | `20260416000001_plz059_drivers_phone_unique.sql` | ❌ Was missing → just applied today | Committed + applied |

## Why it mattered

Anas discovered during PLZ-083 QA spot-check that `completeDriverPinSetupAction` was failing on every fresh driver:

```
error: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

The action uses `upsert(..., { onConflict: 'phone' })`. Without the `drivers_phone_unique` constraint on the live DB, every single fresh driver PIN-setup failed server-side. The client UI conflated this with a PIN-mismatch error, so users saw "Les codes ne correspondent pas" and had no way to complete signup.

## Safety

Both migrations are idempotent — `DO $$ BEGIN IF NOT EXISTS ...` and `ADD COLUMN IF NOT EXISTS`. Re-running them locally or in CI is a no-op against an already-migrated DB.

## Test plan

- [x] Constraint verified live via Management API: `SELECT conname FROM pg_constraint WHERE conrelid = 'drivers'::regclass AND contype = 'u';` → returns `drivers_phone_unique`
- [x] Migration files are idempotent — re-running via the same API call is a no-op
- [x] No code changes; no tsc/lint impact
- [ ] After merge: Saad final retest will confirm the full driver onboarding → admin approve/reject flow works end-to-end

## Follow-up (separate ticket, non-blocking)

The client UI in `DriverPinSetup` uses the same error copy (`"Les codes ne correspondent pas"`) for both genuine PIN mismatch AND server errors returned from the action. A small copy-distinction improvement would make future server issues easier to diagnose. File PLZ-085 post-launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)