### PR TITLE
feat(PLZ-081, PLZ-082): fixture location + MobileNav occlusion (DRAFT)

### DIFF
--- a/app/dashboard/boutique/BoutiqueForm.tsx
+++ b/app/dashboard/boutique/BoutiqueForm.tsx
@@ -734,7 +734,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   // save-button row, fixing SAAD-003 (indicator invisible on desktop).
   return (
     <>
-      <div className="bg-[#FAFAF9] min-h-screen pb-24 md:pb-0">
+      <div className="bg-[#FAFAF9] min-h-screen pb-40 md:pb-0">
         {/* Top bar — mobile: compact h-14 with text link.
                       desktop: bordered ExternalLink button. */}
         <div className="bg-white md:bg-transparent h-14 md:h-auto px-4 md:px-0 flex items-center justify-between border-b md:border-b-0 border-[#E2E8F0] md:pt-8 md:mb-6 md:max-w-[1280px] md:mx-auto md:w-full md:px-8">
@@ -794,8 +794,12 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
 
             {/* Save row — single element, positioned fixed bottom on mobile,
                 static inline on desktop. `flex-col-reverse` on mobile puts the
-                indicator ABOVE the button (DOM order is button → indicator). */}
-            <div className="fixed md:static bottom-0 start-0 end-0 z-10 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:pt-2 flex flex-col-reverse md:flex-row md:items-center md:gap-4">
+                indicator ABOVE the button (DOM order is button → indicator).
+                PLZ-082: on mobile (<lg) MobileNav is fixed at bottom-0 with h-16
+                so the save bar sits at `bottom-16` to stack above it. Z-index
+                stays below MobileNav's z-50 so the nav's shadow doesn't bleed
+                over the save bar; the vertical offset prevents occlusion. */}
+            <div className="fixed md:static bottom-16 md:bottom-0 start-0 end-0 z-10 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:pt-2 flex flex-col-reverse md:flex-row md:items-center md:gap-4">
               <button
                 type="button"
                 onClick={handleSave}

--- a/app/dashboard/produits/ProductForm.tsx
+++ b/app/dashboard/produits/ProductForm.tsx
@@ -505,8 +505,12 @@ export function ProductForm({ product }: Props) {
   // The single publish button below is positioned via its wrapper:
   //  - mobile: `fixed bottom-0` sticky footer across the viewport.
   //  - desktop: `static` inline top-right action bar.
+  // PLZ-082: on mobile (<lg) MobileNav is fixed bottom-0 h-16 at z-50. The
+  // publish bar sits at `bottom-16` so it stacks above MobileNav instead of
+  // being occluded by it. On md+ the wrapper flips to `static`, which nullifies
+  // any `bottom-*` class, so the inline desktop layout is unaffected.
   const publishRow = (
-    <div className="fixed md:static bottom-0 start-0 end-0 z-10 md:z-0 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:mb-6 flex justify-stretch md:justify-end">
+    <div className="fixed md:static bottom-16 md:bottom-0 start-0 end-0 z-10 md:z-0 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:mb-6 flex justify-stretch md:justify-end">
       <button
         type="button"
         onClick={handleSubmit}
@@ -556,7 +560,7 @@ export function ProductForm({ product }: Props) {
 
   return (
     <>
-      <div className="bg-[#FAFAF9] min-h-screen pb-24 md:pb-0">
+      <div className="bg-[#FAFAF9] min-h-screen pb-40 md:pb-0">
         {/* Mobile top bar (back link + title) — hidden on desktop. */}
         <div className="md:hidden bg-white h-14 px-4 flex items-center justify-center relative border-b border-[#E2E8F0]">
           <Link

--- a/components/MapboxMap.tsx
+++ b/components/MapboxMap.tsx
@@ -150,6 +150,7 @@ export default function MapboxMap({ lat, lng, onLocationChange }: Props) {
         disabled={locating}
         className="absolute top-2 right-2 z-10 bg-white rounded-lg shadow-md p-2 hover:bg-stone-50 disabled:opacity-60"
         title="Ma position"
+        data-testid="merchant-boutique-locate-btn"
       >
         {locating ? (
           <div className="w-5 h-5 border-2 border-stone-400 border-t-transparent rounded-full animate-spin" />

--- a/tests/e2e/fixtures/seedFreshMerchant.spec.ts
+++ b/tests/e2e/fixtures/seedFreshMerchant.spec.ts
@@ -1,5 +1,9 @@
+import { loadEnvConfig } from '@next/env';
+import { createClient } from '@supabase/supabase-js';
 import { test, expect, type Page } from '@playwright/test';
 import { seedFreshMerchant } from './seedFreshMerchant';
+
+loadEnvConfig(process.cwd());
 
 /**
  * PLZ-078 — Proof-of-life spec for seedFreshMerchant.
@@ -36,6 +40,23 @@ test.describe('seedFreshMerchant fixture', () => {
     expect(handle.storeSlug.length).toBeGreaterThan(0);
     expect(handle.phone).toMatch(/^\+2126\d{8}$/);
     expect(handle.pin).toBe('1234');
+
+    // PLZ-081 — fixture drives the boutique location pin-drop; assert the
+    // contract field is present AND the merchant row actually has coordinates.
+    expect(handle.hasLocation).toBe(true);
+    const admin = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } },
+    );
+    const { data: merchantRow } = await admin
+      .from('merchants')
+      .select('location_lat, location_lng')
+      .eq('id', handle.merchantId)
+      .maybeSingle();
+    const typed = merchantRow as { location_lat: number | null; location_lng: number | null } | null;
+    expect(typed?.location_lat).not.toBeNull();
+    expect(typed?.location_lng).not.toBeNull();
 
     const storefrontResponse = await page.goto(`/store/${handle.storeSlug}`);
     expect(storefrontResponse?.status()).toBe(200);

--- a/tests/e2e/fixtures/seedFreshMerchant.ts
+++ b/tests/e2e/fixtures/seedFreshMerchant.ts
@@ -16,6 +16,9 @@ loadEnvConfig(process.cwd());
  *   3. /auth/pin-setup (enter PIN twice) → /dashboard → middleware to /onboarding
  *   4. /onboarding (store name) → /dashboard
  *   5. merchantId + storeSlug resolved via admin read (UI-created state only)
+ *   6. (PLZ-081) /dashboard/boutique — geolocation-driven pin-drop at
+ *      Casablanca, then Enregistrer. Lets tests reach "Publier ma boutique"
+ *      since the checklist's 4th step (Localisation) gates the publish.
  *
  * Note on the brief's "/auth/signup" wording:
  *   That route is the deprecated email/password flow (its banner redirects
@@ -37,7 +40,27 @@ export interface FreshMerchantHandle {
   storeSlug: string;
   phone: string; // E.164 Moroccan, e.g. "+212691234567"
   pin: string;
+  /**
+   * PLZ-081 — Present (and always `true`) when the fixture successfully drove
+   * the `/dashboard/boutique` location pin-drop flow and persisted
+   * `location_lat` + `location_lng` on the merchant row. When the Mapbox token
+   * is unavailable or the location step is skipped, the field is absent so
+   * pre-PLZ-081 callers keep their original contract.
+   */
+  hasLocation?: true;
 }
+
+/**
+ * PLZ-081 — default pin-drop coordinates.
+ *
+ * The boutique location picker (components/MapboxMap.tsx) doesn't hardcode a
+ * merchant location — it falls back to MOROCCO_DEFAULT_VIEW (centered on the
+ * country, zoom 5). We pick Casablanca (Twin Center) as a realistic default
+ * for fixture merchants so downstream tests that read `location_description`
+ * get a plausible address context.
+ */
+const CASABLANCA_LAT = 33.5731;
+const CASABLANCA_LNG = -7.5898;
 
 function randomDigits(count: number): string {
   let out = '';
@@ -107,6 +130,24 @@ async function listAuthEmails(): Promise<Set<string>> {
 async function isPhoneTaken(phone: string): Promise<boolean> {
   const emails = await listAuthEmails();
   return emails.has(syntheticEmailFromPhone(phone));
+}
+
+async function readMerchantLocation(
+  merchantId: string,
+): Promise<{ lat: number | null; lng: number | null }> {
+  const { data, error } = await adminClient()
+    .from('merchants')
+    .select('location_lat, location_lng')
+    .eq('id', merchantId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`seedFreshMerchant: location readback failed — ${error.message}`);
+  }
+  const row = data as { location_lat: number | null; location_lng: number | null } | null;
+  return {
+    lat: row?.location_lat ?? null,
+    lng: row?.location_lng ?? null,
+  };
 }
 
 async function resolveMerchantByPhone(
@@ -281,6 +322,84 @@ export async function seedFreshMerchant(page: Page): Promise<FreshMerchantHandle
   }
   markStep('merchant-lookup', stepResolveStart);
 
+  // PLZ-081 — drive the /dashboard/boutique location pin-drop so downstream
+  // tests can reach the "Publier ma boutique" gate (which requires
+  // location_lat to be non-null). We use Playwright's geolocation override
+  // and click the map's "Ma position" control — this fires `handleLocate` in
+  // components/MapboxMap.tsx, which in turn calls the `onLocationChange`
+  // prop that BoutiqueForm uses to populate its local state. We then click
+  // the form's "Enregistrer" button and read back the merchant row.
+  //
+  // If the Mapbox token isn't configured the component renders lat/lng
+  // inputs instead — we fall back to filling those directly.
+  const stepLocationStart = Date.now();
+  let locationApplied = false;
+  try {
+    await page.context().grantPermissions(['geolocation']);
+    await page.context().setGeolocation({
+      latitude: CASABLANCA_LAT,
+      longitude: CASABLANCA_LNG,
+    });
+
+    await page.goto('/dashboard/boutique', { waitUntil: 'domcontentloaded' });
+    await page.waitForURL(/\/dashboard\/boutique/, { timeout: 20_000 });
+
+    // The map is client-side only (dynamic import, ssr:false) and first-run
+    // dev-server compilation + mapbox-gl bundle fetch pushes this well past
+    // the default 5s — give it up to 45s before falling back.
+    const locateBtn = page.getByTestId('merchant-boutique-locate-btn');
+    const locateAttached = await locateBtn
+      .waitFor({ state: 'attached', timeout: 45_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (locateAttached) {
+      await locateBtn.scrollIntoViewIfNeeded();
+      await locateBtn.click();
+      // onLocationChange updates BoutiqueForm's locationLat/locationLng state,
+      // which renders the "Position enregistrée" confirmation line. Waiting
+      // for that text is the strongest proxy for "state is populated".
+      await page.getByText(/Position enregistrée/).waitFor({ timeout: 10_000 });
+    } else {
+      // Token missing → fallback numeric inputs. These are rendered by
+      // MapboxMap.tsx when NEXT_PUBLIC_MAPBOX_TOKEN is absent. No testids
+      // there (intentional — Saad only exercises the happy map path), so
+      // key off label text via Playwright's role/text locators.
+      const latInput = page.getByLabel('Latitude');
+      const lngInput = page.getByLabel('Longitude');
+      await latInput.fill(String(CASABLANCA_LAT));
+      await lngInput.fill(String(CASABLANCA_LNG));
+    }
+
+    await page.getByTestId('merchant-boutique-save-btn').click();
+
+    // Poll the DB until the merchant row reflects the new coordinates —
+    // surviving both the server-action commit round-trip and Supabase's
+    // replica read lag.
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const loc = await readMerchantLocation(resolved.id);
+      if (loc.lat !== null && loc.lng !== null) {
+        locationApplied = true;
+        break;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await page.waitForTimeout(500);
+    }
+  } catch (err) {
+    fail(
+      'location pin-drop (boutique)',
+      'merchant-boutique-locate-btn / merchant-boutique-save-btn',
+      err,
+    );
+  }
+  if (!locationApplied) {
+    throw new Error(
+      `seedFreshMerchant: location pin-drop did not persist — merchants.location_lat still NULL for ${resolved.id}.`,
+    );
+  }
+  markStep('location-pin-drop', stepLocationStart);
+
   const total = Date.now() - t0;
   if (total > 60_000) {
     // eslint-disable-next-line no-console
@@ -292,5 +411,6 @@ export async function seedFreshMerchant(page: Page): Promise<FreshMerchantHandle
     storeSlug: resolved.storeSlug,
     phone,
     pin,
+    hasLocation: true,
   };
 }


### PR DESCRIPTION
## Summary

Combined post-launch batch — DRAFT pending fixture verification.

**PLZ-082 (user-visible):** MobileNav occluded the fixed mobile save/publish bars on `/dashboard/boutique` + `/dashboard/produits/nouveau` on <lg viewports. Lifted both bars to `bottom-16` (clearing h-16 MobileNav) and extended page padding to `pb-40`. Desktop (md+) wrapper flips to `static`, so mobile offsets don't apply.

**PLZ-081 (testability):** Extended `seedFreshMerchant` to drive the boutique location pin-drop so fixture merchants can reach `Publier ma boutique` (gates on `merchants.location_lat IS NOT NULL`). Added one testid (`merchant-boutique-locate-btn`) on the existing Ma position button — convention-valid.

## Verification status

- `npx tsc --noEmit`: PASS
- Fixture spec: NOT run to green in this branch. Dev session ran out of time mid-debug on the Mapbox compile wait. **Anas QA: run the spec end-to-end** (`npx playwright test tests/e2e/fixtures/seedFreshMerchant.spec.ts`) before marking Ready-for-review.

## Test plan

- [ ] Anas: fixture spec runs green
- [ ] Gate B scope (5 files)
- [ ] Gate C testid convention
- [ ] Gate E 375x812 browser: save CTA visible above MobileNav on both boutique and new-product pages