### PR TITLE
fix(PLZ-082): lift mobile save+publish bars above MobileNav (occlusion)

### DIFF
--- a/app/dashboard/boutique/BoutiqueForm.tsx
+++ b/app/dashboard/boutique/BoutiqueForm.tsx
@@ -734,7 +734,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   // save-button row, fixing SAAD-003 (indicator invisible on desktop).
   return (
     <>
-      <div className="bg-[#FAFAF9] min-h-screen pb-24 md:pb-0">
+      <div className="bg-[#FAFAF9] min-h-screen pb-40 md:pb-0">
         {/* Top bar — mobile: compact h-14 with text link.
                       desktop: bordered ExternalLink button. */}
         <div className="bg-white md:bg-transparent h-14 md:h-auto px-4 md:px-0 flex items-center justify-between border-b md:border-b-0 border-[#E2E8F0] md:pt-8 md:mb-6 md:max-w-[1280px] md:mx-auto md:w-full md:px-8">
@@ -794,8 +794,12 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
 
             {/* Save row — single element, positioned fixed bottom on mobile,
                 static inline on desktop. `flex-col-reverse` on mobile puts the
-                indicator ABOVE the button (DOM order is button → indicator). */}
-            <div className="fixed md:static bottom-0 start-0 end-0 z-10 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:pt-2 flex flex-col-reverse md:flex-row md:items-center md:gap-4">
+                indicator ABOVE the button (DOM order is button → indicator).
+                PLZ-082: on mobile (<lg) MobileNav is fixed at bottom-0 with h-16
+                so the save bar sits at `bottom-16` to stack above it. Z-index
+                stays below MobileNav's z-50 so the nav's shadow doesn't bleed
+                over the save bar; the vertical offset prevents occlusion. */}
+            <div className="fixed md:static bottom-16 md:bottom-0 start-0 end-0 z-10 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:pt-2 flex flex-col-reverse md:flex-row md:items-center md:gap-4">
               <button
                 type="button"
                 onClick={handleSave}

--- a/app/dashboard/produits/ProductForm.tsx
+++ b/app/dashboard/produits/ProductForm.tsx
@@ -505,8 +505,12 @@ export function ProductForm({ product }: Props) {
   // The single publish button below is positioned via its wrapper:
   //  - mobile: `fixed bottom-0` sticky footer across the viewport.
   //  - desktop: `static` inline top-right action bar.
+  // PLZ-082: on mobile (<lg) MobileNav is fixed bottom-0 h-16 at z-50. The
+  // publish bar sits at `bottom-16` so it stacks above MobileNav instead of
+  // being occluded by it. On md+ the wrapper flips to `static`, which nullifies
+  // any `bottom-*` class, so the inline desktop layout is unaffected.
   const publishRow = (
-    <div className="fixed md:static bottom-0 start-0 end-0 z-10 md:z-0 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:mb-6 flex justify-stretch md:justify-end">
+    <div className="fixed md:static bottom-16 md:bottom-0 start-0 end-0 z-10 md:z-0 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:mb-6 flex justify-stretch md:justify-end">
       <button
         type="button"
         onClick={handleSubmit}
@@ -556,7 +560,7 @@ export function ProductForm({ product }: Props) {
 
   return (
     <>
-      <div className="bg-[#FAFAF9] min-h-screen pb-24 md:pb-0">
+      <div className="bg-[#FAFAF9] min-h-screen pb-40 md:pb-0">
         {/* Mobile top bar (back link + title) — hidden on desktop. */}
         <div className="md:hidden bg-white h-14 px-4 flex items-center justify-center relative border-b border-[#E2E8F0]">
           <Link


### PR DESCRIPTION
## Summary

Anas Gate E finding pre-launch: on <lg viewports the MobileNav (fixed `bottom-0`, `h-16`, `z-50`) occluded the fixed save bar on `/dashboard/boutique` and the fixed publish bar on `/dashboard/produits/nouveau`, making the CTAs unreachable on small screens.

**Fix:** lift both bars to `bottom-16` (clears MobileNav's `h-16`) and extend page wrapper mobile padding from `pb-24` → `pb-40` so the last field isn't hidden behind the stacked bar. Desktop (md+) wrapper flips to `static`, so mobile offsets don't apply there.

2 files changed, 13/−5.

## Scope note

Split out of the previous combined PLZ-081+082 branch after PLZ-081 fixture-spec work could not be verified green within the agent-stall budget (see PR #76, parked). This PR ships only the user-visible occlusion fix, which Anas can verify via Gate E browser spot-check at both breakpoints — no Playwright required.

## Test plan

- [ ] Gate A: `npx tsc --noEmit` (already PASS locally)
- [ ] Gate B: scope stays within PLZ-082 (2 files: BoutiqueForm, ProductForm)
- [ ] Gate C: no testid changes
- [ ] Gate D: diff-read quality (one class change per file)
- [ ] Gate E: Playwright at 375x812 on `/dashboard/boutique` and `/dashboard/produits/nouveau`
   - [ ] save CTA `getBoundingClientRect().bottom` < MobileNav top
   - [ ] publish CTA same
   - [ ] last form field not clipped behind stacked bar
- [ ] Gate E: Playwright at 1280x720 — no regression (desktop layout unchanged)
- [ ] Gate F: squash-merge + delete branch