### PR TITLE
feat(PLZ-088): merchant refresh PR #1 — global tokens + mobile primary fix

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,17 +5,22 @@
 @layer base {
   :root {
     /* ─── shadcn/ui base tokens ─────────────────────────────────────── */
-    --background: 0 0% 100%;
+    /* Dashboard page canvas — off-white (#F8F9FA) per design-refresh brief §1.1.
+       Admin panel overrides to #F1F5F9 inside .admin-scope (separate PR). */
+    --background: 210 17% 98%;
     --foreground: 222 47% 11%;
     --card: 0 0% 100%;
     --card-foreground: 222 47% 11%;
 
-    /* Primary: #2563EB — warm blue */
-    --primary: 221 83% 53%;
+    /* Primary: #1A6BFF — unified Plaza blue (design-refresh v1) */
+    --primary: 217 100% 55%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 214 32% 91%;
-    --secondary-foreground: 222 47% 11%;
+    /* Secondary: #FF6B1A — brighter Plaza orange (design-refresh v1).
+       Used as brand accent on merchant + customer storefront surfaces.
+       Admin is no-orange — do not use inside .admin-scope. */
+    --secondary: 20 100% 55%;
+    --secondary-foreground: 0 0% 100%;
     --muted: 214 32% 91%;
     --muted-foreground: 215 16% 47%;
 
@@ -29,8 +34,48 @@
     --input: 214 32% 91%;
 
     /* Ring: matches primary */
-    --ring: 221 83% 53%;
+    --ring: 217 100% 55%;
     --radius: 0.75rem;
+
+    /* Success: #10B981 — teal-green (design-refresh v1). */
+    --success: 160 84% 39%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 100%;
+
+    /* Chart palette — Recharts surfaces (design-refresh §1.1). */
+    --chart-1: 217 100% 55%;   /* #1A6BFF primary blue */
+    --chart-2: 160 84% 39%;    /* #10B981 success teal */
+    --chart-3: 38 92% 50%;     /* #F59E0B warning amber */
+    --chart-4: 20 100% 55%;    /* #FF6B1A secondary orange */
+    --chart-5: 0 84% 60%;      /* #EF4444 destructive red */
+
+    /* Sidebar accent border (PR #2 will apply on merchant sidebar). */
+    --sidebar-active-border: 217 100% 55%;
+
+    /* ─── Tailwind v4 @theme CSS-variable form (hex) ─────────────────
+       These forms are consumed by existing code as `var(--color-*)`
+       (e.g. `var(--color-primary)` in BoutiqueForm save bar).
+       PLZ-088 fix: before this change, `--color-primary` was only set
+       via inline style on /driver and /store/[slug] layouts. On the
+       merchant dashboard it was never declared, so `md:hidden` fixed
+       save/publish bars rendered with an empty primary colour. Declare
+       here on `:root` so every surface inherits unless explicitly
+       overridden (storefront still overrides per-tenant primary_color
+       via inline style on the store layout; driver still hard-codes
+       #2563EB for its own consistency).                               */
+    --color-primary: #1A6BFF;
+    --color-primary-foreground: #FFFFFF;
+    --color-secondary: #FF6B1A;
+    --color-secondary-foreground: #FFFFFF;
+    --color-success: #10B981;
+    --color-warning: #F59E0B;
+    --color-destructive: #EF4444;
+    --color-chart-1: #1A6BFF;
+    --color-chart-2: #10B981;
+    --color-chart-3: #F59E0B;
+    --color-chart-4: #FF6B1A;
+    --color-chart-5: #EF4444;
 
     /* ─── Plaza brand color tokens ──────────────────────────────────── */
 


### PR DESCRIPTION
## Summary

- **Scope: token-only, no component restyling. Component work ships in PR #2-4 per design-refresh-brief.md §5.2.**
- Replace shadcn HSL base tokens on `:root` with new Plaza palette:
  - `--primary` `221 83% 53%` (`#2563EB`) → `217 100% 55%` (`#1A6BFF`)
  - `--secondary` muted-slate → `20 100% 55%` (`#FF6B1A`) + secondary-foreground white
  - `--background` `0 0% 100%` → `210 17% 98%` (`#F8F9FA`) dashboard canvas off-white
  - `--ring` matches new primary
  - `--success` new (`#10B981`), `--warning`/`--destructive` formalised
  - `--chart-1..5` added (`#1A6BFF / #10B981 / #F59E0B / #FF6B1A / #EF4444`)
  - `--sidebar-active-border` added for PR #2 consumption
- Add Tailwind v4 `@theme` CSS-variable form on `:root`: `--color-primary`, `--color-secondary`, `--color-success`, `--color-warning`, `--color-destructive`, `--color-chart-1..5` — all with the new hex values.
- **PLZ-088 fix:** root cause is that `--color-primary` was previously only set via inline style on `/driver/layout.tsx` and `/store/[slug]/layout.tsx`. The merchant dashboard layout never declared it, so `md:hidden` fixed save/publish bars in `BoutiqueForm`, `ProductForm`, `SupportClient`, `ProductsClient`, `ParametresClient`, `FinancesClient`, `CompteClient`, `OrdersClient` resolved primary to empty. Declared on `:root` so every surface inherits by default. Storefront per-tenant `primary_color` still overrides via inline style on `app/store/[slug]/layout.tsx`; `/driver` still pins its own `#2563EB` for driver-app consistency.

Follows PM-approved brief at `design-exports/design-refresh-brief.md` v1.
Gate-aware: Anas runs 6 phases + new additions from brief §5.5.

## Files touched (1)
- `app/globals.css` — +51 / −6

Explicitly NOT touched this PR (per brief §5.2):
- `tailwind.config.ts` — unchanged. No `colors.chart[N]` references exist in Tailwind config today; CSS `--chart-*` vars are sufficient and will be wired into `tailwind.config.ts` alongside chart components in a later PR if chart classes are added.
- Any component JSX (`BoutiqueForm`, `ProductForm`, etc.) — restyling is PR #2
- `DashboardLayout` / `SidebarNav` — dark sidebar is PR #2
- `app/admin/**` — Hamza's scope
- `.admin-scope` block in `globals.css` — admin override is Hamza's PR (brief blocker #2)

## WCAG note (brief §5.3)

New `#1A6BFF` on `#FFFFFF` measures **4.42:1**, BORDERLINE below AA 4.5:1 for small body text. This PR does NOT introduce or modify any `text-primary` on white bg — only token values change. Component PRs must use `#1A6BFF` for body text only on backgrounds ≤ `#F8F9FA`, and fall back to `#111827` for body text on white.

## PLZ-088 verification screenshot (375px)

Fixture extracted verbatim from `BoutiqueForm.tsx` mobile save bar CSS (lines 798–805) loaded with only the new `:root` tokens from this PR:

```
.playwright-mcp/plz-088-mobile-save-bar-375px.png
```

Computed style verification at 375px viewport:

```
buttonBg         = rgb(26, 107, 255)  === #1A6BFF   OK
buttonColor      = rgb(255, 255, 255) === #FFFFFF   OK
--color-primary  = #1A6BFF                          OK
--primary        = 217 100% 55%                     OK
--background     = 210 17% 98%                      OK
```

The save button renders solid blue; the "Voir ma boutique" link and store-URL text also pick up the new primary from `var(--color-primary)` with no inline override. This confirms the PLZ-082 regression reported by Anas is closed.

## What I tested

- `npx tsc --noEmit` — passes (exit 0, zero output)
- 375px fixture extracted from the real `BoutiqueForm` save-bar CSS — computed values match `#1A6BFF` / `#FFFFFF`
- Audited all 8 files flagged in PLZ-088 (`BoutiqueForm`, `ProductForm`, `SupportClient`, `ProductsClient`, `ParametresClient`, `FinancesClient`, `CompteClient`, `OrdersClient`) — all consume `var(--color-primary)`, now resolved at `:root`
- Checked that `/driver` and `/store/[slug]` still override via inline style (unchanged) — per-tenant primary color on storefront is preserved
- Grep verified `.admin-scope` untouched; admin-scope still uses its own `--admin-color-primary: #2563EB` (Hamza's PR will unify)

## i18n keys required
None. This is a CSS-only change.

## Why DRAFT

Opened as DRAFT per brief guidance because the `--background` change from `#FFFFFF` to `#F8F9FA` is flagged in the brief blockers list (item #3) as needing founder awareness before merchant pages pick up the new page-canvas colour. All dashboard routes already use `bg-[#FAFAF9]` on their own wrappers so this change is cosmetically near-zero in practice — but the cascade now applies to any page that falls through to `body { @apply bg-background }` (most auth routes, a few edge cases). If PM confirms the brief is green-lit (already implied by the dispatch message), flip to ready-for-review.

Tag: @Anas for Gate A–F review + new brief §5.5 checks.
