### PR TITLE
feat(merchant): merchant refresh PR #4 — Finances + Paramètres + Support (4/4)

### DIFF
--- a/app/dashboard/boutique/BoutiqueForm.tsx
+++ b/app/dashboard/boutique/BoutiqueForm.tsx
@@ -244,13 +244,13 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
       role="switch"
       aria-checked={checked}
       onClick={onChange}
-      className={`relative w-11 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 ${
-        checked ? 'bg-[#16A34A]' : 'bg-[#E2E8F0]'
+      className={`relative w-11 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${
+        checked ? 'bg-success' : 'bg-border'
       }`}
       data-testid={testId}
     >
       <span
-        className={`absolute top-0.5 start-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+        className={`absolute top-0.5 start-0.5 w-5 h-5 bg-card rounded-full shadow transition-transform ${
           checked ? 'translate-x-5' : 'translate-x-0'
         }`}
       />
@@ -259,51 +259,52 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
 
   // ─── Shared sections ─────────────────────────────────────────────────────
 
+  // design-refresh §2.3 card + §2.2 inputs — all inputs share border-border / focus ring.
   const identitySection = (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <h2 className="text-base font-semibold text-[#1C1917] pb-3 mb-4 border-b border-[#E2E8F0]">
+    <div className="bg-card rounded-xl shadow-card p-6">
+      <h2 className="text-base font-semibold text-foreground pb-3 mb-4 border-b border-border">
         {t('identityTitle')}
       </h2>
       <div className="space-y-4">
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">{t('storeName')}</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1.5">{t('storeName')}</label>
           <input
             type="text"
             value={storeName}
             onChange={(e) => setStoreName(e.target.value)}
-            className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+            className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             data-testid="merchant-boutique-store-name-input"
           />
         </div>
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">{t('storeSlug')}</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1.5">{t('storeSlug')}</label>
           <input
             type="text"
             value={storeSlug}
             onChange={(e) =>
               setStoreSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'))
             }
-            className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+            className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             data-testid="merchant-boutique-store-slug-input"
           />
-          <p className="text-xs text-[#78716C] mt-1.5">plaza.ma/store/{storeSlug}</p>
+          <p className="text-xs text-muted-foreground mt-1.5">plaza.ma/store/{storeSlug}</p>
         </div>
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">{t('description')}</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1.5">{t('description')}</label>
           <textarea
             rows={3}
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            className="w-full px-3 py-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] resize-none"
+            className="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring resize-none"
             data-testid="merchant-boutique-description-textarea"
           />
         </div>
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">{t('category')}</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1.5">{t('category')}</label>
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+            className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring bg-card"
             data-testid="merchant-boutique-category-select"
           >
             <option value="" disabled>Choisir une catégorie…</option>
@@ -315,10 +316,10 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           </select>
         </div>
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">
+          <label className="block text-[13px] font-medium text-foreground mb-1.5">
             Localisation de la boutique
           </label>
-          <p className="text-xs text-[#78716C] mb-2">
+          <p className="text-xs text-muted-foreground mb-2">
             Cliquez sur la carte pour épingler l&apos;adresse exacte de votre boutique.
           </p>
           <MapboxLocationPicker
@@ -330,13 +331,13 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             }}
           />
           {locationLat && locationLng && (
-            <p className="text-xs text-[#16A34A] mt-1.5">
+            <p className="text-xs text-success mt-1.5">
               ✓ Position enregistrée ({locationLat.toFixed(5)}, {locationLng.toFixed(5)})
             </p>
           )}
         </div>
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-1.5">
+          <label className="block text-[13px] font-medium text-foreground mb-1.5">
             Indications supplémentaires
           </label>
           <input
@@ -344,7 +345,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             value={locationDescription}
             onChange={(e) => setLocationDescription(e.target.value)}
             placeholder="Ex: 2ème étage, porte bleue, en face du café..."
-            className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+            className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             data-testid="merchant-boutique-location-description-input"
           />
         </div>
@@ -353,14 +354,14 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   );
 
   const appearanceSection = (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <h2 className="text-base font-semibold text-[#1C1917] pb-3 mb-4 border-b border-[#E2E8F0]">
+    <div className="bg-card rounded-xl shadow-card p-6">
+      <h2 className="text-base font-semibold text-foreground pb-3 mb-4 border-b border-border">
         {t('appearanceTitle')}
       </h2>
       <div className="space-y-5">
         {/* Logo */}
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-2">{t('logo')}</label>
+          <label className="block text-[13px] font-medium text-foreground mb-2">{t('logo')}</label>
           <input
             ref={logoInputRef}
             type="file"
@@ -374,15 +375,15 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           />
           <div
             onClick={() => !uploadingLogo && logoInputRef.current?.click()}
-            className="w-[120px] h-[120px] border-2 border-dashed border-[#E2E8F0] rounded-xl flex flex-col items-center justify-center cursor-pointer hover:border-[var(--color-primary)] transition-colors overflow-hidden"
+            className="w-[120px] h-[120px] border-2 border-dashed border-border rounded-xl flex flex-col items-center justify-center cursor-pointer hover:border-primary transition-colors overflow-hidden"
           >
             {logoUrl ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img src={logoUrl} alt="" className="w-full h-full object-cover" />
             ) : (
               <>
-                <Camera className="w-7 h-7 text-[#78716C] mb-1" />
-                <span className="text-[12px] text-[#78716C]">
+                <Camera className="w-7 h-7 text-muted-foreground mb-1" />
+                <span className="text-[12px] text-muted-foreground">
                   {uploadingLogo ? t('uploading') : t('addLogo')}
                 </span>
               </>
@@ -390,9 +391,11 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           </div>
         </div>
 
-        {/* Color */}
+        {/* Color — user-facing brand color picker; hex values are *data* (tenant
+            primary_color), not design tokens. Border of the selected swatch
+            uses the foreground token so it reads on any swatch colour. */}
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-2">{t('primaryColor')}</label>
+          <label className="block text-[13px] font-medium text-foreground mb-2">{t('primaryColor')}</label>
           <div className="flex gap-2 flex-wrap">
             {COLOR_OPTIONS.map((opt) => (
               <button
@@ -400,14 +403,12 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                 type="button"
                 onClick={() => setPrimaryColor(opt.value)}
                 title={opt.name}
-                className="w-10 h-10 rounded-lg transition-all hover:scale-110"
-                style={{
-                  backgroundColor: opt.value,
-                  border:
-                    primaryColor === opt.value
-                      ? '2.5px solid #1C1917'
-                      : '2px solid transparent',
-                }}
+                className={`w-10 h-10 rounded-lg transition-all hover:scale-110 ${
+                  primaryColor === opt.value
+                    ? 'ring-[2.5px] ring-foreground'
+                    : 'ring-2 ring-transparent'
+                }`}
+                style={{ backgroundColor: opt.value }}
                 data-testid={`merchant-boutique-color-${opt.value.replace('#', '').toLowerCase()}-btn`}
               />
             ))}
@@ -416,7 +417,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
 
         {/* Banner */}
         <div>
-          <label className="block text-[13px] font-medium text-[#1C1917] mb-2">{t('banner')}</label>
+          <label className="block text-[13px] font-medium text-foreground mb-2">{t('banner')}</label>
           <input
             ref={bannerInputRef}
             type="file"
@@ -430,15 +431,15 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           />
           <div
             onClick={() => !uploadingBanner && bannerInputRef.current?.click()}
-            className="w-full h-[140px] border-2 border-dashed border-[#E2E8F0] rounded-xl flex flex-col items-center justify-center cursor-pointer hover:border-[var(--color-primary)] transition-colors overflow-hidden"
+            className="w-full h-[140px] border-2 border-dashed border-border rounded-xl flex flex-col items-center justify-center cursor-pointer hover:border-primary transition-colors overflow-hidden"
           >
             {bannerUrl ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img src={bannerUrl} alt="" className="w-full h-full object-cover" />
             ) : (
               <>
-                <ImageIcon className="w-7 h-7 text-[#78716C] mb-1" />
-                <span className="text-[12px] text-[#78716C]">
+                <ImageIcon className="w-7 h-7 text-muted-foreground mb-1" />
+                <span className="text-[12px] text-muted-foreground">
                   {uploadingBanner ? t('uploading') : t('addBanner')}
                 </span>
               </>
@@ -450,17 +451,17 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   );
 
   const deliverySection = (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <h2 className="text-base font-semibold text-[#1C1917] pb-3 mb-4 border-b border-[#E2E8F0]">
+    <div className="bg-card rounded-xl shadow-card p-6">
+      <h2 className="text-base font-semibold text-foreground pb-3 mb-4 border-b border-border">
         {t('deliveryTitle')}
       </h2>
 
-      {/* Info box */}
-      <div className="rounded-lg p-3 mb-5 flex gap-3" style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, white)' }}>
-        <Info className="w-5 h-5 flex-shrink-0 mt-0.5" style={{ color: 'var(--color-primary)' }} />
+      {/* Info box — design-refresh §2.8 primary-tint badge pattern. */}
+      <div className="rounded-lg p-3 mb-5 flex gap-3 bg-primary/10">
+        <Info className="w-5 h-5 flex-shrink-0 mt-0.5 text-primary" />
         <div>
-          <p className="text-[13px] font-semibold text-[#1C1917] mb-1">{t('deliveryHowTitle')}</p>
-          <div className="space-y-0.5 text-xs text-[#78716C] leading-relaxed">
+          <p className="text-[13px] font-semibold text-foreground mb-1">{t('deliveryHowTitle')}</p>
+          <div className="space-y-0.5 text-xs text-muted-foreground leading-relaxed">
             <p>• {t('deliveryHow1')}</p>
             <p>• {t('deliveryHow2')}</p>
             <p>• {t('deliveryHow3')}</p>
@@ -469,11 +470,11 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
       </div>
 
       {/* Free delivery toggle */}
-      <div className="border-b border-[#F1F5F9] pb-4">
+      <div className="border-b border-border pb-4">
         <div className="flex items-center justify-between h-12">
           <div>
-            <div className="text-sm font-medium text-[#1C1917]">{t('freeDeliveryToggle')}</div>
-            <div className="text-xs text-[#78716C] mt-0.5">{t('freeDeliverySubtitle')}</div>
+            <div className="text-sm font-medium text-foreground">{t('freeDeliveryToggle')}</div>
+            <div className="text-xs text-muted-foreground mt-0.5">{t('freeDeliverySubtitle')}</div>
           </div>
           <Toggle
             checked={freeDeliveryEnabled}
@@ -484,7 +485,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
 
         {freeDeliveryEnabled && (
           <div className="pt-4 mt-4">
-            <label className="block text-[13px] font-medium text-[#1C1917] mb-2">
+            <label className="block text-[13px] font-medium text-foreground mb-2">
               {t('freeDeliveryLabel')}
             </label>
             <div className="flex items-center gap-2 mb-3">
@@ -492,34 +493,34 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                 type="number"
                 value={freeDeliveryThreshold}
                 onChange={(e) => setFreeDeliveryThreshold(e.target.value)}
-                className="w-[120px] h-12 px-3 text-center text-xl font-semibold border-2 border-[#E2E8F0] rounded-lg focus:outline-none focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20"
+                className="w-[120px] h-12 px-3 text-center text-xl font-semibold border-2 border-border rounded-lg focus:outline-none focus:border-ring focus:ring-2 focus:ring-ring/20"
                 data-testid="merchant-boutique-free-delivery-threshold-input"
               />
-              <span className="text-base text-[#78716C]">MAD</span>
+              <span className="text-base text-muted-foreground">MAD</span>
             </div>
-            {/* Preview */}
-            <div className="bg-[#F0FDF4] border border-[#BBF7D0] rounded-lg p-3">
+            {/* Preview — §2.8 success-tint info card. */}
+            <div className="bg-success/10 border border-success/30 rounded-lg p-3">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
-                  <ShoppingCart className="w-4 h-4 text-[#78716C]" />
-                  <span className="text-[13px] text-[#1C1917]">
+                  <ShoppingCart className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-[13px] text-foreground">
                     {t('freeDeliveryBelow', { amount: freeDeliveryThreshold })}
                   </span>
                 </div>
-                <span className="text-[13px] text-[#78716C]">{t('freeDeliveryClientPays')}</span>
+                <span className="text-[13px] text-muted-foreground">{t('freeDeliveryClientPays')}</span>
               </div>
-              <div className="border-t border-[#D1FAE5] my-2" />
+              <div className="border-t border-success/20 my-2" />
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <CheckCircle className="w-4 h-4 text-[#16A34A]" />
-                  <span className="text-[13px] text-[#1C1917]">
+                  <CheckCircle className="w-4 h-4 text-success" />
+                  <span className="text-[13px] text-foreground">
                     {t('freeDeliveryAbove', { amount: freeDeliveryThreshold })}
                   </span>
                 </div>
-                <span className="text-[13px] font-semibold text-[#16A34A]">{t('freeDeliveryFree')}</span>
+                <span className="text-[13px] font-semibold text-success">{t('freeDeliveryFree')}</span>
               </div>
-              <div className="mt-2 pt-2 border-t border-[#D1FAE5]">
-                <p className="text-xs text-[#78716C] italic">{t('freeDeliveryNote')}</p>
+              <div className="mt-2 pt-2 border-t border-success/20">
+                <p className="text-xs text-muted-foreground italic">{t('freeDeliveryNote')}</p>
               </div>
             </div>
           </div>
@@ -528,9 +529,9 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
 
       {/* Revenue impact */}
       <div className="mt-5">
-        <label className="block text-sm font-medium text-[#1C1917] mb-3">{t('revenueImpact')}</label>
-        <div className="bg-[#FAFAF9] border border-[#E2E8F0] rounded-lg p-4">
-          <p className="text-xs text-[#78716C] uppercase tracking-wide mb-2.5">
+        <label className="block text-sm font-medium text-foreground mb-3">{t('revenueImpact')}</label>
+        <div className="bg-background border border-border rounded-lg p-4">
+          <p className="text-xs text-muted-foreground uppercase tracking-wide mb-2.5">
             {t('revenueExample', { price: ex1Price })}
           </p>
           <div className="space-y-2 mb-2">
@@ -538,28 +539,28 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
               <span>{t('revenueProducts')}</span>
               <span>{ex1Price} MAD</span>
             </div>
-            <div className="flex justify-between text-sm text-[#DC2626]">
+            <div className="flex justify-between text-sm text-destructive">
               <span>{t('revenueCommission')}</span>
               <span>- {ex1Commission.toFixed(2)} MAD</span>
             </div>
             <div className="flex flex-col gap-0.5">
-              <div className="flex justify-between text-sm text-[#78716C]">
+              <div className="flex justify-between text-sm text-muted-foreground">
                 <span>{t('revenueDeliveryFee')}</span>
                 <span>+ 30 MAD</span>
               </div>
-              <p className="text-[11px] text-[#A8A29E] italic text-right">{t('revenueDeliveryNote')}</p>
+              <p className="text-[11px] text-muted-foreground italic text-right">{t('revenueDeliveryNote')}</p>
             </div>
           </div>
-          <div className="border-t border-[#E2E8F0] my-2" />
+          <div className="border-t border-border my-2" />
           <div className="flex justify-between text-sm font-semibold">
-            <span className="text-[#1C1917]">{t('revenueNet')}</span>
-            <span className="text-[#16A34A]">{ex1Revenue.toFixed(2)} MAD</span>
+            <span className="text-foreground">{t('revenueNet')}</span>
+            <span className="text-success">{ex1Revenue.toFixed(2)} MAD</span>
           </div>
 
           {freeDeliveryEnabled && (
             <>
               <div className="my-3 text-center">
-                <p className="text-xs text-[#78716C]">
+                <p className="text-xs text-muted-foreground">
                   {t('revenueIfFreeDelivery', { threshold: freeDeliveryThreshold })}
                 </p>
               </div>
@@ -568,19 +569,19 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                   <span>{t('revenueProducts')}</span>
                   <span>{ex2Price} MAD</span>
                 </div>
-                <div className="flex justify-between text-sm text-[#DC2626]">
+                <div className="flex justify-between text-sm text-destructive">
                   <span>{t('revenueCommission')}</span>
                   <span>- {ex2Commission.toFixed(2)} MAD</span>
                 </div>
-                <div className="flex justify-between text-sm text-[#DC2626]">
+                <div className="flex justify-between text-sm text-destructive">
                   <span>{t('revenueDeliveryAbsorbed')}</span>
                   <span>- 30 MAD</span>
                 </div>
               </div>
-              <div className="border-t border-[#E2E8F0] my-2" />
+              <div className="border-t border-border my-2" />
               <div className="flex justify-between text-sm font-semibold">
-                <span className="text-[#1C1917]">{t('revenueNet')}</span>
-                <span className="text-[#16A34A]">{ex2Revenue.toFixed(2)} MAD</span>
+                <span className="text-foreground">{t('revenueNet')}</span>
+                <span className="text-success">{ex2Revenue.toFixed(2)} MAD</span>
               </div>
             </>
           )}
@@ -590,16 +591,16 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   );
 
   const statusSection = (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <h2 className="text-base font-semibold text-[#1C1917] pb-3 mb-4 border-b border-[#E2E8F0]">
+    <div className="bg-card rounded-xl shadow-card p-6">
+      <h2 className="text-base font-semibold text-foreground pb-3 mb-4 border-b border-border">
         {t('statusTitle')}
       </h2>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <span className="text-sm text-[#1C1917]">{t('storeOnlineLabel')}</span>
+          <span className="text-sm text-foreground">{t('storeOnlineLabel')}</span>
           <span
             className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${
-              isOnline ? 'bg-[#F0FDF4] text-[#16A34A]' : 'bg-[#FEF2F2] text-[#DC2626]'
+              isOnline ? 'bg-success/10 text-success' : 'bg-destructive/10 text-destructive'
             }`}
           >
             {isOnline ? t('online') : t('offline')}
@@ -612,27 +613,27 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
         />
       </div>
       {!isOnline && (
-        <p className="text-xs text-[#78716C] mt-2">{t('offlineNote')}</p>
+        <p className="text-xs text-muted-foreground mt-2">{t('offlineNote')}</p>
       )}
     </div>
   );
 
   const paymentModesSection = (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <h2 className="text-base font-semibold text-[#1C1917] pb-3 mb-4 border-b border-[#E2E8F0]">
+    <div className="bg-card rounded-xl shadow-card p-6">
+      <h2 className="text-base font-semibold text-foreground pb-3 mb-4 border-b border-border">
         Modes de paiement acceptés
       </h2>
       <div className="space-y-3">
         <div className="flex items-center justify-between py-2">
-          <span className="text-sm text-[#1C1917]">Paiement à la livraison (espèces)</span>
+          <span className="text-sm text-foreground">Paiement à la livraison (espèces)</span>
           <div className="flex items-center gap-2">
-            <CheckCircle className="w-4 h-4 text-[#16A34A]" />
-            <span className="text-xs font-medium text-[#16A34A]">Activé</span>
+            <CheckCircle className="w-4 h-4 text-success" />
+            <span className="text-xs font-medium text-success">Activé</span>
           </div>
         </div>
 
-        <div className="flex items-center justify-between py-2 border-t border-[#F1F5F9]">
-          <span className="text-sm text-[#1C1917]">Terminal carte</span>
+        <div className="flex items-center justify-between py-2 border-t border-border">
+          <span className="text-sm text-foreground">Terminal carte</span>
           <Toggle
             checked={terminalEnabled}
             onChange={() => {
@@ -644,17 +645,17 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           />
         </div>
 
-        <div className="flex items-center justify-between py-2 border-t border-[#F1F5F9]">
-          <span className="text-sm text-[#1C1917]">Carte en ligne (CMI)</span>
+        <div className="flex items-center justify-between py-2 border-t border-border">
+          <span className="text-sm text-foreground">Carte en ligne (CMI)</span>
           {merchant.cmi_enabled ? (
             <div className="flex items-center gap-2">
-              <CheckCircle className="w-4 h-4 text-[#16A34A]" />
-              <span className="text-xs font-medium text-[#16A34A]">Activé par Plaza</span>
+              <CheckCircle className="w-4 h-4 text-success" />
+              <span className="text-xs font-medium text-success">Activé par Plaza</span>
             </div>
           ) : (
             <div className="flex items-center gap-2">
-              <Lock className="w-4 h-4 text-[#A8A29E]" />
-              <span className="text-xs font-medium text-[#78716C]">Non activé</span>
+              <Lock className="w-4 h-4 text-muted-foreground" />
+              <span className="text-xs font-medium text-muted-foreground">Non activé</span>
             </div>
           )}
         </div>
@@ -664,13 +665,15 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
 
   const previewPanel = (
     <div className="hidden md:block w-[300px] flex-shrink-0">
-      <div className="bg-white rounded-xl shadow-sm p-4 sticky top-8">
-        <h3 className="text-xs font-semibold text-[#78716C] uppercase tracking-wide mb-4">
+      <div className="bg-card rounded-xl shadow-card p-4 sticky top-8">
+        <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-4">
           {t('previewTitle')}
         </h3>
 
-        {/* Phone mockup */}
-        <div className="w-[220px] mx-auto border-2 border-[#E2E8F0] rounded-3xl overflow-hidden mb-3">
+        {/* Phone mockup — the interior card colour stays `bg-white` for the
+            mini preview of the storefront (always light irrespective of our
+            dashboard tokens). The header bar is tenant primaryColor (data). */}
+        <div className="w-[220px] mx-auto border-2 border-border rounded-3xl overflow-hidden mb-3">
           <div className="bg-white h-[380px] overflow-hidden">
             <div
               className="h-14 flex items-center px-4 gap-3"
@@ -682,9 +685,9 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             <div className="p-3 grid grid-cols-2 gap-2">
               {[1, 2, 3, 4].map((i) => (
                 <div key={i} className="space-y-1">
-                  <div className="aspect-square bg-[#F5F5F4] rounded-lg" />
-                  <div className="h-2 bg-[#F5F5F4] rounded w-3/4" />
-                  <div className="h-2 bg-[#F5F5F4] rounded w-1/2" />
+                  <div className="aspect-square bg-muted rounded-lg" />
+                  <div className="h-2 bg-muted rounded w-3/4" />
+                  <div className="h-2 bg-muted rounded w-1/2" />
                 </div>
               ))}
             </div>
@@ -692,23 +695,23 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
         </div>
 
         {/* Store link */}
-        <div className="mt-3 pt-3 border-t border-[#E2E8F0]">
-          <h4 className="text-xs font-semibold text-[#78716C] uppercase tracking-wide mb-2">
+        <div className="mt-3 pt-3 border-t border-border">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
             {t('storeLink')}
           </h4>
           <div className="flex items-center gap-2">
-            <span className="text-sm text-[#1C1917] flex-1 truncate">
+            <span className="text-sm text-foreground flex-1 truncate">
               plaza.ma/store/{storeSlug}
             </span>
             <button
               type="button"
               onClick={copyLink}
-              className="p-1.5 hover:bg-[#F8FAFC] rounded transition-colors"
+              className="p-1.5 hover:bg-muted rounded transition-colors"
             >
               {copied ? (
-                <Check className="w-4 h-4 text-[#16A34A]" />
+                <Check className="w-4 h-4 text-success" />
               ) : (
-                <Copy className="w-4 h-4 text-[#78716C]" />
+                <Copy className="w-4 h-4 text-muted-foreground" />
               )}
             </button>
           </div>
@@ -716,8 +719,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             href={`/store/${storeSlug}`}
             target="_blank"
             rel="noreferrer"
-            className="mt-2 text-[13px] hover:underline flex items-center gap-1"
-            style={{ color: 'var(--color-primary)' }}
+            className="mt-2 text-[13px] hover:underline flex items-center gap-1 text-primary"
           >
             <ExternalLink className="w-3.5 h-3.5" />
             {t('viewStore')}
@@ -734,12 +736,13 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
   // save-button row, fixing SAAD-003 (indicator invisible on desktop).
   return (
     <>
-      <div className="bg-[#FAFAF9] min-h-screen pb-40 md:pb-0">
+      {/* design-refresh §3.1 — canvas is `bg-background` (#F8F9FA). */}
+      <div className="bg-background min-h-screen pb-40 md:pb-0">
         {/* Top bar — mobile: compact h-14 with text link.
                       desktop: bordered ExternalLink button. */}
-        <div className="bg-white md:bg-transparent h-14 md:h-auto px-4 md:px-0 flex items-center justify-between border-b md:border-b-0 border-[#E2E8F0] md:pt-8 md:mb-6 md:max-w-[1280px] md:mx-auto md:w-full md:px-8">
-          <h1 className="text-base md:text-2xl font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
-          {/* Mobile variant: plain text link. */}
+        <div className="bg-card md:bg-transparent h-14 md:h-auto px-4 md:px-0 flex items-center justify-between border-b md:border-b-0 border-border md:pt-8 md:mb-6 md:max-w-[1280px] md:mx-auto md:w-full md:px-8">
+          <h1 className="text-base md:text-2xl font-semibold text-foreground">{t('pageTitle')}</h1>
+          {/* Mobile variant: plain text link. Tenant primary via CSS var.    */}
           <a
             href={`/store/${storeSlug}`}
             target="_blank"
@@ -749,7 +752,9 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           >
             {t('viewStore')}
           </a>
-          {/* Desktop variant: bordered button with ExternalLink icon. */}
+          {/* Desktop variant: bordered button with ExternalLink icon. Uses
+              tenant `--color-primary` so it matches the storefront
+              per-tenant colour the merchant configures below. */}
           <a
             href={`/store/${storeSlug}`}
             target="_blank"
@@ -765,17 +770,17 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
         </div>
 
         {/* Mobile-only link preview card (desktop has it inside the preview panel). */}
-        <div className="md:hidden bg-white mx-4 mt-4 rounded-xl shadow-sm p-4">
-          <p className="text-xs text-[#78716C] uppercase mb-1">{t('storeLink')}</p>
+        <div className="md:hidden bg-card mx-4 mt-4 rounded-xl shadow-card p-4">
+          <p className="text-xs text-muted-foreground uppercase mb-1">{t('storeLink')}</p>
           <div className="flex items-center gap-2">
             <span className="text-sm flex-1 truncate" style={{ color: 'var(--color-primary)' }}>
               plaza.ma/store/{storeSlug}
             </span>
             <button type="button" onClick={copyLink} className="p-1.5">
               {copied ? (
-                <Check className="w-4 h-4 text-[#16A34A]" />
+                <Check className="w-4 h-4 text-success" />
               ) : (
-                <Copy className="w-4 h-4 text-[#78716C]" />
+                <Copy className="w-4 h-4 text-muted-foreground" />
               )}
             </button>
           </div>
@@ -799,7 +804,9 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                 so the save bar sits at `bottom-16` to stack above it. Z-index
                 stays below MobileNav's z-50 so the nav's shadow doesn't bleed
                 over the save bar; the vertical offset prevents occlusion. */}
-            <div className="fixed md:static bottom-16 md:bottom-0 start-0 end-0 z-10 bg-white md:bg-transparent border-t md:border-t-0 border-[#E2E8F0] p-4 md:p-0 md:pt-2 flex flex-col-reverse md:flex-row md:items-center md:gap-4">
+            {/* Save bar — tenant `--color-primary` var kept intact for PLZ-088
+                mobile fix. Surface colour swapped to `bg-card`. */}
+            <div className="fixed md:static bottom-16 md:bottom-0 start-0 end-0 z-10 bg-card md:bg-transparent border-t md:border-t-0 border-border p-4 md:p-0 md:pt-2 flex flex-col-reverse md:flex-row md:items-center md:gap-4">
               <button
                 type="button"
                 onClick={handleSave}
@@ -811,7 +818,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
                 {isPending ? t('saving') : t('save')}
               </button>
               {savedIndicator && (
-                <span className="text-center md:text-start text-sm font-medium text-[#16A34A] mb-2 md:mb-0">
+                <span className="text-center md:text-start text-sm font-medium text-success mb-2 md:mb-0">
                   Enregistré ✓
                 </span>
               )}
@@ -831,22 +838,21 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
           aria-labelledby="incomplete-modal-title"
           data-testid="merchant-boutique-incomplete-dialog"
         >
-          <div className="w-full max-w-sm bg-white rounded-2xl shadow-xl p-6">
+          <div className="w-full max-w-sm bg-card rounded-2xl shadow-xl p-6">
             <h2
               id="incomplete-modal-title"
-              className="text-base font-semibold text-[#1C1917] mb-4"
+              className="text-base font-semibold text-foreground mb-4"
             >
               Complétez d&apos;abord ces étapes :
             </h2>
             <ul className="space-y-2 mb-6">
               {missingItems.map((item) => (
                 <li key={item.label} className="flex items-center gap-2">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[#DC2626] flex-shrink-0 mt-0.5" />
+                  <span className="w-1.5 h-1.5 rounded-full bg-destructive flex-shrink-0 mt-0.5" />
                   <a
                     href={item.href}
                     onClick={() => setShowIncompleteModal(false)}
-                    className="text-sm hover:underline"
-                    style={{ color: 'var(--color-primary)' }}
+                    className="text-sm hover:underline text-primary"
                   >
                     {item.label}
                   </a>
@@ -856,7 +862,7 @@ export function BoutiqueForm({ merchant, deliveryZones }: Props) {
             <button
               type="button"
               onClick={() => setShowIncompleteModal(false)}
-              className="w-full h-10 rounded-xl border border-[#E2E8F0] text-sm font-medium text-[#1C1917] hover:bg-[#F8FAFC] transition-colors"
+              className="w-full h-10 rounded-xl border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors"
               data-testid="merchant-boutique-incomplete-close-btn"
             >
               Fermer

--- a/app/dashboard/boutique/DeliveryZones.tsx
+++ b/app/dashboard/boutique/DeliveryZones.tsx
@@ -11,40 +11,35 @@ type Props = {
 
 export function DeliveryZones({ initialZones: _initialZones }: Props) {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <h2 className="text-base font-semibold text-[#1C1917] pb-3 mb-4 border-b border-[#E2E8F0]">
+    <div className="bg-card rounded-xl shadow-card p-6">
+      <h2 className="text-base font-semibold text-foreground pb-3 mb-4 border-b border-border">
         Zones de livraison
       </h2>
 
       <div className="flex items-start gap-2 mb-4">
-        <MapPin className="w-4 h-4 flex-shrink-0 mt-0.5" style={{ color: 'var(--color-primary)' }} />
-        <p className="text-sm text-[#78716C]">
+        <MapPin className="w-4 h-4 flex-shrink-0 mt-0.5 text-primary" />
+        <p className="text-sm text-muted-foreground">
           Plaza livre actuellement dans ces villes :
         </p>
       </div>
 
+      {/* design-refresh §2.8 — info badge uses primary tint. */}
       <div className="flex flex-wrap gap-2 mb-5">
         {PLAZA_CITIES.map((city) => (
           <span
             key={city}
-            className="px-3 py-1.5 rounded-full text-sm font-medium"
-            style={{
-              backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, white)',
-              color: 'var(--color-primary)',
-              border: '1px solid color-mix(in srgb, var(--color-primary) 30%, transparent)',
-            }}
+            className="px-3 py-1.5 rounded-full text-sm font-medium bg-primary/10 text-primary border border-primary/30"
           >
             {city}
           </span>
         ))}
       </div>
 
-      <div className="bg-[#FAFAF9] border border-[#E2E8F0] rounded-lg p-3 text-sm text-[#78716C]">
+      <div className="bg-background border border-border rounded-lg p-3 text-sm text-muted-foreground">
         Vous souhaitez une nouvelle ville ?{' '}
         <a
           href="/dashboard/support"
-          className="hover:underline font-medium"
-          style={{ color: 'var(--color-primary)' }}
+          className="hover:underline font-medium text-primary"
         >
           Contactez-nous.
         </a>

--- a/app/dashboard/boutique/WorkingHoursSection.tsx
+++ b/app/dashboard/boutique/WorkingHoursSection.tsx
@@ -86,14 +86,15 @@ export function WorkingHoursSection({ initialHours }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <h2 className="text-base font-semibold text-[#1C1917] pb-3 mb-4 border-b border-[#E2E8F0]">
+    <div className="bg-card rounded-xl shadow-card p-6">
+      <h2 className="text-base font-semibold text-foreground pb-3 mb-4 border-b border-border">
         Horaires d&apos;ouverture
       </h2>
 
-      {/* Schema error banner — shown only if save fails unexpectedly */}
+      {/* Schema error banner — shown only if save fails unexpectedly.
+          design-refresh §2.7 toast/banner warning pattern. */}
       {schemaPending && (
-        <div className="bg-amber-50 border border-amber-300 rounded-lg p-3 text-sm text-amber-900 mb-4">
+        <div className="bg-warning/10 border border-warning/30 rounded-lg p-3 text-sm text-warning mb-4">
           ℹ️ Les horaires ne peuvent pas être sauvegardés pour le moment. Veuillez réessayer.
         </div>
       )}
@@ -105,9 +106,9 @@ export function WorkingHoursSection({ initialHours }: Props) {
           id="sameForAll"
           checked={sameForAll}
           onChange={(e) => handleSameForAll(e.target.checked)}
-          className="w-4 h-4 rounded border-[#E2E8F0] text-[var(--color-primary)] focus:ring-[var(--color-primary)]"
+          className="w-4 h-4 rounded border-border text-primary focus:ring-ring"
         />
-        <label htmlFor="sameForAll" className="text-sm text-[#1C1917] cursor-pointer select-none">
+        <label htmlFor="sameForAll" className="text-sm text-foreground cursor-pointer select-none">
           Mêmes horaires tous les jours
         </label>
       </div>
@@ -118,48 +119,48 @@ export function WorkingHoursSection({ initialHours }: Props) {
           const day = hours[key] ?? DEFAULT_HOURS[key] ?? { open: false, from: '', to: '' };
           return (
             <div key={key} className="flex items-center gap-3 flex-wrap">
-              {/* Toggle */}
+              {/* Toggle — brief §2.2 switch, success-on when open. */}
               <button
                 type="button"
                 role="switch"
                 aria-checked={day.open}
                 onClick={() => updateDay(key, { open: !day.open })}
-                className={`relative w-10 h-5 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 flex-shrink-0 ${
-                  day.open ? 'bg-[#16A34A]' : 'bg-[#E2E8F0]'
+                className={`relative w-10 h-5 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0 ${
+                  day.open ? 'bg-success' : 'bg-border'
                 }`}
               >
                 <span
-                  className={`absolute top-0.5 start-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                  className={`absolute top-0.5 start-0.5 w-4 h-4 bg-card rounded-full shadow transition-transform ${
                     day.open ? 'translate-x-5' : 'translate-x-0'
                   }`}
                 />
               </button>
 
               {/* Day label */}
-              <span className="w-[80px] text-sm font-medium text-[#1C1917] flex-shrink-0">
+              <span className="w-[80px] text-sm font-medium text-foreground flex-shrink-0">
                 {label}
               </span>
 
-              {/* Time inputs */}
+              {/* Time inputs — brief §2.2 form inputs. */}
               {day.open ? (
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-[#78716C]">De :</span>
+                  <span className="text-xs text-muted-foreground">De :</span>
                   <input
                     type="time"
                     value={day.from}
                     onChange={(e) => updateDay(key, { from: e.target.value })}
-                    className="h-8 px-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] disabled:opacity-40 disabled:cursor-not-allowed"
+                    className="h-8 px-2 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring disabled:opacity-40 disabled:cursor-not-allowed"
                   />
-                  <span className="text-xs text-[#78716C]">À :</span>
+                  <span className="text-xs text-muted-foreground">À :</span>
                   <input
                     type="time"
                     value={day.to}
                     onChange={(e) => updateDay(key, { to: e.target.value })}
-                    className="h-8 px-2 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] disabled:opacity-40 disabled:cursor-not-allowed"
+                    className="h-8 px-2 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring disabled:opacity-40 disabled:cursor-not-allowed"
                   />
                 </div>
               ) : (
-                <span className="text-xs text-[#A8A29E] italic">Fermé</span>
+                <span className="text-xs text-muted-foreground italic">Fermé</span>
               )}
             </div>
           );
@@ -167,7 +168,7 @@ export function WorkingHoursSection({ initialHours }: Props) {
       </div>
 
       {isPending && (
-        <p className="text-xs text-[#78716C] mt-3">Sauvegarde…</p>
+        <p className="text-xs text-muted-foreground mt-3">Sauvegarde…</p>
       )}
     </div>
   );

--- a/app/dashboard/boutique/loading.tsx
+++ b/app/dashboard/boutique/loading.tsx
@@ -1,14 +1,15 @@
 export default function BoutiqueLoading() {
+  // design-refresh §3.1 — canvas inherits from DashboardLayout (`bg-background`).
   return (
-    <div className="bg-[#FAFAF9] min-h-screen p-4 md:p-8 animate-pulse">
+    <div className="bg-background min-h-screen p-4 md:p-8 animate-pulse">
       <div className="max-w-[1040px] mx-auto space-y-3">
-        <div className="h-8 bg-[#E2E8F0] rounded w-48 mb-6" />
+        <div className="h-8 bg-border rounded w-48 mb-6" />
         {[1, 2, 3].map((i) => (
-          <div key={i} className="bg-white rounded-xl shadow-sm p-6">
-            <div className="h-4 bg-[#F5F5F4] rounded w-32 mb-4" />
+          <div key={i} className="bg-card rounded-xl shadow-card p-6">
+            <div className="h-4 bg-muted rounded w-32 mb-4" />
             <div className="space-y-3">
-              <div className="h-10 bg-[#F5F5F4] rounded" />
-              <div className="h-10 bg-[#F5F5F4] rounded" />
+              <div className="h-10 bg-muted rounded" />
+              <div className="h-10 bg-muted rounded" />
             </div>
           </div>
         ))}

--- a/app/dashboard/compte/CompteClient.tsx
+++ b/app/dashboard/compte/CompteClient.tsx
@@ -77,61 +77,63 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
     : initials;
 
   return (
-    <div className="bg-[#FAFAF9] min-h-screen">
+    // design-refresh §3.1 — canvas inherits the off-white `bg-background`.
+    <div className="bg-background min-h-screen">
       {/* Mobile top bar */}
-      <div className="md:hidden bg-white h-14 px-4 flex items-center justify-center border-b border-[#E2E8F0]">
-        <h1 className="text-base font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
+      <div className="md:hidden bg-card h-14 px-4 flex items-center justify-center border-b border-border">
+        <h1 className="text-base font-semibold text-foreground">{t('pageTitle')}</h1>
       </div>
 
       <div className="max-w-[640px] mx-auto px-4 py-6 md:py-10 space-y-4">
         {/* Desktop header */}
         <div className="hidden md:block mb-6">
-          <p className="text-xs text-[#78716C] mb-2">{t('breadcrumb')}</p>
-          <h1 className="text-2xl font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
+          <p className="text-xs text-muted-foreground mb-2">{t('breadcrumb')}</p>
+          <h1 className="text-2xl font-semibold text-foreground">{t('pageTitle')}</h1>
         </div>
 
-        {/* Profile card */}
-        <div className="bg-white rounded-xl shadow-sm p-6 text-center">
+        {/* Profile card — avatar uses tenant primary tint so it matches the
+            per-tenant brand colour, not the platform primary. */}
+        <div className="bg-card rounded-xl shadow-card p-6 text-center">
           <div className="w-20 h-20 rounded-full flex items-center justify-center text-2xl font-semibold mx-auto" style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, white)', color: 'var(--color-primary)' }}>
             {displayInitials || '?'}
           </div>
-          <h2 className="text-xl font-semibold text-[#1C1917] mt-3">{name || fullName}</h2>
-          <p className="text-sm text-[#78716C]">{mail}</p>
+          <h2 className="text-xl font-semibold text-foreground mt-3">{name || fullName}</h2>
+          <p className="text-sm text-muted-foreground">{mail}</p>
         </div>
 
-        {/* Form card */}
-        <div className="bg-white rounded-xl shadow-sm p-6">
-          <h3 className="text-base font-semibold text-[#1C1917] mb-4">{t('personalInfo')}</h3>
+        {/* Form card — brief §2.2 input states. */}
+        <div className="bg-card rounded-xl shadow-card p-6">
+          <h3 className="text-base font-semibold text-foreground mb-4">{t('personalInfo')}</h3>
           <div className="space-y-4">
             <div>
-              <label className="block text-[13px] text-[#78716C] mb-1.5">{t('fullName')}</label>
+              <label className="block text-[13px] text-muted-foreground mb-1.5">{t('fullName')}</label>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                 data-testid="merchant-account-full-name-input"
               />
             </div>
             <div>
-              <label className="block text-[13px] text-[#78716C] mb-1.5">{t('email')}</label>
+              <label className="block text-[13px] text-muted-foreground mb-1.5">{t('email')}</label>
               <input
                 type="email"
                 value={mail}
                 onChange={(e) => setMail(e.target.value)}
-                className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                 data-testid="merchant-account-email-input"
               />
-              <p className="text-xs text-[#78716C] mt-1">{t('emailNote')}</p>
+              <p className="text-xs text-muted-foreground mt-1">{t('emailNote')}</p>
             </div>
             <div>
-              <label className="block text-[13px] text-[#78716C] mb-1.5">{t('phone')}</label>
+              <label className="block text-[13px] text-muted-foreground mb-1.5">{t('phone')}</label>
               <input
                 type="tel"
                 dir="ltr"
                 value={tel}
                 onChange={(e) => setTel(e.target.value)}
-                className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                 data-testid="merchant-account-phone-input"
               />
             </div>
@@ -140,8 +142,7 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
             <button
               type="button"
               onClick={() => setShowPasswordForm((v) => !v)}
-              className="w-full h-12 flex items-center justify-between px-4 border border-[#E2E8F0] rounded-lg text-sm hover:bg-[#F8FAFC] transition-colors"
-              style={{ color: 'var(--color-primary)' }}
+              className="w-full h-12 flex items-center justify-between px-4 border border-border rounded-lg text-sm text-primary hover:bg-muted transition-colors"
               data-testid="merchant-account-change-password-btn"
             >
               <span>{t('changePassword')}</span>
@@ -153,34 +154,34 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
             </button>
 
             {showPasswordForm && (
-              <div className="border border-[#E2E8F0] rounded-lg p-4 space-y-3">
+              <div className="border border-border rounded-lg p-4 space-y-3">
                 <div>
-                  <label className="block text-[13px] text-[#78716C] mb-1.5">{t('newPassword')}</label>
+                  <label className="block text-[13px] text-muted-foreground mb-1.5">{t('newPassword')}</label>
                   <div className="relative">
                     <input
                       type={showPassword ? 'text' : 'password'}
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
                       placeholder={t('passwordPlaceholder')}
-                      className="w-full h-10 px-3 pr-10 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                      className="w-full h-10 px-3 pr-10 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                       data-testid="merchant-account-new-password-input"
                     />
                     <button
                       type="button"
                       onClick={() => setShowPassword((v) => !v)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-[#78716C]"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground"
                     >
                       {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                     </button>
                   </div>
-                  {passwordError && <p className="text-xs text-[#DC2626] mt-1">{passwordError}</p>}
-                  {passwordSuccess && <p className="text-xs text-[#16A34A] mt-1">{passwordSuccess}</p>}
+                  {passwordError && <p className="text-xs text-destructive mt-1">{passwordError}</p>}
+                  {passwordSuccess && <p className="text-xs text-success mt-1">{passwordSuccess}</p>}
                 </div>
                 <button
                   type="button"
                   onClick={handlePasswordSave}
                   disabled={isPasswordPending}
-                  className="h-9 px-4 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+                  className="h-9 px-4 text-primary-foreground rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
                   style={{ backgroundColor: 'var(--color-primary)' }}
                   data-testid="merchant-account-save-password-btn"
                 >
@@ -190,16 +191,16 @@ export function CompteClient({ fullName, email, phone, initials }: Props) {
             )}
           </div>
 
-          {error && <p className="text-sm text-[#DC2626] mt-3">{error}</p>}
-          {success && <p className="text-sm text-[#16A34A] mt-3">{success}</p>}
+          {error && <p className="text-sm text-destructive mt-3">{error}</p>}
+          {success && <p className="text-sm text-success mt-3">{success}</p>}
         </div>
 
-        {/* Save button */}
+        {/* Save button — tenant `--color-primary` var kept for PLZ-088. */}
         <button
           type="button"
           onClick={handleSave}
           disabled={isPending}
-          className="w-full h-11 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+          className="w-full h-11 text-primary-foreground rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
           style={{ backgroundColor: 'var(--color-primary)' }}
           data-testid="merchant-account-save-btn"
         >

--- a/app/dashboard/finances/FinancesClient.tsx
+++ b/app/dashboard/finances/FinancesClient.tsx
@@ -34,6 +34,18 @@ function formatChartDate(iso: string, period: Period): string {
   return d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', timeZone: MOROCCO_TZ });
 }
 
+// ─── Chart colour tokens ─────────────────────────────────────────────────────
+
+// Recharts `stroke`/`fill` props require raw colour strings — they do not
+// resolve CSS-variable expressions at render time. We hard-code the
+// design-refresh palette hex values here (not tenant-specific, these are
+// platform-level chart colours per brief §3.1 & §5 data-viz notes).
+const CHART_LINE_HEX = '#1A6BFF';     // design-refresh primary
+const CHART_GRID_HEX = '#E5E7EB';     // matches `--border`
+const CHART_AXIS_HEX = '#6B7280';     // matches `--muted-foreground`
+const CHART_TOOLTIP_BG_HEX = '#FFFFFF';
+const CHART_TOOLTIP_BORDER_HEX = '#E5E7EB';
+
 // ─── Payment colours ──────────────────────────────────────────────────────────
 
 // Note: PAYMENT_COLORS values are used as SVG/Recharts fill colors.
@@ -88,19 +100,20 @@ export function FinancesClient({ metrics, period }: Props) {
   const isEmpty = metrics.totalOrders === 0;
 
   const ChartPlaceholder = ({ h }: { h: string }) => (
-    <div className={`${h} bg-[#F8FAFC] rounded-lg flex items-center justify-center`}>
-      <span className="text-sm text-[#A8A29E]">{t('no_data')}</span>
+    <div className={`${h} bg-muted rounded-lg flex items-center justify-center`}>
+      <span className="text-sm text-muted-foreground">{t('no_data')}</span>
     </div>
   );
 
   return (
+    // design-refresh §3.1 — off-white canvas inherited from body (`bg-background`).
     <div className="p-4 md:p-8 max-w-[1040px] mx-auto">
 
       {/* ── Page header ──────────────────────────────────────────────────── */}
       <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <h1 className="text-2xl font-semibold text-[#1C1917]">{t('title')}</h1>
+        <h1 className="text-2xl font-semibold text-foreground">{t('title')}</h1>
 
-        {/* Period selector */}
+        {/* Period selector — brief §2.1 pill buttons. */}
         <div className="flex gap-2">
           {PERIODS.map((p) => (
             <button
@@ -108,8 +121,8 @@ export function FinancesClient({ metrics, period }: Props) {
               onClick={() => router.push(`?period=${p.id}`)}
               className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
                 period === p.id
-                  ? 'bg-[var(--color-primary)] text-white'
-                  : 'bg-white text-[#78716C] border border-[#E2E8F0] hover:bg-[#F8FAFC]'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-card text-muted-foreground border border-border hover:bg-muted'
               }`}
               data-testid={`merchant-finances-period-${p.id}-btn`}
             >
@@ -121,23 +134,23 @@ export function FinancesClient({ metrics, period }: Props) {
 
       {/* ── Stats row ─────────────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4 mb-6">
-        <div className="bg-white rounded-xl shadow-sm p-4 md:p-5 col-span-2 md:col-span-1">
-          <div className="text-[13px] text-[#78716C] mb-2">{t('stat_revenue')}</div>
-          <div className="text-xl md:text-2xl font-semibold text-[#1C1917]">
+        <div className="bg-card rounded-xl shadow-card p-4 md:p-5 col-span-2 md:col-span-1">
+          <div className="text-[13px] text-muted-foreground mb-2">{t('stat_revenue')}</div>
+          <div className="text-xl md:text-2xl font-semibold text-foreground">
             {isEmpty ? '—' : formatMAD(metrics.totalRevenue)}
           </div>
         </div>
 
-        <div className="bg-white rounded-xl shadow-sm p-4 md:p-5">
-          <div className="text-[13px] text-[#78716C] mb-2">{t('stat_orders')}</div>
-          <div className="text-xl md:text-2xl font-semibold text-[#1C1917]">
+        <div className="bg-card rounded-xl shadow-card p-4 md:p-5">
+          <div className="text-[13px] text-muted-foreground mb-2">{t('stat_orders')}</div>
+          <div className="text-xl md:text-2xl font-semibold text-foreground">
             {isEmpty ? '—' : metrics.totalOrders}
           </div>
         </div>
 
-        <div className="bg-white rounded-xl shadow-sm p-4 md:p-5">
-          <div className="text-[13px] text-[#78716C] mb-2">{t('stat_avg_basket')}</div>
-          <div className="text-xl md:text-2xl font-semibold text-[#1C1917]">
+        <div className="bg-card rounded-xl shadow-card p-4 md:p-5">
+          <div className="text-[13px] text-muted-foreground mb-2">{t('stat_avg_basket')}</div>
+          <div className="text-xl md:text-2xl font-semibold text-foreground">
             {isEmpty ? '—' : formatMAD(metrics.avgBasket)}
           </div>
         </div>
@@ -145,12 +158,12 @@ export function FinancesClient({ metrics, period }: Props) {
 
       {isEmpty ? (
         /* ── Empty state ─────────────────────────────────────────────────── */
-        <div className="bg-white rounded-xl shadow-sm py-20 text-center">
-          <BarChart3Icon className="w-12 h-12 text-[#E2E8F0] mx-auto mb-4" />
-          <h3 className="text-base font-semibold text-[#1C1917] mb-2">
+        <div className="bg-card rounded-xl shadow-card py-20 text-center">
+          <BarChart3Icon className="w-12 h-12 text-border mx-auto mb-4" />
+          <h3 className="text-base font-semibold text-foreground mb-2">
             {t('empty_title')}
           </h3>
-          <p className="text-sm text-[#78716C]">
+          <p className="text-sm text-muted-foreground">
             {t('empty_body')}
           </p>
         </div>
@@ -159,9 +172,9 @@ export function FinancesClient({ metrics, period }: Props) {
           {/* ── Desktop layout: chart + right column ─────────────────────── */}
           <div className="hidden md:flex gap-6">
 
-            {/* Revenue line chart */}
-            <div className="flex-1 bg-white rounded-xl shadow-sm p-6">
-              <h2 className="text-base font-semibold text-[#1C1917] mb-4">
+            {/* Revenue line chart — design-refresh primary blue per brief §5. */}
+            <div className="flex-1 bg-card rounded-xl shadow-card p-6">
+              <h2 className="text-base font-semibold text-foreground mb-4">
                 {t('chart_title')}
               </h2>
               <div className="h-[220px]">
@@ -170,20 +183,20 @@ export function FinancesClient({ metrics, period }: Props) {
                     <LineChart data={chartData}>
                       <defs>
                         <linearGradient id="colorRevenue" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="5%"  stopColor="#E8632A" stopOpacity={0.15} />
-                          <stop offset="95%" stopColor="#E8632A" stopOpacity={0} />
+                          <stop offset="5%"  stopColor={CHART_LINE_HEX} stopOpacity={0.15} />
+                          <stop offset="95%" stopColor={CHART_LINE_HEX} stopOpacity={0} />
                         </linearGradient>
                       </defs>
-                      <CartesianGrid strokeDasharray="3 3" stroke="#F3F4F6" />
+                      <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_HEX} />
                       <XAxis
                         dataKey="label"
-                        stroke="#78716C"
+                        stroke={CHART_AXIS_HEX}
                         fontSize={12}
                         tickLine={false}
                         axisLine={false}
                       />
                       <YAxis
-                        stroke="#78716C"
+                        stroke={CHART_AXIS_HEX}
                         fontSize={12}
                         tickLine={false}
                         axisLine={false}
@@ -191,8 +204,8 @@ export function FinancesClient({ metrics, period }: Props) {
                       />
                       <Tooltip
                         contentStyle={{
-                          backgroundColor: 'white',
-                          border: '1px solid #E2E8F0',
+                          backgroundColor: CHART_TOOLTIP_BG_HEX,
+                          border: `1px solid ${CHART_TOOLTIP_BORDER_HEX}`,
                           borderRadius: '8px',
                           fontSize: '12px',
                         }}
@@ -201,9 +214,9 @@ export function FinancesClient({ metrics, period }: Props) {
                       <Line
                         type="monotone"
                         dataKey="revenue"
-                        stroke="#E8632A"
+                        stroke={CHART_LINE_HEX}
                         strokeWidth={2}
-                        dot={{ fill: '#E8632A', r: 3 }}
+                        dot={{ fill: CHART_LINE_HEX, r: 3 }}
                         activeDot={{ r: 5 }}
                       />
                     </LineChart>
@@ -218,8 +231,8 @@ export function FinancesClient({ metrics, period }: Props) {
             <div className="w-[340px] space-y-4 flex-shrink-0">
 
               {/* Payment breakdown */}
-              <div className="bg-white rounded-xl shadow-sm p-6">
-                <h2 className="text-base font-semibold text-[#1C1917] mb-4">
+              <div className="bg-card rounded-xl shadow-card p-6">
+                <h2 className="text-base font-semibold text-foreground mb-4">
                   {t('payment_title')}
                 </h2>
                 {mounted && pieData.length > 0 ? (
@@ -244,10 +257,10 @@ export function FinancesClient({ metrics, period }: Props) {
                           </PieChart>
                         </ResponsiveContainer>
                         <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-                          <div className="text-xl font-bold text-[#1C1917]">
+                          <div className="text-xl font-bold text-foreground">
                             {metrics.totalOrders}
                           </div>
-                          <div className="text-xs text-[#78716C]">{t('orders_label')}</div>
+                          <div className="text-xs text-muted-foreground">{t('orders_label')}</div>
                         </div>
                       </div>
                     </div>
@@ -256,9 +269,9 @@ export function FinancesClient({ metrics, period }: Props) {
                         <div key={item.name} className="flex items-center justify-between">
                           <div className="flex items-center gap-2">
                             <div className="w-3 h-3 rounded-full" style={{ backgroundColor: item.color }} />
-                            <span className="text-sm text-[#1C1917]">{item.name}</span>
+                            <span className="text-sm text-foreground">{item.name}</span>
                           </div>
-                          <span className="text-sm font-semibold text-[#1C1917]">
+                          <span className="text-sm font-semibold text-foreground">
                             {item.value}%
                           </span>
                         </div>
@@ -271,25 +284,25 @@ export function FinancesClient({ metrics, period }: Props) {
               </div>
 
               {/* Top products */}
-              <div className="bg-white rounded-xl shadow-sm p-6">
-                <h2 className="text-base font-semibold text-[#1C1917] mb-3">
+              <div className="bg-card rounded-xl shadow-card p-6">
+                <h2 className="text-base font-semibold text-foreground mb-3">
                   {t('top_products_title')}
                 </h2>
                 {metrics.topProducts.length === 0 ? (
-                  <p className="text-sm text-[#78716C] text-center py-4">{t('no_products')}</p>
+                  <p className="text-sm text-muted-foreground text-center py-4">{t('no_products')}</p>
                 ) : (
                   <div>
                     {metrics.topProducts.map((p, i) => (
                       <div
                         key={p.product_id ?? p.name_fr}
-                        className={`flex items-center gap-3 py-3 -mx-3 px-3 rounded-lg hover:bg-[#F8FAFC] transition-colors ${
-                          i < metrics.topProducts.length - 1 ? 'border-b border-[#F3F4F6]' : ''
+                        className={`flex items-center gap-3 py-3 -mx-3 px-3 rounded-lg hover:bg-muted transition-colors ${
+                          i < metrics.topProducts.length - 1 ? 'border-b border-border' : ''
                         } ${p.product_id ? 'cursor-pointer' : ''}`}
                       >
-                        <div className="w-6 text-center text-sm font-semibold text-[#A8A29E]">
+                        <div className="w-6 text-center text-sm font-semibold text-muted-foreground">
                           {i + 1}
                         </div>
-                        <div className="w-10 h-10 rounded-md bg-[#F5F5F4] flex-shrink-0 overflow-hidden">
+                        <div className="w-10 h-10 rounded-md bg-muted flex-shrink-0 overflow-hidden">
                           {p.image_url && (
                             // eslint-disable-next-line @next/next/no-img-element
                             <img src={p.image_url} alt={p.name_fr} className="w-full h-full object-cover" />
@@ -299,18 +312,18 @@ export function FinancesClient({ metrics, period }: Props) {
                           {p.product_id ? (
                             <Link
                               href={`/dashboard/produits/${p.product_id}`}
-                              className="text-sm font-medium text-[#1C1917] truncate hover:text-[var(--color-primary)] block"
+                              className="text-sm font-medium text-foreground truncate hover:text-[var(--color-primary)] block"
                               data-testid="merchant-finances-top-product-link"
                               data-id={p.product_id}
                             >
                               {p.name_fr}
                             </Link>
                           ) : (
-                            <div className="text-sm font-medium text-[#1C1917] truncate">{p.name_fr}</div>
+                            <div className="text-sm font-medium text-foreground truncate">{p.name_fr}</div>
                           )}
-                          <div className="text-xs text-[#78716C]">{t('sold_count', { count: p.sold })}</div>
+                          <div className="text-xs text-muted-foreground">{t('sold_count', { count: p.sold })}</div>
                         </div>
-                        <div className="text-sm font-semibold text-[#1C1917] flex-shrink-0">
+                        <div className="text-sm font-semibold text-foreground flex-shrink-0">
                           {formatMAD(p.revenue)}
                         </div>
                       </div>
@@ -326,23 +339,23 @@ export function FinancesClient({ metrics, period }: Props) {
           <div className="md:hidden space-y-3">
 
             {/* Revenue card + chart */}
-            <div className="bg-white rounded-xl shadow-sm p-5">
-              <div className="text-[12px] text-[#78716C] uppercase mb-1">{t('stat_revenue')}</div>
-              <div className="text-[28px] font-semibold text-[#1C1917] mb-4">
+            <div className="bg-card rounded-xl shadow-card p-5">
+              <div className="text-xs text-muted-foreground uppercase mb-1">{t('stat_revenue')}</div>
+              <div className="text-[28px] font-semibold text-foreground mb-4">
                 {formatMAD(metrics.totalRevenue)}
               </div>
-              <div className="bg-[#FAFAF9] rounded-lg p-2 h-[160px]">
+              <div className="bg-background rounded-lg p-2 h-[160px]">
                 {mounted ? (
                   <ResponsiveContainer width="100%" height="100%">
                     <LineChart data={chartData} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>
                       <XAxis
                         dataKey="label"
-                        tick={{ fontSize: 11, fill: '#78716C' }}
+                        tick={{ fontSize: 11, fill: CHART_AXIS_HEX }}
                         axisLine={false}
                         tickLine={false}
                       />
                       <YAxis
-                        tick={{ fontSize: 11, fill: '#78716C' }}
+                        tick={{ fontSize: 11, fill: CHART_AXIS_HEX }}
                         axisLine={false}
                         tickLine={false}
                         width={30}
@@ -350,7 +363,7 @@ export function FinancesClient({ metrics, period }: Props) {
                       <Line
                         type="monotone"
                         dataKey="revenue"
-                        stroke="#E8632A"
+                        stroke={CHART_LINE_HEX}
                         strokeWidth={2}
                         dot={false}
                         isAnimationActive={false}
@@ -358,14 +371,14 @@ export function FinancesClient({ metrics, period }: Props) {
                     </LineChart>
                   </ResponsiveContainer>
                 ) : (
-                  <div className="h-full bg-[#F0F0EF] rounded animate-pulse" />
+                  <div className="h-full bg-muted rounded animate-pulse" />
                 )}
               </div>
             </div>
 
             {/* Payment breakdown — mobile uses custom SVG donut */}
-            <div className="bg-white rounded-xl shadow-sm p-5">
-              <h3 className="text-[16px] font-semibold text-[#1C1917] mb-4">
+            <div className="bg-card rounded-xl shadow-card p-5">
+              <h3 className="text-base font-semibold text-foreground mb-4">
                 {t('payment_title')}
               </h3>
               {pieData.length > 0 ? (
@@ -376,9 +389,9 @@ export function FinancesClient({ metrics, period }: Props) {
                       <div key={item.name} className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
                           <div className="w-3 h-3 rounded-full" style={{ backgroundColor: item.color }} />
-                          <span className="text-[14px] text-[#1C1917]">{item.name}</span>
+                          <span className="text-sm text-foreground">{item.name}</span>
                         </div>
-                        <span className="text-[14px] font-semibold text-[#1C1917]">
+                        <span className="text-sm font-semibold text-foreground">
                           {item.value}%
                         </span>
                       </div>
@@ -386,33 +399,33 @@ export function FinancesClient({ metrics, period }: Props) {
                   </div>
                 </>
               ) : (
-                <p className="text-sm text-center text-[#78716C] py-8">{t('no_data')}</p>
+                <p className="text-sm text-center text-muted-foreground py-8">{t('no_data')}</p>
               )}
             </div>
 
             {/* Top products */}
-            <div className="bg-white rounded-xl shadow-sm p-4">
-              <h3 className="text-[16px] font-semibold text-[#1C1917] mb-3">{t('top_products_title')}</h3>
+            <div className="bg-card rounded-xl shadow-card p-4">
+              <h3 className="text-base font-semibold text-foreground mb-3">{t('top_products_title')}</h3>
               {metrics.topProducts.length === 0 ? (
-                <p className="text-sm text-center text-[#78716C] py-4">{t('no_products')}</p>
+                <p className="text-sm text-center text-muted-foreground py-4">{t('no_products')}</p>
               ) : (
                 <div className="space-y-3">
                   {metrics.topProducts.map((p, i) => (
                     <div key={p.product_id ?? p.name_fr} className="flex items-center gap-3">
-                      <div className="w-6 h-6 rounded-full flex items-center justify-center text-[12px] font-semibold flex-shrink-0" style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, white)', color: 'var(--color-primary)' }}>
+                      <div className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0" style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, white)', color: 'var(--color-primary)' }}>
                         {i + 1}
                       </div>
-                      <div className="w-10 h-10 rounded-md bg-[#F5F5F4] flex-shrink-0 overflow-hidden">
+                      <div className="w-10 h-10 rounded-md bg-muted flex-shrink-0 overflow-hidden">
                         {p.image_url && (
                           // eslint-disable-next-line @next/next/no-img-element
                           <img src={p.image_url} alt={p.name_fr} className="w-full h-full object-cover" />
                         )}
                       </div>
                       <div className="flex-1 min-w-0">
-                        <div className="text-[14px] font-medium text-[#1C1917] truncate">{p.name_fr}</div>
-                        <div className="text-[12px] text-[#78716C]">{t('sold_count', { count: p.sold })}</div>
+                        <div className="text-sm font-medium text-foreground truncate">{p.name_fr}</div>
+                        <div className="text-xs text-muted-foreground">{t('sold_count', { count: p.sold })}</div>
                       </div>
-                      <div className="text-[14px] font-semibold text-[#1C1917]">
+                      <div className="text-sm font-semibold text-foreground">
                         {formatMAD(p.revenue)}
                       </div>
                     </div>
@@ -470,8 +483,8 @@ function DonutChartSVG({ data, total, ordersLabel }: { data: DonutSegment[]; tot
           ))}
         </svg>
         <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <div className="text-xl font-bold text-[#1C1917]">{total}</div>
-          <div className="text-xs text-[#78716C]">{ordersLabel}</div>
+          <div className="text-xl font-bold text-foreground">{total}</div>
+          <div className="text-xs text-muted-foreground">{ordersLabel}</div>
         </div>
       </div>
     </div>

--- a/app/dashboard/parametres/ParametresClient.tsx
+++ b/app/dashboard/parametres/ParametresClient.tsx
@@ -36,6 +36,7 @@ export function ParametresClient() {
     });
   }
 
+  // Toggle — brief §2.2. Track `bg-primary` when on, `bg-border` when off.
   const Toggle = ({ checked, onChange, disabled = false, testId }: { checked: boolean; onChange: () => void; disabled?: boolean; testId?: string }) => (
     <button
       type="button"
@@ -44,12 +45,12 @@ export function ParametresClient() {
       onClick={onChange}
       disabled={disabled}
       data-testid={testId}
-      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
-        checked ? 'bg-[var(--color-primary)]' : 'bg-[#E2E8F0]'
+      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
+        checked ? 'bg-primary' : 'bg-border'
       }`}
     >
       <span
-        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+        className={`inline-block h-4 w-4 transform rounded-full bg-card shadow transition-transform ${
           checked ? 'translate-x-6' : 'translate-x-1'
         }`}
       />
@@ -57,31 +58,32 @@ export function ParametresClient() {
   );
 
   return (
-    <div className="bg-[#FAFAF9] min-h-screen">
+    // design-refresh §3.1 — off-white canvas (#F8F9FA) via `bg-background`.
+    <div className="bg-background min-h-screen">
       {/* Mobile top bar */}
-      <div className="md:hidden bg-white h-14 px-4 flex items-center justify-center border-b border-[#E2E8F0]">
-        <h1 className="text-base font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
+      <div className="md:hidden bg-card h-14 px-4 flex items-center justify-center border-b border-border">
+        <h1 className="text-base font-semibold text-foreground">{t('pageTitle')}</h1>
       </div>
 
       <div className="max-w-[640px] mx-auto px-4 py-6 md:py-10 space-y-4">
         {/* Desktop header */}
         <div className="hidden md:block mb-6">
-          <p className="text-xs text-[#78716C] mb-2">{t('breadcrumb')}</p>
-          <h1 className="text-2xl font-semibold text-[#1C1917]">{t('pageTitle')}</h1>
+          <p className="text-xs text-muted-foreground mb-2">{t('breadcrumb')}</p>
+          <h1 className="text-2xl font-semibold text-foreground">{t('pageTitle')}</h1>
         </div>
 
         {/* Notifications */}
-        <div className="bg-white rounded-xl shadow-sm p-6">
-          <h2 className="text-base font-semibold text-[#1C1917] mb-4">{t('notificationsTitle')}</h2>
+        <div className="bg-card rounded-xl shadow-card p-6">
+          <h2 className="text-base font-semibold text-foreground mb-4">{t('notificationsTitle')}</h2>
           <div>
             {notifItems.map((item, idx) => (
               <div
                 key={item.id}
                 className={`h-12 flex items-center justify-between ${
-                  idx < notifItems.length - 1 ? 'border-b border-[#F3F4F6]' : ''
+                  idx < notifItems.length - 1 ? 'border-b border-border' : ''
                 }`}
               >
-                <span className="text-sm text-[#1C1917]">{item.label}</span>
+                <span className="text-sm text-foreground">{item.label}</span>
                 <Toggle
                   checked={notifications[item.id]}
                   onChange={() =>
@@ -92,24 +94,24 @@ export function ParametresClient() {
               </div>
             ))}
           </div>
-          <p className="text-xs text-[#A8A29E] mt-3">{t('notifNote')}</p>
+          <p className="text-xs text-muted-foreground mt-3">{t('notifNote')}</p>
         </div>
 
         {/* Language */}
-        <div className="bg-white rounded-xl shadow-sm p-6">
-          <h2 className="text-base font-semibold text-[#1C1917] mb-3">{t('languageTitle')}</h2>
+        <div className="bg-card rounded-xl shadow-card p-6">
+          <h2 className="text-base font-semibold text-foreground mb-3">{t('languageTitle')}</h2>
           <div>
             {/* French — active, always selected */}
-            <div className="h-12 w-full flex items-center justify-between px-1 border-b border-[#F3F4F6]">
-              <span className="text-sm text-[#1C1917]">{t('langFr')}</span>
-              <div className="w-5 h-5 rounded-full flex items-center justify-center" style={{ backgroundColor: 'var(--color-primary)' }}>
-                <Check className="w-3 h-3 text-white" />
+            <div className="h-12 w-full flex items-center justify-between px-1 border-b border-border">
+              <span className="text-sm text-foreground">{t('langFr')}</span>
+              <div className="w-5 h-5 rounded-full flex items-center justify-center bg-primary">
+                <Check className="w-3 h-3 text-primary-foreground" />
               </div>
             </div>
             {/* Arabic — coming soon */}
             <div className="h-12 w-full flex items-center justify-between px-1 opacity-50 cursor-not-allowed">
-              <span className="text-sm text-[#78716C]">{t('langAr')}</span>
-              <span className="text-xs text-[#A8A29E] bg-[#F5F5F4] px-2 py-1 rounded-full">
+              <span className="text-sm text-muted-foreground">{t('langAr')}</span>
+              <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded-full">
                 Bientôt disponible
               </span>
             </div>
@@ -117,20 +119,21 @@ export function ParametresClient() {
         </div>
 
         {/* Security */}
-        <div className="bg-white rounded-xl shadow-sm p-6">
-          <h2 className="text-base font-semibold text-[#1C1917] mb-3">{t('securityTitle')}</h2>
+        <div className="bg-card rounded-xl shadow-card p-6">
+          <h2 className="text-base font-semibold text-foreground mb-3">{t('securityTitle')}</h2>
           <div>
             <a
               href="/dashboard/compte"
-              className="h-12 w-full flex items-center justify-between hover:bg-[#F8FAFC] transition-colors border-b border-[#F3F4F6] px-1"
+              className="h-12 w-full flex items-center justify-between hover:bg-muted transition-colors border-b border-border px-1"
             >
-              <span className="text-sm text-[#1C1917]">{t('changePassword')}</span>
-              <ChevronRight className="w-4 h-4 text-[#78716C]" />
+              <span className="text-sm text-foreground">{t('changePassword')}</span>
+              <ChevronRight className="w-4 h-4 text-muted-foreground" />
             </a>
             <div className="h-12 flex items-center justify-between px-1">
               <div className="flex items-center gap-2">
-                <span className="text-sm text-[#1C1917]">{t('twoFactor')}</span>
-                <span className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-[#FFF7ED] text-[#E8632A]">
+                <span className="text-sm text-foreground">{t('twoFactor')}</span>
+                {/* "Bientôt" pill uses orange secondary per brief §3.1. */}
+                <span className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-secondary/10 text-secondary">
                   {t('twoFactorSoon')}
                 </span>
               </div>
@@ -143,32 +146,32 @@ export function ParametresClient() {
           </div>
         </div>
 
-        {/* Danger zone */}
-        <div className="bg-white rounded-xl border border-[#FEE2E2] shadow-sm p-6">
+        {/* Danger zone — outlined destructive button per brief §2.1. */}
+        <div className="bg-card rounded-xl border border-destructive/30 shadow-card p-6">
           <button
             type="button"
             onClick={() => setShowDeleteModal(true)}
-            className="w-full h-11 bg-white border-[1.5px] border-[#DC2626] text-[#DC2626] rounded-lg text-sm font-medium hover:bg-[#FEF2F2] transition-colors"
+            className="w-full h-11 bg-card border-[1.5px] border-destructive text-destructive rounded-lg text-sm font-medium hover:bg-destructive/10 transition-colors"
             data-testid="merchant-settings-delete-account-btn"
           >
             {t('deleteAccount')}
           </button>
-          <p className="text-xs text-[#78716C] mt-2">{t('deleteAccountNote')}</p>
+          <p className="text-xs text-muted-foreground mt-2">{t('deleteAccountNote')}</p>
         </div>
       </div>
 
-      {/* Delete confirmation modal */}
+      {/* Delete confirmation modal — brief §2.6. */}
       {showDeleteModal && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" data-testid="merchant-settings-delete-dialog">
-          <div className="bg-white rounded-xl p-6 max-w-sm w-full shadow-xl">
-            <h3 className="text-lg font-semibold text-[#1C1917] mb-2">{t('deleteAccountTitle')}</h3>
-            <p className="text-sm text-[#78716C] mb-6">{t('deleteAccountBody')}</p>
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" data-testid="merchant-settings-delete-dialog">
+          <div className="bg-card rounded-xl p-6 max-w-sm w-full shadow-xl">
+            <h3 className="text-lg font-semibold text-foreground mb-2">{t('deleteAccountTitle')}</h3>
+            <p className="text-sm text-muted-foreground mb-6">{t('deleteAccountBody')}</p>
             <div className="flex gap-3">
               <button
                 type="button"
                 onClick={() => setShowDeleteModal(false)}
                 disabled={isDeleting}
-                className="flex-1 h-10 border border-[#E2E8F0] text-[#1C1917] text-sm font-medium rounded-lg hover:bg-[#F5F5F4] transition-colors disabled:opacity-50"
+                className="flex-1 h-10 border border-border text-foreground text-sm font-medium rounded-lg hover:bg-muted transition-colors disabled:opacity-50"
                 data-testid="merchant-settings-delete-cancel-btn"
               >
                 {t('deleteCancel')}
@@ -177,7 +180,7 @@ export function ParametresClient() {
                 type="button"
                 onClick={handleDeleteAccount}
                 disabled={isDeleting}
-                className="flex-1 h-10 bg-[#DC2626] text-white text-sm font-medium rounded-lg hover:bg-[#b91c1c] transition-colors disabled:opacity-50"
+                className="flex-1 h-10 bg-destructive text-destructive-foreground text-sm font-medium rounded-lg hover:bg-destructive/90 transition-colors disabled:opacity-50"
                 data-testid="merchant-settings-delete-confirm-btn"
               >
                 {isDeleting ? '…' : t('deleteConfirm')}

--- a/app/dashboard/support/NewTicketSheet.tsx
+++ b/app/dashboard/support/NewTicketSheet.tsx
@@ -49,21 +49,21 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
 
   return (
     <>
-      {/* Backdrop */}
-      <div className="fixed inset-0 bg-black/30 z-40" onClick={onClose} />
+      {/* Backdrop — brief §2.6 modal overlay. */}
+      <div className="fixed inset-0 bg-black/50 z-40" onClick={onClose} />
 
       {/* Sheet */}
       <div
-        className="fixed end-0 top-0 h-screen w-full max-w-[480px] bg-white shadow-xl z-50 flex flex-col"
+        className="fixed end-0 top-0 h-screen w-full max-w-[480px] bg-card shadow-xl z-50 flex flex-col"
         data-testid="merchant-support-new-ticket-sheet"
       >
 
         {/* Header */}
-        <div className="h-16 border-b border-[#E2E8F0] px-6 flex items-center justify-between flex-shrink-0">
-          <h2 className="text-base font-semibold text-[#1C1917]">{t('sheet_title')}</h2>
+        <div className="h-16 border-b border-border px-6 flex items-center justify-between flex-shrink-0">
+          <h2 className="text-base font-semibold text-foreground">{t('sheet_title')}</h2>
           <button
             onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center text-[#78716C] hover:text-[#1C1917] hover:bg-[#F8FAFC] rounded-lg transition-colors"
+            className="w-8 h-8 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors"
           >
             <X className="w-5 h-5" />
           </button>
@@ -74,23 +74,23 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
 
           {submitted ? (
             <div className="flex flex-col items-center justify-center h-full py-12 text-center">
-              <div className="w-16 h-16 rounded-full bg-[#F0FDF4] flex items-center justify-center mb-4">
+              <div className="w-16 h-16 rounded-full bg-success/10 flex items-center justify-center mb-4">
                 <span className="text-3xl">✅</span>
               </div>
-              <h3 className="text-lg font-semibold text-[#1C1917] mb-2">{t('sheet_success_title')}</h3>
-              <p className="text-sm text-[#78716C]">{t('sheet_success_body')}</p>
+              <h3 className="text-lg font-semibold text-foreground mb-2">{t('sheet_success_title')}</h3>
+              <p className="text-sm text-muted-foreground">{t('sheet_success_body')}</p>
             </div>
           ) : (
             <>
-              {/* Category */}
+              {/* Category — brief §2.2 select. */}
               <div>
-                <label className="block text-sm font-medium text-[#1C1917] mb-1.5">
+                <label className="block text-sm font-medium text-foreground mb-1.5">
                   {t('sheet_category')}
                 </label>
                 <select
                   value={category}
                   onChange={(e) => setCategory(e.target.value as TicketCategory)}
-                  className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)] bg-white"
+                  className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring bg-card"
                   data-testid="merchant-support-new-ticket-category-select"
                 >
                   {CATEGORIES.map((c) => (
@@ -101,7 +101,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
 
               {/* Subject */}
               <div>
-                <label className="block text-sm font-medium text-[#1C1917] mb-1.5">
+                <label className="block text-sm font-medium text-foreground mb-1.5">
                   {t('sheet_subject')}
                 </label>
                 <input
@@ -109,7 +109,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
                   value={subject}
                   onChange={(e) => setSubject(e.target.value)}
                   placeholder={t('sheet_subject_placeholder')}
-                  className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                  className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                   data-testid="merchant-support-new-ticket-subject-input"
                 />
               </div>
@@ -117,15 +117,15 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
               {/* Order number (conditional) */}
               {category === 'order_issue' && (
                 <div>
-                  <label className="block text-sm font-medium text-[#1C1917] mb-1.5">
-                    {t('sheet_order_number')} <span className="text-[#A8A29E] font-normal">({t('sheet_optional')})</span>
+                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                    {t('sheet_order_number')} <span className="text-muted-foreground font-normal">({t('sheet_optional')})</span>
                   </label>
                   <input
                     type="text"
                     value={orderId}
                     onChange={(e) => setOrderId(e.target.value)}
                     placeholder="PLZ-042"
-                    className="w-full h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                    className="w-full h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                     data-testid="merchant-support-new-ticket-order-id-input"
                   />
                 </div>
@@ -133,7 +133,7 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
 
               {/* Description */}
               <div>
-                <label className="block text-sm font-medium text-[#1C1917] mb-1.5">
+                <label className="block text-sm font-medium text-foreground mb-1.5">
                   {t('sheet_description')}
                 </label>
                 <textarea
@@ -141,39 +141,40 @@ export function NewTicketSheet({ onClose, onCreated }: Props) {
                   onChange={(e) => setDescription(e.target.value.slice(0, MAX_DESC))}
                   placeholder={t('sheet_description_placeholder')}
                   rows={5}
-                  className="w-full px-3 py-2.5 border border-[#E2E8F0] rounded-lg text-sm resize-none focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+                  className="w-full px-3 py-2.5 border border-border rounded-lg text-sm resize-none focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                   data-testid="merchant-support-new-ticket-description-textarea"
                 />
-                <div className="text-xs text-[#A8A29E] text-end mt-1">
+                <div className="text-xs text-muted-foreground text-end mt-1">
                   {description.length}/{MAX_DESC}
                 </div>
               </div>
 
               {/* File upload zone (UI only — storage not yet configured) */}
               <div>
-                <label className="block text-sm font-medium text-[#1C1917] mb-1.5">
-                  {t('sheet_attachment')} <span className="text-[#A8A29E] font-normal">({t('sheet_optional')})</span>
+                <label className="block text-sm font-medium text-foreground mb-1.5">
+                  {t('sheet_attachment')} <span className="text-muted-foreground font-normal">({t('sheet_optional')})</span>
                 </label>
-                <div className="border-2 border-dashed border-[#E2E8F0] rounded-lg p-5 flex flex-col items-center gap-2 text-center">
-                  <Paperclip className="w-6 h-6 text-[#A8A29E]" />
-                  <p className="text-sm text-[#78716C]">
+                <div className="border-2 border-dashed border-border rounded-lg p-5 flex flex-col items-center gap-2 text-center">
+                  <Paperclip className="w-6 h-6 text-muted-foreground" />
+                  <p className="text-sm text-muted-foreground">
                     {t('sheet_attachment_hint')}{' '}
-                    <span className="cursor-pointer hover:underline" style={{ color: 'var(--color-primary)' }}>{t('sheet_attachment_browse')}</span>
+                    <span className="cursor-pointer hover:underline text-primary">{t('sheet_attachment_browse')}</span>
                   </p>
-                  <p className="text-xs text-[#A8A29E]">{t('sheet_attachment_types')}</p>
+                  <p className="text-xs text-muted-foreground">{t('sheet_attachment_types')}</p>
                 </div>
               </div>
             </>
           )}
         </div>
 
-        {/* Footer */}
+        {/* Footer — tenant `--color-primary` var kept for consistency with the
+            rest of the support surface (merchant bubble, send button). */}
         {!submitted && (
-          <div className="border-t border-[#E2E8F0] px-6 py-4 flex-shrink-0">
+          <div className="border-t border-border px-6 py-4 flex-shrink-0">
             <button
               disabled={isPending || !subject.trim()}
               onClick={handleSubmit}
-              className="w-full h-11 text-white text-sm font-semibold rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center justify-center gap-2"
+              className="w-full h-11 text-primary-foreground text-sm font-semibold rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center justify-center gap-2"
               style={{ backgroundColor: 'var(--color-primary)' }}
               data-testid="merchant-support-new-ticket-submit-btn"
             >

--- a/app/dashboard/support/SupportClient.tsx
+++ b/app/dashboard/support/SupportClient.tsx
@@ -10,7 +10,9 @@ import type { SupportTicket, SupportMessage, TicketStatus } from '@/lib/db/suppo
 import { MOROCCO_TZ } from '@/lib/timezone';
 
 // ─── Ticket status badge ──────────────────────────────────────────────────────
-
+// Brief §2.8 status pills: neutral (muted), info (primary), success (success).
+// `bg` and `text` are passed as CSS values (tokens or color-mix expressions),
+// so this stays compatible with the per-status config map below.
 function TicketStatusPill({ label, bg, text }: { label: string; bg: string; text: string }) {
   return (
     <span
@@ -32,14 +34,15 @@ function MessageBubble({ msg, plazaLabel }: { msg: SupportMessage; plazaLabel: s
     timeZone: MOROCCO_TZ,
   });
 
+  // Merchant bubble → tenant primary; Plaza bubble → neutral muted surface.
   if (isMe) {
     return (
       <div className="flex justify-end">
         <div className="flex flex-col items-end max-w-[70%]">
-          <div className="bg-[var(--color-primary)] text-white px-4 py-2.5 rounded-xl rounded-tr-none text-sm">
+          <div className="bg-[var(--color-primary)] text-primary-foreground px-4 py-2.5 rounded-xl rounded-tr-none text-sm">
             {msg.content}
           </div>
-          <div className="text-[11px] text-[#A8A29E] mt-1">{time}</div>
+          <div className="text-[11px] text-muted-foreground mt-1">{time}</div>
         </div>
       </div>
     );
@@ -47,15 +50,15 @@ function MessageBubble({ msg, plazaLabel }: { msg: SupportMessage; plazaLabel: s
 
   return (
     <div className="flex gap-2 max-w-[70%]">
-      <div className="w-8 h-8 rounded-full bg-[var(--color-primary)] text-white flex items-center justify-center text-sm font-semibold flex-shrink-0">
+      <div className="w-8 h-8 rounded-full bg-[var(--color-primary)] text-primary-foreground flex items-center justify-center text-sm font-semibold flex-shrink-0">
         P
       </div>
       <div>
-        <div className="text-[12px] text-[#78716C] mb-1">{plazaLabel}</div>
-        <div className="bg-[#F5F5F4] text-[#1C1917] px-4 py-2.5 rounded-xl rounded-tl-none text-sm">
+        <div className="text-[12px] text-muted-foreground mb-1">{plazaLabel}</div>
+        <div className="bg-muted text-foreground px-4 py-2.5 rounded-xl rounded-tl-none text-sm">
           {msg.content}
         </div>
-        <div className="text-[11px] text-[#A8A29E] mt-1">{time}</div>
+        <div className="text-[11px] text-muted-foreground mt-1">{time}</div>
       </div>
     </div>
   );
@@ -90,19 +93,20 @@ function ChatPanel({
     setContent('');
   };
 
+  // Brief §2.8 status pills — tokens via hsl(var(--*)) for tint + text.
   const STATUS_CONFIG: Record<TicketStatus, { label: string; bg: string; text: string }> = {
-    open:        { label: t('ticket_status_open'),        bg: '#F3F4F6', text: '#6B7280' },
-    in_progress: { label: t('ticket_status_in_progress'), bg: 'color-mix(in srgb, var(--color-primary) 8%, white)', text: 'var(--color-primary)' },
-    resolved:    { label: t('ticket_status_resolved'),    bg: '#F0FDF4', text: '#16A34A' },
-    closed:      { label: t('ticket_status_closed'),      bg: '#F3F4F6', text: '#6B7280' },
+    open:        { label: t('ticket_status_open'),        bg: 'hsl(var(--muted))',                                     text: 'hsl(var(--muted-foreground))' },
+    in_progress: { label: t('ticket_status_in_progress'), bg: 'color-mix(in srgb, var(--color-primary) 10%, white)',    text: 'var(--color-primary)' },
+    resolved:    { label: t('ticket_status_resolved'),    bg: 'color-mix(in srgb, hsl(var(--success)) 10%, white)',     text: 'hsl(var(--success))' },
+    closed:      { label: t('ticket_status_closed'),      bg: 'hsl(var(--muted))',                                     text: 'hsl(var(--muted-foreground))' },
   };
 
   return (
     <>
       {/* Header */}
-      <div className="h-16 border-b border-[#E2E8F0] px-6 flex items-center justify-between flex-shrink-0">
+      <div className="h-16 border-b border-border px-6 flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-3 min-w-0">
-          <span className="text-base font-semibold text-[#1C1917] truncate">
+          <span className="text-base font-semibold text-foreground truncate">
             {ticket.ticket_number} — {ticket.subject}
           </span>
           <TicketStatusPill {...STATUS_CONFIG[ticket.status]} />
@@ -111,14 +115,14 @@ function ChatPanel({
 
       {/* Context card */}
       {ticket.order_id && (
-        <div className="mx-4 mt-4 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl p-3 text-sm flex items-center gap-4">
-          <span className="text-[#78716C]">
+        <div className="mx-4 mt-4 bg-muted/40 border border-border rounded-xl p-3 text-sm flex items-center gap-4">
+          <span className="text-muted-foreground">
             {t('linked_order')}:{' '}
             <Link href={`/dashboard/commandes/${ticket.order_id}`} className="hover:underline" style={{ color: 'var(--color-primary)' }}>
               {t('view_order')}
             </Link>
           </span>
-          <span className="text-[#78716C]">
+          <span className="text-muted-foreground">
             {t('opened_on')}{' '}
             {new Date(ticket.created_at).toLocaleDateString('fr-FR', {
               day: 'numeric',
@@ -133,7 +137,7 @@ function ChatPanel({
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-6 space-y-4">
         <div className="flex justify-center">
-          <span className="text-xs text-[#78716C] bg-[#F5F5F4] px-3 py-1 rounded-full">
+          <span className="text-xs text-muted-foreground bg-muted px-3 py-1 rounded-full">
             {new Date(ticket.created_at).toLocaleDateString('fr-FR', {
               weekday: 'long',
               day: 'numeric',
@@ -143,7 +147,7 @@ function ChatPanel({
           </span>
         </div>
         {messages.length === 0 && (
-          <div className="text-center text-sm text-[#A8A29E] py-8">
+          <div className="text-center text-sm text-muted-foreground py-8">
             {t('no_messages')}
           </div>
         )}
@@ -153,12 +157,12 @@ function ChatPanel({
         <div ref={bottomRef} />
       </div>
 
-      {/* Reply bar */}
-      <div className="h-16 border-t border-[#E2E8F0] px-4 flex items-center gap-3 flex-shrink-0">
+      {/* Reply bar — brief §2.2 inputs. */}
+      <div className="h-16 border-t border-border px-4 flex items-center gap-3 flex-shrink-0">
         <button
           disabled
           title={t('paperclip_tooltip')}
-          className="p-2 text-[#E2E8F0] opacity-50 cursor-not-allowed"
+          className="p-2 text-muted-foreground opacity-50 cursor-not-allowed"
         >
           <Paperclip className="w-5 h-5" />
         </button>
@@ -168,14 +172,14 @@ function ChatPanel({
           value={content}
           onChange={(e) => setContent(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSend()}
-          className="flex-1 h-10 px-3 border border-[#E2E8F0] rounded-lg text-sm focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+          className="flex-1 h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
           disabled={isSending}
           data-testid="merchant-support-reply-input"
         />
         <button
           onClick={handleSend}
           disabled={!content.trim() || isSending}
-          className="w-10 h-10 bg-[var(--color-primary)] text-white rounded-full flex items-center justify-center hover:opacity-90 disabled:opacity-50 transition-colors"
+          className="w-10 h-10 bg-[var(--color-primary)] text-primary-foreground rounded-full flex items-center justify-center hover:opacity-90 disabled:opacity-50 transition-colors"
           data-testid="merchant-support-send-btn"
         >
           {isSending ? (
@@ -199,11 +203,12 @@ type Props = {
 
 export function SupportClient({ tickets }: Props) {
   const t = useTranslations('support');
+  // Brief §2.8 status pills — tokens via hsl(var(--*)) for tint + text.
   const STATUS_CONFIG: Record<TicketStatus, { label: string; bg: string; text: string }> = {
-    open:        { label: t('ticket_status_open'),        bg: '#F3F4F6', text: '#6B7280' },
-    in_progress: { label: t('ticket_status_in_progress'), bg: 'color-mix(in srgb, var(--color-primary) 8%, white)', text: 'var(--color-primary)' },
-    resolved:    { label: t('ticket_status_resolved'),    bg: '#F0FDF4', text: '#16A34A' },
-    closed:      { label: t('ticket_status_closed'),      bg: '#F3F4F6', text: '#6B7280' },
+    open:        { label: t('ticket_status_open'),        bg: 'hsl(var(--muted))',                                     text: 'hsl(var(--muted-foreground))' },
+    in_progress: { label: t('ticket_status_in_progress'), bg: 'color-mix(in srgb, var(--color-primary) 10%, white)',    text: 'var(--color-primary)' },
+    resolved:    { label: t('ticket_status_resolved'),    bg: 'color-mix(in srgb, hsl(var(--success)) 10%, white)',     text: 'hsl(var(--success))' },
+    closed:      { label: t('ticket_status_closed'),      bg: 'hsl(var(--muted))',                                     text: 'hsl(var(--muted-foreground))' },
   };
   const [selectedTicket, setSelectedTicket] = useState<SupportTicket | null>(
     tickets[0] ?? null,
@@ -263,13 +268,13 @@ export function SupportClient({ tickets }: Props) {
       <div className="hidden md:block p-8 max-w-[1040px] mx-auto">
         <div className="flex gap-6" style={{ height: 'calc(100vh - 128px)' }}>
 
-          {/* Left panel: ticket list */}
-          <div className="w-[320px] bg-white rounded-xl shadow-sm overflow-hidden flex flex-col flex-shrink-0">
-            <div className="h-16 border-b border-[#E2E8F0] px-6 flex items-center justify-between flex-shrink-0">
-              <h2 className="text-lg font-semibold text-[#1C1917]">{t('title')}</h2>
+          {/* Left panel: ticket list — brief §2.3 card. */}
+          <div className="w-[320px] bg-card rounded-xl shadow-card overflow-hidden flex flex-col flex-shrink-0">
+            <div className="h-16 border-b border-border px-6 flex items-center justify-between flex-shrink-0">
+              <h2 className="text-lg font-semibold text-foreground">{t('title')}</h2>
               <button
                 onClick={() => setShowNewTicket(true)}
-                className="h-9 px-3 bg-[var(--color-primary)] text-white rounded-lg text-sm font-medium hover:opacity-90 transition-colors"
+                className="h-9 px-3 bg-[var(--color-primary)] text-primary-foreground rounded-lg text-sm font-medium hover:opacity-90 transition-colors"
                 data-testid="merchant-support-new-ticket-btn"
               >
                 {t('new_ticket')}
@@ -279,37 +284,37 @@ export function SupportClient({ tickets }: Props) {
             <div className="flex-1 overflow-y-auto">
               {tickets.length === 0 ? (
                 <div className="p-6 text-center">
-                  <MessageCircle className="w-10 h-10 text-[#E2E8F0] mx-auto mb-3" />
-                  <p className="text-sm text-[#78716C]">{t('no_tickets')}</p>
+                  <MessageCircle className="w-10 h-10 text-border mx-auto mb-3" />
+                  <p className="text-sm text-muted-foreground">{t('no_tickets')}</p>
                 </div>
               ) : (
                 tickets.map((ticket) => (
                   <div
                     key={ticket.id}
                     onClick={() => handleSelectTicket(ticket)}
-                    className={`p-4 border-b border-[#F3F4F6] cursor-pointer transition-colors ${
+                    className={`p-4 border-b border-border cursor-pointer transition-colors ${
                       selectedTicket?.id === ticket.id
-                        ? 'bg-[#F8FAFC]'
-                        : 'hover:bg-[#F8FAFC]'
+                        ? 'bg-muted/40'
+                        : 'hover:bg-muted/40'
                     }`}
                     data-testid="merchant-support-ticket-row"
                     data-id={ticket.id}
                   >
                     <div className="flex items-start justify-between mb-1">
-                      <span className="text-[13px] font-bold text-[#1C1917]">
+                      <span className="text-[13px] font-bold text-foreground">
                         {ticket.ticket_number}
                       </span>
                       <TicketStatusPill {...STATUS_CONFIG[ticket.status]} />
                     </div>
-                    <div className="text-[13px] text-[#1C1917] truncate mb-1">
+                    <div className="text-[13px] text-foreground truncate mb-1">
                       {ticket.subject}
                     </div>
                     {ticket.preview && (
-                      <div className="text-[12px] text-[#78716C] truncate mb-1">
+                      <div className="text-[12px] text-muted-foreground truncate mb-1">
                         {ticket.preview}
                       </div>
                     )}
-                    <div className="text-[11px] text-[#A8A29E]">
+                    <div className="text-[11px] text-muted-foreground">
                       {new Date(ticket.created_at).toLocaleDateString('fr-FR', {
                         day: 'numeric',
                         month: 'short',
@@ -323,7 +328,7 @@ export function SupportClient({ tickets }: Props) {
           </div>
 
           {/* Right panel: chat or empty state */}
-          <div className="flex-1 bg-white rounded-xl shadow-sm overflow-hidden flex flex-col min-w-0">
+          <div className="flex-1 bg-card rounded-xl shadow-card overflow-hidden flex flex-col min-w-0">
             {selectedTicket && !loadingMessages ? (
               <ChatPanel
                 ticket={selectedTicket}
@@ -339,8 +344,8 @@ export function SupportClient({ tickets }: Props) {
             ) : (
               <div className="flex-1 flex items-center justify-center">
                 <div className="text-center">
-                  <MessageCircle className="w-20 h-20 text-[#E2E8F0] mx-auto mb-4" />
-                  <p className="text-base text-[#78716C]">
+                  <MessageCircle className="w-20 h-20 text-border mx-auto mb-4" />
+                  <p className="text-base text-muted-foreground">
                     {t('select_ticket')}
                   </p>
                 </div>
@@ -354,10 +359,10 @@ export function SupportClient({ tickets }: Props) {
       {/* ── Mobile ticket list ─────────────────────────────────────────── */}
       <div className="md:hidden p-4">
         <div className="flex items-center justify-between mb-4">
-          <h1 className="text-xl font-semibold text-[#1C1917]">{t('title')}</h1>
+          <h1 className="text-xl font-semibold text-foreground">{t('title')}</h1>
           <button
             onClick={() => setShowNewTicket(true)}
-            className="h-9 px-3 bg-[var(--color-primary)] text-white rounded-lg text-sm font-medium flex items-center gap-1.5 hover:opacity-90 transition-colors"
+            className="h-9 px-3 bg-[var(--color-primary)] text-primary-foreground rounded-lg text-sm font-medium flex items-center gap-1.5 hover:opacity-90 transition-colors"
             data-testid="merchant-support-new-ticket-btn"
           >
             <Plus className="w-4 h-4" />
@@ -366,12 +371,12 @@ export function SupportClient({ tickets }: Props) {
         </div>
 
         {tickets.length === 0 ? (
-          <div className="bg-white rounded-xl shadow-sm py-16 text-center">
-            <MessageCircle className="w-10 h-10 text-[#E2E8F0] mx-auto mb-3" />
-            <h3 className="text-base font-semibold text-[#1C1917] mb-1">
+          <div className="bg-card rounded-xl shadow-card py-16 text-center">
+            <MessageCircle className="w-10 h-10 text-border mx-auto mb-3" />
+            <h3 className="text-base font-semibold text-foreground mb-1">
               {t('no_tickets')}
             </h3>
-            <p className="text-sm text-[#78716C]">
+            <p className="text-sm text-muted-foreground">
               {t('no_tickets_cta')}
             </p>
           </div>
@@ -381,25 +386,25 @@ export function SupportClient({ tickets }: Props) {
               <Link
                 key={ticket.id}
                 href={`/dashboard/support/${ticket.id}`}
-                className="block bg-white rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow"
+                className="block bg-card rounded-xl p-4 shadow-card hover:shadow-card-hover transition-shadow"
                 data-testid="merchant-support-ticket-row"
                 data-id={ticket.id}
               >
                 <div className="flex items-start justify-between mb-2">
-                  <div className="text-[14px] font-semibold text-[#1C1917]">
+                  <div className="text-[14px] font-semibold text-foreground">
                     {ticket.ticket_number}
                   </div>
                   <TicketStatusPill {...STATUS_CONFIG[ticket.status]} />
                 </div>
-                <div className="text-[14px] text-[#1C1917] mb-1 truncate">
+                <div className="text-[14px] text-foreground mb-1 truncate">
                   {ticket.subject}
                 </div>
                 {ticket.preview && (
-                  <div className="text-[12px] text-[#78716C] truncate mb-1">
+                  <div className="text-[12px] text-muted-foreground truncate mb-1">
                     {ticket.preview}
                   </div>
                 )}
-                <div className="text-[11px] text-[#A8A29E]">
+                <div className="text-[11px] text-muted-foreground">
                   {new Date(ticket.created_at).toLocaleDateString('fr-FR', {
                     day: 'numeric',
                     month: 'short',

--- a/app/dashboard/support/[id]/TicketDetailClient.tsx
+++ b/app/dashboard/support/[id]/TicketDetailClient.tsx
@@ -19,11 +19,15 @@ type Props = {
 
 export function TicketDetailClient({ ticket }: Props) {
   const t = useTranslations('support');
+  // Status config — brief §2.8 semantic status pills.
+  // Token-based CSS expressions so the runtime styling matches the refreshed
+  // palette (muted for neutral states, primary-tinted for in-progress, success
+  // for resolved).
   const STATUS_CONFIG: Record<TicketStatus, { label: string; bg: string; text: string }> = {
-    open:        { label: t('ticket_status_open'),        bg: '#F3F4F6', text: '#6B7280' },
-    in_progress: { label: t('ticket_status_in_progress'), bg: 'color-mix(in srgb, var(--color-primary) 8%, white)', text: 'var(--color-primary)' },
-    resolved:    { label: t('ticket_status_resolved'),    bg: '#F0FDF4', text: '#16A34A' },
-    closed:      { label: t('ticket_status_closed'),      bg: '#F3F4F6', text: '#6B7280' },
+    open:        { label: t('ticket_status_open'),        bg: 'hsl(var(--muted))',                                                    text: 'hsl(var(--muted-foreground))' },
+    in_progress: { label: t('ticket_status_in_progress'), bg: 'color-mix(in srgb, var(--color-primary) 10%, white)',                  text: 'var(--color-primary)' },
+    resolved:    { label: t('ticket_status_resolved'),    bg: 'color-mix(in srgb, hsl(var(--success)) 10%, white)',                   text: 'hsl(var(--success))' },
+    closed:      { label: t('ticket_status_closed'),      bg: 'hsl(var(--muted))',                                                    text: 'hsl(var(--muted-foreground))' },
   };
   const router = useRouter();
   const [isSending, startSending] = useTransition();
@@ -60,23 +64,24 @@ export function TicketDetailClient({ ticket }: Props) {
   };
 
   return (
-    <div className="min-h-screen bg-[#FAFAF9]">
+    // design-refresh §3.1 — off-white canvas via `bg-background`.
+    <div className="min-h-screen bg-background">
       <div className="max-w-[480px] mx-auto flex flex-col h-screen">
 
         {/* Top bar */}
-        <div className="bg-white h-14 px-4 flex items-center justify-between border-b border-[#E2E8F0] flex-shrink-0">
+        <div className="bg-card h-14 px-4 flex items-center justify-between border-b border-border flex-shrink-0">
           <button
             onClick={() => router.back()}
             className="p-2 -ml-2"
             data-testid="merchant-support-ticket-back-btn"
           >
-            <ArrowLeft size={20} className="text-[#1C1917]" />
+            <ArrowLeft size={20} className="text-foreground" />
           </button>
-          <h1 className="text-[16px] font-semibold text-[#1C1917] flex-1 text-center truncate px-2">
+          <h1 className="text-base font-semibold text-foreground flex-1 text-center truncate px-2">
             {ticket.subject}
           </h1>
           <span
-            className="text-[12px] px-2 py-1 rounded-full flex-shrink-0"
+            className="text-xs px-2 py-1 rounded-full flex-shrink-0"
             style={{ backgroundColor: cfg.bg, color: cfg.text }}
           >
             {cfg.label}
@@ -86,9 +91,9 @@ export function TicketDetailClient({ ticket }: Props) {
         {/* Context card */}
         {ticket.order_id && (
           <div className="p-4 pb-0">
-            <div className="bg-white rounded-xl shadow-sm p-3">
+            <div className="bg-card rounded-xl shadow-card p-3">
               <div className="text-[13px]">
-                <span className="text-[#78716C]">{t('linked_order')}: </span>
+                <span className="text-muted-foreground">{t('linked_order')}: </span>
                 <Link
                   href={`/dashboard/commandes/${ticket.order_id}`}
                   className="hover:underline"
@@ -97,7 +102,7 @@ export function TicketDetailClient({ ticket }: Props) {
                   {t('view_order')}
                 </Link>
               </div>
-              <div className="text-[13px] text-[#78716C] mt-1">
+              <div className="text-[13px] text-muted-foreground mt-1">
                 {t('opened_on')}{' '}
                 {new Date(ticket.created_at).toLocaleDateString('fr-FR', {
                   day: 'numeric',
@@ -114,7 +119,7 @@ export function TicketDetailClient({ ticket }: Props) {
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
           {/* Date pill */}
           <div className="flex justify-center">
-            <span className="px-3 py-1 bg-[#F5F5F4] text-[#78716C] text-[12px] rounded-full">
+            <span className="px-3 py-1 bg-muted text-muted-foreground text-xs rounded-full">
               {new Date(ticket.created_at).toLocaleDateString('fr-FR', {
                 weekday: 'long',
                 day: 'numeric',
@@ -125,7 +130,7 @@ export function TicketDetailClient({ ticket }: Props) {
           </div>
 
           {messages.length === 0 && (
-            <div className="text-center text-sm text-[#A8A29E] py-8">
+            <div className="text-center text-sm text-muted-foreground py-8">
               {t('no_messages')}
             </div>
           )}
@@ -142,10 +147,12 @@ export function TicketDetailClient({ ticket }: Props) {
               return (
                 <div key={msg.id} className="flex justify-end">
                   <div className="flex flex-col items-end max-w-[85%]">
-                    <div className="bg-[var(--color-primary)] text-white rounded-xl rounded-tr-none p-3">
-                      <p className="text-[14px]">{msg.content}</p>
+                    {/* Merchant bubble — tenant `--color-primary` for the
+                        per-tenant brand tint (PLZ-088). */}
+                    <div className="bg-[var(--color-primary)] text-primary-foreground rounded-xl rounded-tr-none p-3">
+                      <p className="text-sm">{msg.content}</p>
                     </div>
-                    <div className="text-[11px] text-[#A8A29E] mt-1">{time}</div>
+                    <div className="text-[11px] text-muted-foreground mt-1">{time}</div>
                   </div>
                 </div>
               );
@@ -153,15 +160,15 @@ export function TicketDetailClient({ ticket }: Props) {
 
             return (
               <div key={msg.id} className="flex gap-2">
-                <div className="w-8 h-8 rounded-full bg-[var(--color-primary)] text-white flex items-center justify-center text-[14px] font-semibold flex-shrink-0">
+                <div className="w-8 h-8 rounded-full bg-[var(--color-primary)] text-primary-foreground flex items-center justify-center text-sm font-semibold flex-shrink-0">
                   P
                 </div>
                 <div className="flex-1">
-                  <div className="text-[12px] text-[#78716C] mb-1">{t('plaza_support')}</div>
-                  <div className="bg-[#F5F5F4] rounded-xl rounded-tl-none p-3 max-w-[85%]">
-                    <p className="text-[14px] text-[#1C1917]">{msg.content}</p>
+                  <div className="text-xs text-muted-foreground mb-1">{t('plaza_support')}</div>
+                  <div className="bg-muted rounded-xl rounded-tl-none p-3 max-w-[85%]">
+                    <p className="text-sm text-foreground">{msg.content}</p>
                   </div>
-                  <div className="text-[11px] text-[#A8A29E] mt-1">{time}</div>
+                  <div className="text-[11px] text-muted-foreground mt-1">{time}</div>
                 </div>
               </div>
             );
@@ -171,9 +178,9 @@ export function TicketDetailClient({ ticket }: Props) {
         </div>
 
         {/* Reply bar */}
-        <div className="bg-white border-t border-[#E2E8F0] p-3 flex-shrink-0">
+        <div className="bg-card border-t border-border p-3 flex-shrink-0">
           <div className="flex items-center gap-2">
-            <button className="p-2 text-[#78716C]">
+            <button className="p-2 text-muted-foreground">
               <Paperclip size={20} />
             </button>
             <input
@@ -183,13 +190,13 @@ export function TicketDetailClient({ ticket }: Props) {
               onChange={(e) => setContent(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSend()}
               disabled={isSending}
-              className="flex-1 h-10 px-3 border border-[#E2E8F0] rounded-lg text-[14px] focus:outline-none focus:border-[var(--color-primary)]"
+              className="flex-1 h-10 px-3 border border-border rounded-lg text-sm focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               data-testid="merchant-support-reply-input"
             />
             <button
               onClick={handleSend}
               disabled={!content.trim() || isSending}
-              className="w-10 h-10 rounded-full bg-[var(--color-primary)] flex items-center justify-center text-white hover:opacity-90 disabled:opacity-50 transition-opacity"
+              className="w-10 h-10 rounded-full bg-[var(--color-primary)] flex items-center justify-center text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-opacity"
               data-testid="merchant-support-send-btn"
             >
               {isSending ? (

--- a/app/onboarding/StepStoreDetails.tsx
+++ b/app/onboarding/StepStoreDetails.tsx
@@ -41,7 +41,7 @@ export function StepStoreDetails({
 
   const slugIndicator =
     slugStatus === 'available'
-      ? <span className="text-xs text-green-600">{t('storeSlugAvailable')}</span>
+      ? <span className="text-xs text-success">{t('storeSlugAvailable')}</span>
       : slugStatus === 'taken'
       ? <span className="text-xs text-destructive">{t('storeSlugTaken')}</span>
       : slugStatus === 'checking'


### PR DESCRIPTION
## Summary

Final merchant design-refresh PR — closes the 4/4 sprint alongside PRs #78, #79, #82.

- **Finances** — Period selector + stats row + revenue line chart (primary blue `#1A6BFF`) + payment donut + top-products list. Token-swapped to `bg-card`, `shadow-card`, `text-foreground`, `text-muted-foreground`, `border-border`, `bg-muted`.
- **Paramètres** — Notifications toggles (`bg-primary`/`bg-border`), language card, security (password link, 2FA disabled w/ orange-secondary pill per brief §3.1), delete-account danger zone (outlined `border-destructive`, confirm modal with `bg-destructive text-destructive-foreground`).
- **Support** — List view, chat panel, new-ticket sheet, mobile ticket-detail. Status pills → semantic token expressions (`hsl(var(--muted))`, `color-mix(... var(--color-primary))`, `hsl(var(--success))`). Merchant bubble retains `bg-[var(--color-primary)]` + `text-primary-foreground` per PLZ-088.
- **Boutique (residual)** — `BoutiqueForm`, `DeliveryZones`, `WorkingHoursSection`, `loading.tsx` folded onto tokens. Color picker swatches keep tenant hex values (data). Storefront preview phone mockup kept literal white (represents tenant store, not dashboard chrome).
- **Compte** — Profile card, form inputs, password sub-form, avatar tint via `color-mix(..., var(--color-primary))`.
- **Onboarding** — Single `text-green-600` → `text-success` remnant in `StepStoreDetails`.

## Files touched (11)

- `app/dashboard/boutique/BoutiqueForm.tsx`
- `app/dashboard/boutique/DeliveryZones.tsx`
- `app/dashboard/boutique/WorkingHoursSection.tsx`
- `app/dashboard/boutique/loading.tsx`
- `app/dashboard/compte/CompteClient.tsx`
- `app/dashboard/finances/FinancesClient.tsx`
- `app/dashboard/parametres/ParametresClient.tsx`
- `app/dashboard/support/NewTicketSheet.tsx`
- `app/dashboard/support/SupportClient.tsx`
- `app/dashboard/support/[id]/TicketDetailClient.tsx`
- `app/onboarding/StepStoreDetails.tsx`

## Scope audit — clean

- **No admin touch**: zero diffs under `app/admin/**` or `.admin-scope`.
- **No auth / middleware / Supabase query / schema / API route changes.**
- **No IA / flow / routing / nav-entry changes.** No new screens or CTAs.
- **All `data-testid=` preserved** — 0 removed, styling-only edits.
- **PLZ-088 retained**: tenant `var(--color-primary)` kept on mobile save bars, account save button, support send button, merchant chat bubble, boutique form submit.
- Tailwind-v4 theme tokens + shadcn HSL vars used throughout (`bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`, `bg-muted`, `shadow-card`, `bg-success/10`, `text-warning`, `bg-destructive`, etc).
- `text-primary` / `bg-primary` (platform blue) used only on ≤ `#F8F9FA` surfaces per WCAG AA.

## Scope-adjacent notes (for PM)

- **Finances line chart** — recharts `stroke` props can't resolve CSS vars at runtime, so chart colours are hard-coded hex constants (`CHART_LINE_HEX = #1A6BFF` = design-refresh primary, `CHART_GRID_HEX = #E5E7EB` ≈ `--border`, `CHART_AXIS_HEX = #6B7280` ≈ `--muted-foreground`). Follow-up ticket could move these to a shared `chart-colors.ts`.
- **Brand-color picker** — `COLOR_OPTIONS` hex array in `BoutiqueForm` is intentional *data* (tenant-chosen brand colour), not design tokens. Likewise the `primary_color ?? '#2563EB'` fallback in `BoutiqueForm`. Flagging so QA doesn't file it as a hex-in-code regression.
- **Storefront phone-preview mockup** — the inner phone mockup inside `BoutiqueForm` preview kept `bg-white` / hex colours deliberately; it represents the *storefront* chrome (separate design system from dashboard).

## Checks

- [x] `npm run type-check` — clean
- [x] `npm run lint` — no new errors (pre-existing `<img>` warnings on storefront files unchanged)
- [x] Rebased on `origin/main` (`2d59470`) to include admin refresh PR #83
- [x] No `--no-verify`, no `--force` (push used `--force-with-lease`)
- [ ] Full-device regression — handing to Saad (QA) for authed dashboard screenshot capture (login flow requires OTP; blocking in agent environment)

## Test plan

- [ ] `/dashboard/finances` — period pills, stats cards, chart blue line, payment donut, top-products hover
- [ ] `/dashboard/parametres` — toggles, danger zone, delete modal
- [ ] `/dashboard/support` — list, status pills, sheet, ticket-detail bubble colours
- [ ] `/dashboard/boutique` — color picker ring, save bar, checklist modal
- [ ] `/dashboard/compte` — avatar tint, password sub-form, save button
- [ ] Scroll at 375px and 1440px, no horizontal overflow
- [ ] Spot check `/admin/finances`, `/admin/support` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)