### PR TITLE
feat(schema): add products.images jsonb + backfill (PLZ-090a)

### DIFF
--- a/app/store/[slug]/actions.ts
+++ b/app/store/[slug]/actions.ts
@@ -73,8 +73,11 @@ export async function getMerchantBySlug(
 // PLZ-048: Columns consumed by storefront product listing and detail views.
 // Excluded: merchant_id (filter param only, never rendered), created_at (not displayed).
 // Cast to Product so callers need no changes.
+// PLZ-090a: `images` jsonb added for the forthcoming multi-image gallery
+// (consumed by PLZ-090b). `image_url` stays selected as a safety net until
+// the follow-up migration drops it.
 const PRODUCT_STOREFRONT_SELECT =
-  'id, name_fr, name_ar, description, price, stock, image_url, ' +
+  'id, name_fr, name_ar, description, price, stock, image_url, images, ' +
   'is_visible, category_l1, category_l2, category_l3, ' +
   'original_price, discount_active';
 

--- a/supabase/migrations/20260423000001_plz090a_product_images_jsonb.sql
+++ b/supabase/migrations/20260423000001_plz090a_product_images_jsonb.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- PLZ-090a: product images jsonb + backfill
+-- ============================================================
+-- Foundation for multi-image product gallery (PLZ-090b storefront,
+-- PLZ-090c merchant upload). Backfill-safe, idempotent, no UI impact.
+--
+-- image_url column is intentionally preserved as a safety net and
+-- will be dropped in a follow-up migration after one full release
+-- cycle of production verification.
+-- ============================================================
+
+-- 1. Add images jsonb column with empty-array default.
+alter table public.products
+  add column if not exists images jsonb not null default '[]'::jsonb;
+
+-- 2. Backfill: for every product with a non-empty image_url, populate
+--    images with [{"url": <image_url>, "alt": ""}]. The
+--    jsonb_array_length guard makes this safe to re-run.
+update public.products
+set images = jsonb_build_array(jsonb_build_object('url', image_url, 'alt', ''))
+where (image_url is not null and image_url <> '')
+  and (images is null or jsonb_array_length(images) = 0);
+
+-- 3. Shape + soft-cap constraint (idempotent via DO block).
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'products_images_shape'
+  ) then
+    alter table public.products
+      add constraint products_images_shape check (
+        jsonb_typeof(images) = 'array'
+        and jsonb_array_length(images) <= 8
+      );
+  end if;
+end $$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -155,6 +155,9 @@ export type Database = {
           price:           number
           stock:           number
           image_url:       string | null
+          // Multi-image gallery (migration 2026-04-23, PLZ-090a).
+          // Backfilled from image_url: [{ url, alt: '' }]. Soft cap 8 enforced by check constraint.
+          images:          { url: string; alt: string }[]
           is_visible:      boolean
           created_at:      string
           // 3-level product categories (migration 2026-04-10)
@@ -174,6 +177,7 @@ export type Database = {
           price:            number
           stock?:           number
           image_url?:       string | null
+          images?:          { url: string; alt: string }[]
           is_visible?:      boolean
           created_at?:      string
           category_l1?:     string | null
@@ -191,6 +195,7 @@ export type Database = {
           price?:           number
           stock?:           number
           image_url?:       string | null
+          images?:          { url: string; alt: string }[]
           is_visible?:      boolean
           created_at?:      string
           category_l1?:     string | null


### PR DESCRIPTION
## Summary
Schema foundation for PLZ-090 multi-image gallery. Backfill-safe migration + TS types + loader field. Zero UI changes.

## Migration applied to production
- Project: hnheztkadfgcqsimfzsl (supabase-plaza, ACTIVE_HEALTHY)
- Applied via Management API `/v1/projects/{ref}/database/query` (HTTP 201, empty result set = DDL success)
- Re-ran after apply to verify idempotency: HTTP 201 again, counts unchanged
- Backfill verification:
  ```
  total_products = 18
  with_images    = 14
  with_image_url = 14   // match -> every product with image_url got backfilled
  ```
- Spot-check (3 sample rows post-migration):
  ```
  id: 814f32ff-accf-4a68-b6d4-329160f14236
  image_url: https://hnheztkadfgcqsimfzsl.supabase.co/storage/v1/object/public/product-images/6603c707-.../1776833479049.png
  images: [{"alt":"","url":"https://hnheztkadfgcqsimfzsl.supabase.co/storage/v1/object/public/product-images/6603c707-.../1776833479049.png"}]

  id: acdd2858-43a4-4a99-a04a-53921599e031
  image_url: https://hnheztkadfgcqsimfzsl.supabase.co/storage/v1/object/public/product-images/1e9930d5-.../1776833556854.png
  images: [{"alt":"","url":"https://hnheztkadfgcqsimfzsl.supabase.co/storage/v1/object/public/product-images/1e9930d5-.../1776833556854.png"}]

  id: a8910cfc-edd8-4150-8a45-95244cad62fd
  image_url: https://hnheztkadfgcqsimfzsl.supabase.co/storage/v1/object/public/product-images/b6e96c44-.../1775812502479.jpg
  images: [{"alt":"","url":"https://hnheztkadfgcqsimfzsl.supabase.co/storage/v1/object/public/product-images/b6e96c44-.../1775812502479.jpg"}]
  ```
- Products with no `image_url` correctly got `images = []`.
- Check constraint `products_images_shape` confirmed present (array + soft cap 8).

## Files changed
- `supabase/migrations/20260423000001_plz090a_product_images_jsonb.sql` - new: adds images jsonb column, backfills from image_url, adds shape constraint. Idempotent.
- `types/supabase.ts` - adds `images: { url: string; alt: string }[]` to products Row/Insert/Update. image_url kept alongside.
- `app/store/[slug]/actions.ts` - adds `images` to `PRODUCT_STOREFRONT_SELECT`. No UI or rendering changes.

## Post-migration verification
- [x] Storefront `/store/boutique-test` renders identically (HTTP 200, product cards present)
- [x] `/store/boutique-test22` renders identically (HTTP 200)
- [x] `/store/boutique-test/commande` reachable (HTTP 200)
- [x] Product detail `/store/boutique-test/produit/<id>` (HTTP 200)
- [x] `/dashboard` route guard still works (307 redirect when unauthenticated)
- [x] `tsc --noEmit` exit 0
- [ ] `npm run lint` - blocked by pre-existing worktree env conflict (parent `.eslintrc.json` + duplicate `@next/next` plugin resolution). Same failure reproduces on an untouched baseline file in this worktree — not caused by this PR. CI runs from a flat clone and will not hit this.

## Rollback plan
If a regression emerges in production, hot-fix path:
1. Drop the `images` column: `alter table products drop column images;`
2. image_url is untouched; storefront continues to read it as today.

## Follow-up PRs
- PLZ-090b: storefront gallery UI (consumes `images`)
- PLZ-090c: merchant upload UI (drag-reorder, alt text, delete, per-image progress)
- [future] drop `image_url` column after one release cycle
