### PR TITLE
feat(storefront): multi-image gallery on PDP (PLZ-090b)

### DIFF
--- a/app/store/[slug]/_components/ProductDetailClient.tsx
+++ b/app/store/[slug]/_components/ProductDetailClient.tsx
@@ -13,9 +13,11 @@ import { motion } from 'motion/react';
 import { useRouter } from 'next/navigation';
 
 import type { Merchant, Product } from '@/types/supabase';
+import { getProductImages } from '@/lib/product-images';
 import { useCart } from './CartProvider';
 import { CartDrawer } from './CartDrawer';
 import { BottomTabBar } from './BottomTabBar';
+import { ProductImageGallery } from './ProductImageGallery';
 
 interface ProductDetailClientProps {
   product: Product;
@@ -97,7 +99,7 @@ export function ProductDetailClient({
         id: product.id,
         name: product.name_fr,
         price: priceMAD,
-        image: product.image_url ?? '',
+        image: primaryImageUrl,
         stock: product.stock,
       },
       quantity,
@@ -114,7 +116,7 @@ export function ProductDetailClient({
       name: product.name_fr,
       price: priceMAD,          // MAD (already divided by 100)
       quantity: quantity,
-      image: product.image_url ?? '',
+      image: primaryImageUrl,
     }];
     sessionStorage.setItem('cartItems', JSON.stringify(directCart));
     sessionStorage.setItem('cartSlug', slug);
@@ -123,7 +125,10 @@ export function ProductDetailClient({
     // Note: no setBuyingNow(false) needed — navigation unmounts the component
   }
 
-  const productImage = product.image_url ?? '';
+  const galleryImages = getProductImages(product);
+  // Kept for cart-item payload + buy-now sessionStorage (cart row still
+  // uses single image_url). First gallery entry is the best representative.
+  const primaryImageUrl = galleryImages[0]?.url ?? product.image_url ?? '';
 
   return (
     <div className="min-h-screen bg-[#FAFAF9] pb-32 lg:pb-0">
@@ -160,19 +165,12 @@ export function ProductDetailClient({
         </button>
       </motion.header>
 
-      {/* Mobile: Full-width Image */}
+      {/* Mobile: Full-width Gallery */}
       <div className="relative w-full aspect-square overflow-hidden lg:hidden">
-        {productImage ? (
-          <img
-            src={productImage}
-            alt={product.name_fr}
-            className="w-full h-full object-cover"
-          />
-        ) : (
-          <div className="w-full h-full bg-[#F5F5F4] flex items-center justify-center">
-            <span className="text-6xl text-[#D6D3D1]">🛍️</span>
-          </div>
-        )}
+        <ProductImageGallery
+          images={galleryImages}
+          productName={product.name_fr}
+        />
       </div>
 
       {/* Desktop: 2-col layout */}
@@ -185,17 +183,10 @@ export function ProductDetailClient({
           className="sticky top-20 h-fit"
         >
           <div className="relative aspect-square overflow-hidden rounded-2xl">
-            {productImage ? (
-              <img
-                src={productImage}
-                alt={product.name_fr}
-                className="w-full h-full object-cover"
-              />
-            ) : (
-              <div className="w-full h-full bg-[#F5F5F4] flex items-center justify-center">
-                <span className="text-6xl text-[#D6D3D1]">🛍️</span>
-              </div>
-            )}
+            <ProductImageGallery
+              images={galleryImages}
+              productName={product.name_fr}
+            />
           </div>
         </motion.div>
 

--- a/app/store/[slug]/_components/ProductImageGallery.tsx
+++ b/app/store/[slug]/_components/ProductImageGallery.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { resolveImageAlt, type ProductImage } from '@/lib/product-images';
+import { cn } from '@/lib/utils';
 
 interface ProductImageGalleryProps {
   images: ProductImage[];
@@ -32,11 +33,18 @@ export function ProductImageGallery({
   const total = images.length;
 
   // Scroll to a specific slide, anchored to the snap point.
+  // Honours `prefers-reduced-motion` — users who opt out of animation get
+  // an instant jump instead of the smooth scroll.
   const scrollToIndex = useCallback((index: number, behavior: ScrollBehavior = 'smooth') => {
     const scroller = scrollerRef.current;
     if (!scroller) return;
     const clamped = Math.max(0, Math.min(index, total - 1));
-    scroller.scrollTo({ left: scroller.clientWidth * clamped, behavior });
+    const prefersReducedMotion = typeof window !== 'undefined'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    scroller.scrollTo({
+      left: scroller.clientWidth * clamped,
+      behavior: prefersReducedMotion ? 'auto' : behavior,
+    });
     setActiveIndex(clamped);
   }, [total]);
 
@@ -114,7 +122,7 @@ export function ProductImageGallery({
         aria-label={`${productName} — galerie d'images`}
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        className="w-full h-full flex overflow-x-auto snap-x snap-mandatory scroll-smooth focus:outline-none focus-visible:ring-2"
+        className="w-full h-full flex overflow-x-auto snap-x snap-mandatory motion-safe:scroll-smooth focus:outline-none focus-visible:ring-2"
         style={{
           scrollSnapType: 'x mandatory',
           // Hide native scrollbar cross-browser without bleeding into global CSS.
@@ -122,7 +130,12 @@ export function ProductImageGallery({
         }}
       >
         {images.map((img, i) => {
-          const alt = resolveImageAlt(img, productName, i);
+          // Slide carries aria-label="{productName} image N of M". If the merchant
+          // didn't author a custom alt, `resolveImageAlt` falls back to the same
+          // string → screen readers would announce it twice. Mirror the predicate
+          // from `resolveImageAlt` and pass alt="" when the fallback would collide.
+          const hasCustomAlt = (img.alt ?? '').trim().length > 0;
+          const alt = hasCustomAlt ? resolveImageAlt(img, productName, i) : '';
           return (
             <div
               key={`${img.url}-${i}`}
@@ -159,15 +172,24 @@ export function ProductImageGallery({
               onClick={() => scrollToIndex(i)}
               aria-label={`Go to image ${i + 1} of ${total}`}
               aria-current={active ? 'true' : undefined}
-              className="rounded-full transition-all"
-              style={{
-                width: active ? 10 : 8,
-                height: active ? 10 : 8,
-                backgroundColor: active
-                  ? 'var(--color-primary, #1A6BFF)'
-                  : 'rgba(120, 113, 108, 0.45)',
-              }}
-            />
+              className={cn(
+                // 24×24 CSS-px hit area — WCAG 2.5.8 AA target size.
+                'grid place-items-center h-6 w-6 rounded-full',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--color-primary,#1A6BFF)]',
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'block rounded-full transition-all',
+                  // Inactive dot: stone-500 (#78716c) on bg-white/70 pill
+                  // clears WCAG 1.4.11 3:1 non-text contrast (~4.3:1).
+                  active
+                    ? 'h-2.5 w-2.5 bg-[var(--color-primary,#1A6BFF)]'
+                    : 'h-2 w-2 bg-stone-500',
+                )}
+              />
+            </button>
           );
         })}
       </div>

--- a/app/store/[slug]/_components/ProductImageGallery.tsx
+++ b/app/store/[slug]/_components/ProductImageGallery.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { resolveImageAlt, type ProductImage } from '@/lib/product-images';
+
+interface ProductImageGalleryProps {
+  images: ProductImage[];
+  productName: string;
+  className?: string;
+}
+
+/**
+ * Storefront multi-image gallery — PLZ-090b.
+ *
+ * Rendering modes:
+ *   - 0 images  → branded placeholder (matches PDP empty state)
+ *   - 1 image   → single eager <img>, no gallery chrome
+ *   - 2+ images → CSS scroll-snap carousel with dot pagination,
+ *                 arrow-key nav, screen-reader "image N of M" live region
+ *
+ * Per-merchant accents flow via `var(--color-primary)` — zero hardcoded hex.
+ */
+export function ProductImageGallery({
+  images,
+  productName,
+  className,
+}: ProductImageGalleryProps) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const announceRef = useRef<number | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const total = images.length;
+
+  // Scroll to a specific slide, anchored to the snap point.
+  const scrollToIndex = useCallback((index: number, behavior: ScrollBehavior = 'smooth') => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    const clamped = Math.max(0, Math.min(index, total - 1));
+    scroller.scrollTo({ left: scroller.clientWidth * clamped, behavior });
+    setActiveIndex(clamped);
+  }, [total]);
+
+  // Observe horizontal scroll to keep activeIndex in sync (debounced so
+  // the live region doesn't spam while the user is still dragging).
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller || total < 2) return;
+
+    const onScroll = () => {
+      if (announceRef.current) window.clearTimeout(announceRef.current);
+      announceRef.current = window.setTimeout(() => {
+        const width = scroller.clientWidth;
+        if (width <= 0) return;
+        const nextIndex = Math.round(scroller.scrollLeft / width);
+        setActiveIndex((prev) => (prev === nextIndex ? prev : nextIndex));
+      }, 100);
+    };
+
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener('scroll', onScroll);
+      if (announceRef.current) window.clearTimeout(announceRef.current);
+    };
+  }, [total]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (total < 2) return;
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      scrollToIndex(activeIndex + 1);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      scrollToIndex(activeIndex - 1);
+    }
+  };
+
+  // ── Zero images → branded placeholder ─────────────────────────────
+  if (total === 0) {
+    return (
+      <div
+        className={`w-full h-full bg-[#F5F5F4] flex items-center justify-center ${className ?? ''}`}
+        data-testid="customer-product-detail-image"
+      >
+        <span className="text-6xl text-[#D6D3D1]">🛍️</span>
+      </div>
+    );
+  }
+
+  // ── Single image → no gallery chrome ──────────────────────────────
+  if (total === 1) {
+    const only = images[0];
+    return (
+      <img
+        src={only.url}
+        alt={resolveImageAlt(only, productName, 0)}
+        loading="eager"
+        className={`w-full h-full object-cover ${className ?? ''}`}
+        data-testid="customer-product-detail-image"
+      />
+    );
+  }
+
+  // ── Multi-image gallery ───────────────────────────────────────────
+  return (
+    <div
+      className={`relative w-full h-full ${className ?? ''}`}
+      data-testid="customer-product-detail-gallery"
+    >
+      {/* Scroll-snap carousel */}
+      <div
+        ref={scrollerRef}
+        role="region"
+        aria-roledescription="carousel"
+        aria-label={`${productName} — galerie d'images`}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className="w-full h-full flex overflow-x-auto snap-x snap-mandatory scroll-smooth focus:outline-none focus-visible:ring-2"
+        style={{
+          scrollSnapType: 'x mandatory',
+          // Hide native scrollbar cross-browser without bleeding into global CSS.
+          scrollbarWidth: 'none',
+        }}
+      >
+        {images.map((img, i) => {
+          const alt = resolveImageAlt(img, productName, i);
+          return (
+            <div
+              key={`${img.url}-${i}`}
+              role="group"
+              aria-roledescription="slide"
+              aria-label={`${productName} image ${i + 1} of ${total}`}
+              className="shrink-0 w-full h-full snap-center flex items-center justify-center"
+              style={{ scrollSnapAlign: 'center' }}
+            >
+              <img
+                src={img.url}
+                alt={alt}
+                loading={i === 0 ? 'eager' : 'lazy'}
+                {...(i === 0 ? { fetchPriority: 'high' as const } : {})}
+                className="w-full h-full object-cover"
+                data-testid={i === 0 ? 'customer-product-detail-image' : undefined}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Dot indicators */}
+      <div
+        className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-2 bg-white/70 backdrop-blur-sm rounded-full px-3 py-1.5"
+        data-testid="customer-product-detail-gallery-dots"
+      >
+        {images.map((_, i) => {
+          const active = i === activeIndex;
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => scrollToIndex(i)}
+              aria-label={`Go to image ${i + 1} of ${total}`}
+              aria-current={active ? 'true' : undefined}
+              className="rounded-full transition-all"
+              style={{
+                width: active ? 10 : 8,
+                height: active ? 10 : 8,
+                backgroundColor: active
+                  ? 'var(--color-primary, #1A6BFF)'
+                  : 'rgba(120, 113, 108, 0.45)',
+              }}
+            />
+          );
+        })}
+      </div>
+
+      {/* Screen-reader live region — announces N of M on settle */}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="customer-product-detail-gallery-liveregion"
+      >
+        {`Image ${activeIndex + 1} of ${total}`}
+      </div>
+    </div>
+  );
+}

--- a/lib/product-images.ts
+++ b/lib/product-images.ts
@@ -1,0 +1,69 @@
+/**
+ * Product image helpers — single source of truth for reading the
+ * multi-image gallery payload (added by PLZ-090a).
+ *
+ * Reused by:
+ *   - ProductImageGallery (storefront PDP) — PLZ-090b
+ *   - Merchant image upload form           — PLZ-090c
+ *
+ * Graceful fallback path: if a product has no `images[]` entries (pre-090a
+ * rows or a migration gap) we synthesise one from the legacy `image_url`
+ * column, which the schema still preserves as a safety net.
+ */
+
+export const MAX_PRODUCT_IMAGES = 8;
+
+export type ProductImage = {
+  url: string;
+  alt: string;
+};
+
+/**
+ * Anything with an `images` jsonb array and/or the legacy `image_url` column.
+ * Deliberately loose so this works for `Product` rows, form drafts, and
+ * anonymous API payloads without dragging in the full generated type.
+ */
+type ProductLike = {
+  images?: ProductImage[] | null;
+  image_url?: string | null;
+};
+
+/**
+ * Returns the product's image list as a normalised array.
+ * Order of precedence:
+ *   1. `images[]` (jsonb) if present and non-empty
+ *   2. `[{ url: image_url, alt: '' }]` if only legacy column has a value
+ *   3. `[]` (empty — caller should render placeholder)
+ */
+export function getProductImages(product: ProductLike): ProductImage[] {
+  if (Array.isArray(product.images) && product.images.length > 0) {
+    // Defensive: filter out entries missing a url (shouldn't happen per
+    // schema, but keeps the gallery rendering from crashing on drift).
+    return product.images.filter((img) => typeof img?.url === 'string' && img.url.length > 0);
+  }
+  if (typeof product.image_url === 'string' && product.image_url.length > 0) {
+    return [{ url: product.image_url, alt: '' }];
+  }
+  return [];
+}
+
+/**
+ * Default alt text when a merchant leaves the alt field blank.
+ * Uses 1-based indexing to read naturally ("image 1 of 3").
+ */
+export function getDefaultAlt(productName: string, index: number): string {
+  return `${productName} image ${index + 1}`;
+}
+
+/**
+ * Single source of truth for resolving the displayed alt attribute.
+ * Merchant-entered alt wins; otherwise we fall back to a human-readable default.
+ */
+export function resolveImageAlt(
+  image: { alt: string },
+  productName: string,
+  index: number,
+): string {
+  const trimmed = (image.alt ?? '').trim();
+  return trimmed.length > 0 ? trimmed : getDefaultAlt(productName, index);
+}

--- a/tests/unit/product-images.test.ts
+++ b/tests/unit/product-images.test.ts
@@ -1,0 +1,73 @@
+import {
+  getProductImages,
+  getDefaultAlt,
+  resolveImageAlt,
+  MAX_PRODUCT_IMAGES,
+} from '@/lib/product-images'
+
+describe('MAX_PRODUCT_IMAGES', () => {
+  it('matches the DB check constraint (8)', () => {
+    expect(MAX_PRODUCT_IMAGES).toBe(8)
+  })
+})
+
+describe('getProductImages', () => {
+  it('returns images array when non-empty', () => {
+    const result = getProductImages({
+      images: [
+        { url: 'https://cdn/a.jpg', alt: 'Front' },
+        { url: 'https://cdn/b.jpg', alt: '' },
+      ],
+      image_url: 'https://cdn/a.jpg',
+    })
+    expect(result).toEqual([
+      { url: 'https://cdn/a.jpg', alt: 'Front' },
+      { url: 'https://cdn/b.jpg', alt: '' },
+    ])
+  })
+
+  it('falls back to image_url when images array is empty', () => {
+    const result = getProductImages({ images: [], image_url: 'https://cdn/legacy.jpg' })
+    expect(result).toEqual([{ url: 'https://cdn/legacy.jpg', alt: '' }])
+  })
+
+  it('falls back to image_url when images is null/undefined', () => {
+    const result = getProductImages({ image_url: 'https://cdn/legacy.jpg' })
+    expect(result).toEqual([{ url: 'https://cdn/legacy.jpg', alt: '' }])
+  })
+
+  it('returns [] when no images and no image_url', () => {
+    expect(getProductImages({})).toEqual([])
+    expect(getProductImages({ images: [], image_url: null })).toEqual([])
+    expect(getProductImages({ images: null, image_url: '' })).toEqual([])
+  })
+
+  it('filters out entries without a url', () => {
+    const result = getProductImages({
+      // @ts-expect-error — intentional drift payload
+      images: [{ url: 'https://cdn/a.jpg', alt: '' }, { alt: 'no-url' }, { url: '', alt: 'empty' }],
+    })
+    expect(result).toEqual([{ url: 'https://cdn/a.jpg', alt: '' }])
+  })
+})
+
+describe('getDefaultAlt', () => {
+  it('returns "{name} image N" with 1-based index', () => {
+    expect(getDefaultAlt('Sneaker Pro', 0)).toBe('Sneaker Pro image 1')
+    expect(getDefaultAlt('Sneaker Pro', 2)).toBe('Sneaker Pro image 3')
+  })
+})
+
+describe('resolveImageAlt', () => {
+  it('uses merchant-entered alt when non-blank', () => {
+    expect(resolveImageAlt({ alt: 'Hero shot' }, 'Sneaker Pro', 0)).toBe('Hero shot')
+  })
+
+  it('falls back to default when alt is blank', () => {
+    expect(resolveImageAlt({ alt: '' }, 'Sneaker Pro', 0)).toBe('Sneaker Pro image 1')
+  })
+
+  it('falls back to default when alt is whitespace-only', () => {
+    expect(resolveImageAlt({ alt: '   ' }, 'Sneaker Pro', 1)).toBe('Sneaker Pro image 2')
+  })
+})


### PR DESCRIPTION
## Summary
Storefront gallery for PLZ-090. Reads `products.images` (added in PLZ-090a). Graceful fallback to `image_url` via shared helper. Per-merchant primary flows through dots.

## Founder constraints met
- [x] CSS scroll-snap (0 KB dependency)
- [x] Dot pagination (desktop + mobile)
- [x] Single-image fallback: no gallery chrome
- [x] Lazy-load images 2-N; first is eager (`loading="eager"` + `fetchPriority="high"`)
- [x] Alt text from `image.alt` with `"{product_name} image N"` fallback
- [x] Keyboard arrow-key navigation
- [x] Screen reader "Image N of M" via `aria-live="polite"` region
- [x] Zero hardcoded primary — all via `var(--color-primary)`

## Files changed
- `lib/product-images.ts` — new. `getProductImages`, `getDefaultAlt`, `resolveImageAlt`, `MAX_PRODUCT_IMAGES`. Reused by PLZ-090c.
- `app/store/[slug]/_components/ProductImageGallery.tsx` — new. Scroll-snap carousel, dot pagination, arrow-key nav, live region. 0/1/many rendering modes.
- `app/store/[slug]/_components/ProductDetailClient.tsx` — rewired to use `getProductImages(product)` + `<ProductImageGallery>`. Single and zero-image handled inside the component.
- `tests/unit/product-images.test.ts` — 10 unit tests covering normalisation, fallback, and alt resolution.

## Test data
Temporarily seeded product `a8910cfc-edd8-4150-8a45-95244cad62fd` (boutique-test22 / "Produit 1") with 3 image entries to verify gallery mechanics. **Reverted to single-image (`jsonb_array_length = 1`) before opening the PR** — confirmed via Management API round-trip.

To repro gallery mode, QA can re-seed via the Management API query in the dispatch brief.

## Manual test results
- **Zero-image product** (`boutique-test` / Produit test): branded 🛍️ placeholder renders; no gallery chrome. HTTP 200.
- **Single-image product** (post-revert, `boutique-test22`): single `<img>` eager, no gallery chrome. No `carousel` / `gallery-dots` markers present in DOM. Testid `customer-product-detail-image` preserved. HTTP 200.
- **Multi-image product** (during seed window): 3 slides rendered with `aria-roledescription="slide"` and `aria-label="Produit 1 image N of 3"`, 3 dot buttons (`Go to image N of 3`), `aria-roledescription="carousel"` on container, `aria-live="polite"` live region present, first image `loading="eager"`, images 2-3 `loading="lazy"`. HTTP 200.

## Feature flag
**Skipped — no feature-flag infra in repo** (grep for `feature.*flag|FEATURE_|NEXT_PUBLIC_FEATURE` returned nothing in `lib/` or `app/`). Shipped unconditionally; single-image fallback means zero user-visible regression for backfilled products. Brief explicitly authorises this path.

## Testid preservation
Zero removed. `customer-product-detail-image` is still applied in every mode (placeholder, single, first slide of multi) — QA selectors untouched.

## Next PR
PLZ-090c — merchant upload UI. Same agent. Reuses `lib/product-images.ts` helpers (`MAX_PRODUCT_IMAGES`, `getDefaultAlt`).
