### PR TITLE
feat(dashboard): multi-image upload on product form (PLZ-090c)

### DIFF
--- a/app/dashboard/produits/ProductForm.tsx
+++ b/app/dashboard/produits/ProductForm.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import { useState, useTransition, useRef } from 'react';
+import { useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
-import { Camera, Info, ArrowLeft } from 'lucide-react';
+import { Info, ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import type { Product } from '@/types/supabase';
 import { createProduct, updateProduct, deleteProduct } from './actions';
+import { ProductImageUploader } from './_components/ProductImageUploader';
+import {
+  getProductImages,
+  validateImagesForPublish,
+  type ProductImage,
+} from '@/lib/product-images';
 
 const PRODUCT_CATEGORIES: Record<string, Record<string, string[]>> = {
   'Mode': {
@@ -89,8 +95,12 @@ export function ProductForm({ product }: Props) {
   // Edited products keep their existing stock value.
   const [stock, setStock] = useState(product?.stock ?? (isEdit ? 0 : 1));
   const [isVisible, setIsVisible] = useState(product?.is_visible ?? true);
-  const [imageUrl, setImageUrl] = useState(product?.image_url ?? '');
-  const [uploading, setUploading] = useState(false);
+  // Multi-image gallery state (PLZ-090c). Initialised via getProductImages
+  // so we gracefully fall back to [{ url: image_url, alt: '' }] for
+  // pre-090a products that never had the `images[]` column populated.
+  const [images, setImages] = useState<ProductImage[]>(() =>
+    product ? getProductImages(product) : [],
+  );
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, startDeleteTransition] = useTransition();
@@ -106,8 +116,6 @@ export function ProductForm({ product }: Props) {
     product?.original_price ? String(product.original_price / 100) : ''
   );
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
   // Price calculator
   const priceNum = parseFloat(price) || 0;
   const commission = priceNum * 0.05;
@@ -115,27 +123,16 @@ export function ProductForm({ product }: Props) {
   const showCalc = priceNum >= 1;
   const priceError = price !== '' && priceNum > 0 && priceNum < 1;
 
-  async function handleImageChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setUploading(true);
-    try {
-      const fd = new FormData();
-      fd.append('file', file);
-      fd.append('bucket', 'product-images');
-      const res = await fetch('/api/upload', { method: 'POST', body: fd });
-      const json = await res.json() as { url?: string; error?: string };
-      if (json.url) setImageUrl(json.url);
-    } finally {
-      setUploading(false);
-    }
-  }
-
   function validate(): boolean {
     const newErrors: Record<string, string> = {};
     if (!nameFr.trim()) newErrors.nameFr = t('formNameRequired');
     if (!price || priceNum <= 0) newErrors.price = t('formPriceRequired');
     if (priceNum > 0 && priceNum < 1) newErrors.price = t('formPriceMin');
+    // Founder binding (PLZ-090c): at least 1 image required on publish.
+    // Product form has no draft path today — every save is a publish, so we
+    // enforce this on every submit. `validateImagesForPublish` owns the copy.
+    const imgCheck = validateImagesForPublish(images);
+    if (!imgCheck.ok) newErrors.images = imgCheck.reason;
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   }
@@ -155,7 +152,12 @@ export function ProductForm({ product }: Props) {
     fd.set('description', description);
     fd.set('price', price);
     fd.set('stock', String(stock));
-    fd.set('image_url', imageUrl);
+    // PLZ-090c — write both shapes:
+    //  - images (new jsonb column, source of truth for storefront gallery)
+    //  - image_url (legacy column, kept in sync with images[0].url as a
+    //    safety net for one more release cycle per the 090a migration note)
+    fd.set('images', JSON.stringify(images));
+    fd.set('image_url', images[0]?.url ?? '');
     fd.set('is_visible', String(isVisible));
     fd.set('category_l1', catL1);
     fd.set('category_l2', catL2);
@@ -281,45 +283,26 @@ export function ProductForm({ product }: Props) {
     </div>
   );
 
+  // PLZ-090c — multi-image uploader replaces the single-image photo card.
+  // Legacy image_url column is still written on save (images[0].url) to keep
+  // the pre-090a safety-net column in sync for one more release cycle.
   const photoCard = (
-    <div className="bg-card rounded-xl shadow-card p-5">
-      <h3 className="text-sm font-semibold text-foreground mb-3">{t('formPhoto')}</h3>
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/jpeg,image/png,image/webp"
-        className="hidden"
-        onChange={handleImageChange}
-        data-testid="merchant-product-form-photo-input"
+    <div className="space-y-1.5">
+      <ProductImageUploader
+        value={images}
+        onChange={setImages}
+        productName={nameFr}
+        disabled={isPending}
+        data-testid="merchant-product-form-image-uploader"
       />
-      <div
-        onClick={() => !uploading && fileInputRef.current?.click()}
-        className="w-full h-[200px] rounded-lg flex flex-col items-center justify-center gap-2 mb-2 cursor-pointer transition-colors overflow-hidden"
-        style={{ background: imageUrl ? 'transparent' : undefined }}
-      >
-        {imageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={imageUrl} alt="" className="w-full h-full object-cover rounded-lg" />
-        ) : (
-          <div className="w-full h-full bg-muted/60 hover:bg-muted transition-colors flex flex-col items-center justify-center gap-2">
-            <Camera className="w-8 h-8 text-muted-foreground" />
-            <span className="text-[13px]" style={{ color: 'var(--color-primary)' }}>
-              {uploading ? t('uploading') : (imageUrl ? t('formPhotoChange') : t('formPhotoAdd'))}
-            </span>
-          </div>
-        )}
-      </div>
-      {imageUrl && (
-        <button
-          type="button"
-          onClick={() => !uploading && fileInputRef.current?.click()}
-          className="text-[13px] hover:underline"
-          style={{ color: 'var(--color-primary)' }}
+      {errors.images && (
+        <p
+          className="text-xs text-destructive px-1"
+          data-testid="merchant-product-form-images-error"
         >
-          {uploading ? t('uploading') : t('formPhotoChange')}
-        </button>
+          {errors.images}
+        </p>
       )}
-      <p className="text-xs text-muted-foreground mt-1">{t('formPhotoFormats')}</p>
     </div>
   );
 
@@ -518,7 +501,7 @@ export function ProductForm({ product }: Props) {
       <button
         type="button"
         onClick={handleSubmit}
-        disabled={isPending || uploading}
+        disabled={isPending}
         className="w-full md:w-auto h-12 md:h-10 md:px-4 text-white text-base md:text-sm font-semibold md:font-medium rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
         style={{ backgroundColor: 'var(--color-primary)' }}
         data-testid="merchant-product-form-publish-btn"

--- a/app/dashboard/produits/ProductsClient.tsx
+++ b/app/dashboard/produits/ProductsClient.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { Search, Edit2, Trash2, Plus } from 'lucide-react';
 import type { Product } from '@/types/supabase';
 import { toggleProductVisibility, deleteProduct } from './actions';
+import { getProductImages } from '@/lib/product-images';
 
 type FilterStatus = 'tous' | 'en-stock' | 'rupture' | 'masques';
 
@@ -107,13 +108,17 @@ export function ProductsClient({ products: initialProducts }: Props) {
         {filtered.length === 0 ? (
           <EmptyState hasProducts={initialProducts.length > 0} />
         ) : (
-          filtered.map((product) => (
+          filtered.map((product) => {
+            // PLZ-090c — cover image comes from images[0] (the reorderable
+            // slot 1), falling back to image_url for pre-090a rows.
+            const coverUrl = getProductImages(product)[0]?.url ?? null;
+            return (
             <Link key={product.id} href={`/dashboard/produits/${product.id}`} data-testid="merchant-products-row" data-id={product.id}>
               <div className="bg-card rounded-xl p-3 shadow-card flex gap-3 hover:shadow-card-hover transition-shadow">
-                {product.image_url ? (
+                {coverUrl ? (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
-                    src={product.image_url}
+                    src={coverUrl}
                     alt={product.name_fr}
                     className="w-20 h-20 rounded-lg object-cover flex-shrink-0"
                   />
@@ -149,7 +154,8 @@ export function ProductsClient({ products: initialProducts }: Props) {
                 </div>
               </div>
             </Link>
-          ))
+            );
+          })
         )}
       </div>
 
@@ -167,7 +173,11 @@ export function ProductsClient({ products: initialProducts }: Props) {
         {filtered.length === 0 ? (
           <EmptyState hasProducts={initialProducts.length > 0} />
         ) : (
-          filtered.map((product) => (
+          filtered.map((product) => {
+            // PLZ-090c — cover image comes from images[0] (the reorderable
+            // slot 1), falling back to image_url for pre-090a rows.
+            const coverUrl = getProductImages(product)[0]?.url ?? null;
+            return (
             <div
               key={product.id}
               className="min-h-16 px-4 flex items-center border-b border-border hover:bg-muted/40 transition-colors last:border-b-0"
@@ -175,10 +185,10 @@ export function ProductsClient({ products: initialProducts }: Props) {
               data-id={product.id}
             >
               <div className="w-16">
-                {product.image_url ? (
+                {coverUrl ? (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
-                    src={product.image_url}
+                    src={coverUrl}
                     alt={product.name_fr}
                     className="w-12 h-12 rounded-lg object-cover"
                   />
@@ -256,7 +266,8 @@ export function ProductsClient({ products: initialProducts }: Props) {
                 </button>
               </div>
             </div>
-          ))
+            );
+          })
         )}
       </div>
 

--- a/app/dashboard/produits/_components/ProductImageUploader.tsx
+++ b/app/dashboard/produits/_components/ProductImageUploader.tsx
@@ -196,7 +196,7 @@ export function ProductImageUploader({
               over
                 ? `Image déplacée sur la position ${over.id}`
                 : `Image ${String(active.id)} en cours de déplacement.`,
-            onDragEnd: ({ active, over }) =>
+            onDragEnd: ({ over }) =>
               over
                 ? `Image déposée à la position ${over.id} sur ${value.length}.`
                 : `Déplacement annulé.`,

--- a/app/dashboard/produits/_components/ProductImageUploader.tsx
+++ b/app/dashboard/produits/_components/ProductImageUploader.tsx
@@ -1,0 +1,410 @@
+'use client';
+
+/**
+ * PLZ-090c — Merchant multi-image uploader for the product form.
+ *
+ * Founder requirements (binding):
+ *   - Up to 8 images (MAX_PRODUCT_IMAGES soft cap, DB constraint is backup)
+ *   - Slot 1 is the "Photo principale" shown on cards across storefront + dashboard
+ *   - Drag-to-reorder with keyboard a11y (dnd-kit)
+ *   - Per-image delete
+ *   - Per-image alt text (optional — resolveImageAlt falls back at render time)
+ *   - Per-image upload progress (boolean, matching the PLZ-080 pattern)
+ *
+ * Pure-UI component. Owns transient uploading state but never writes to the
+ * DB directly — parent form handles persistence via the existing server
+ * action. Keeps ProductForm.tsx single-responsibility.
+ */
+
+import { useRef, useState, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { Camera, Trash2, GripVertical, ImageOff } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
+  type ProductImage,
+  MAX_PRODUCT_IMAGES,
+  canAddImage,
+  getDefaultAlt,
+  removeImageAt,
+} from '@/lib/product-images';
+
+type Props = {
+  value: ProductImage[];
+  onChange: (images: ProductImage[]) => void;
+  productName?: string;
+  disabled?: boolean;
+  'data-testid'?: string;
+};
+
+// Stable id helper — dnd-kit needs a string id per item. We derive it from
+// the image url + index so re-renders after an upload/remove don't lose
+// drag state mid-gesture. Urls are unique per upload (timestamp in path).
+function idFor(img: ProductImage, index: number): string {
+  return `${img.url}#${index}`;
+}
+
+export function ProductImageUploader({
+  value,
+  onChange,
+  productName = '',
+  disabled = false,
+  'data-testid': testId,
+}: Props) {
+  const t = useTranslations('products');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // One boolean flag per ongoing upload (keyed by the client-side index the
+  // slot is appended at). Matches the PLZ-080 boolean pattern — we display
+  // t('uploading') over the slot while true.
+  const [uploadingCount, setUploadingCount] = useState(0);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      // 4px activation distance — prevents the drag from firing on a simple
+      // click/tap (which should open the delete flow, not start a drag).
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const ids = value.map((img, i) => idFor(img, i));
+      const oldIndex = ids.indexOf(String(active.id));
+      const newIndex = ids.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
+      onChange(arrayMove(value, oldIndex, newIndex));
+    },
+    [value, onChange],
+  );
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      onChange(removeImageAt(value, index));
+    },
+    [value, onChange],
+  );
+
+  const handleAltChange = useCallback(
+    (index: number, alt: string) => {
+      const next = value.slice();
+      next[index] = { ...next[index], alt };
+      onChange(next);
+    },
+    [value, onChange],
+  );
+
+  const handleFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+      setUploadError(null);
+
+      // Honor the cap when multiple files are selected at once.
+      const remaining = MAX_PRODUCT_IMAGES - value.length;
+      const toUpload = Array.from(files).slice(0, Math.max(0, remaining));
+      if (toUpload.length === 0) return;
+
+      setUploadingCount((c) => c + toUpload.length);
+
+      // Upload in parallel; on success append in the order they resolve.
+      // We append atomically at the end to avoid race conditions where two
+      // onChange calls see stale value props.
+      const uploaded: ProductImage[] = [];
+      await Promise.all(
+        toUpload.map(async (file) => {
+          try {
+            const fd = new FormData();
+            fd.append('file', file);
+            fd.append('bucket', 'product-images');
+            const res = await fetch('/api/upload', { method: 'POST', body: fd });
+            const json = (await res.json()) as { url?: string; error?: string };
+            if (json.url) {
+              uploaded.push({ url: json.url, alt: '' });
+            } else {
+              setUploadError(json.error ?? 'upload_failed');
+            }
+          } catch {
+            setUploadError('upload_failed');
+          }
+        }),
+      );
+
+      if (uploaded.length > 0) {
+        onChange([...value, ...uploaded]);
+      }
+      setUploadingCount((c) => Math.max(0, c - toUpload.length));
+    },
+    [value, onChange],
+  );
+
+  const handlePick = () => {
+    if (disabled) return;
+    fileInputRef.current?.click();
+  };
+
+  const canAdd = canAddImage(value) && !disabled;
+
+  return (
+    <div
+      className="bg-card rounded-xl shadow-card p-5"
+      data-testid={testId ?? 'merchant-product-image-uploader'}
+    >
+      <h3 className="text-sm font-semibold text-foreground mb-3">{t('formPhoto')}</h3>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          void handleFiles(e.target.files);
+          // Allow re-picking the same file if user deletes then re-adds.
+          e.target.value = '';
+        }}
+        data-testid="merchant-product-form-photo-input"
+      />
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        accessibility={{
+          announcements: {
+            onDragStart: ({ active }) => `Image ${String(active.id)} saisie.`,
+            onDragOver: ({ active, over }) =>
+              over
+                ? `Image déplacée sur la position ${over.id}`
+                : `Image ${String(active.id)} en cours de déplacement.`,
+            onDragEnd: ({ active, over }) =>
+              over
+                ? `Image déposée à la position ${over.id} sur ${value.length}.`
+                : `Déplacement annulé.`,
+            onDragCancel: () => 'Déplacement annulé.',
+          },
+        }}
+      >
+        <SortableContext
+          items={value.map((img, i) => idFor(img, i))}
+          strategy={rectSortingStrategy}
+        >
+          <div
+            className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3"
+            data-testid="merchant-product-image-uploader-grid"
+          >
+            {value.map((image, index) => (
+              <SortableSlot
+                key={idFor(image, index)}
+                id={idFor(image, index)}
+                image={image}
+                index={index}
+                productName={productName}
+                disabled={disabled}
+                onRemove={() => handleRemove(index)}
+                onAltChange={(alt) => handleAltChange(index, alt)}
+              />
+            ))}
+
+            {/* Uploading placeholder tiles — one per in-flight upload. */}
+            {Array.from({ length: uploadingCount }).map((_, i) => (
+              <div
+                key={`uploading-${i}`}
+                className="aspect-square rounded-lg bg-muted/60 border border-border flex flex-col items-center justify-center gap-2"
+                data-testid="merchant-product-image-uploader-uploading"
+              >
+                <div className="w-6 h-6 border-2 border-[var(--color-primary)] border-t-transparent rounded-full animate-spin" />
+                <span className="text-[11px] text-muted-foreground">{t('uploading')}</span>
+              </div>
+            ))}
+
+            {/* "+" tile — hidden when at cap. */}
+            {canAdd && (
+              <button
+                type="button"
+                onClick={handlePick}
+                disabled={disabled}
+                className="aspect-square rounded-lg border-2 border-dashed border-border hover:border-[var(--color-primary)] hover:bg-muted/40 transition-colors flex flex-col items-center justify-center gap-1.5 text-muted-foreground"
+                data-testid="merchant-product-image-uploader-add-btn"
+              >
+                <Camera className="w-6 h-6" />
+                <span className="text-[11px]" style={{ color: 'var(--color-primary)' }}>
+                  {value.length === 0 ? t('formPhotoAdd') : '+'}
+                </span>
+              </button>
+            )}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      <p className="text-xs text-muted-foreground mt-3">
+        {t('formPhotoFormats')}
+        {' · '}
+        <span>
+          {value.length}/{MAX_PRODUCT_IMAGES}
+        </span>
+      </p>
+
+      {uploadError && (
+        <p
+          className="text-xs text-destructive mt-1.5"
+          data-testid="merchant-product-image-uploader-error"
+        >
+          {uploadError === 'file_too_large'
+            ? 'Fichier trop volumineux (max 5 Mo)'
+            : uploadError === 'invalid_type'
+              ? 'Format de fichier non supporté'
+              : "Erreur d'envoi — réessayez"}
+        </p>
+      )}
+
+      {value.length === 0 && (
+        <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1.5">
+          <ImageOff className="w-3.5 h-3.5" />
+          Ajoutez au moins une image pour pouvoir publier.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── Sortable slot ──────────────────────────────────────────────────────────
+
+type SlotProps = {
+  id: string;
+  image: ProductImage;
+  index: number;
+  productName: string;
+  disabled: boolean;
+  onRemove: () => void;
+  onAltChange: (alt: string) => void;
+};
+
+function SortableSlot({
+  id,
+  image,
+  index,
+  productName,
+  disabled,
+  onRemove,
+  onAltChange,
+}: SlotProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const isCover = index === 0;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex flex-col gap-1.5 ${isDragging ? 'z-10' : ''}`}
+      data-testid="merchant-product-image-uploader-slot"
+      data-index={index}
+    >
+      <div
+        className={`relative aspect-square rounded-lg overflow-hidden border-2 ${
+          isCover ? 'border-[var(--color-primary)]' : 'border-border'
+        }`}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={image.url}
+          alt=""
+          className="w-full h-full object-cover"
+          draggable={false}
+        />
+
+        {/* "Principale" badge on slot 1 */}
+        {isCover && (
+          <span
+            className="absolute top-1 start-1 px-1.5 py-0.5 rounded text-[10px] font-semibold text-white shadow"
+            style={{ backgroundColor: 'var(--color-primary)' }}
+            data-testid="merchant-product-image-uploader-cover-badge"
+          >
+            Principale
+          </span>
+        )}
+
+        {/* Drag handle — keyboard-focusable, announces via dnd-kit */}
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="absolute top-1 end-1 w-7 h-7 rounded-md bg-black/50 text-white flex items-center justify-center hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-white disabled:opacity-50"
+          aria-label={`Déplacer l'image ${index + 1}`}
+          disabled={disabled}
+          data-testid="merchant-product-image-uploader-drag-handle"
+          data-index={index}
+        >
+          <GripVertical className="w-4 h-4" />
+        </button>
+
+        {/* Delete — bottom-right so it doesn't overlap the drag handle */}
+        <button
+          type="button"
+          onClick={onRemove}
+          className="absolute bottom-1 end-1 w-7 h-7 rounded-md bg-black/50 text-white flex items-center justify-center hover:bg-destructive focus:outline-none focus:ring-2 focus:ring-white disabled:opacity-50"
+          aria-label={`Supprimer l'image ${index + 1}`}
+          disabled={disabled}
+          data-testid="merchant-product-image-uploader-delete-btn"
+          data-index={index}
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Cover label under slot 1 (per founder binding) */}
+      {isCover && (
+        <span className="text-[11px] font-medium text-[var(--color-primary)] text-center">
+          Photo principale
+        </span>
+      )}
+
+      {/* Alt text — placeholder shows the fallback that resolveImageAlt
+          would use at render time. */}
+      <input
+        type="text"
+        value={image.alt}
+        onChange={(e) => onAltChange(e.target.value)}
+        placeholder={getDefaultAlt(productName || 'Produit', index)}
+        aria-label={`Texte alternatif pour l'image ${index + 1} (optionnel)`}
+        disabled={disabled}
+        className="w-full h-8 px-2 border border-border rounded text-[11px] focus:outline-none focus:border-[var(--color-primary)] focus:ring-1 focus:ring-[var(--color-primary)]"
+        data-testid="merchant-product-image-uploader-alt-input"
+        data-index={index}
+      />
+    </div>
+  );
+}

--- a/app/dashboard/produits/actions.ts
+++ b/app/dashboard/produits/actions.ts
@@ -4,6 +4,37 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import type { Merchant } from '@/types/supabase';
+import { MAX_PRODUCT_IMAGES, type ProductImage } from '@/lib/product-images';
+
+/**
+ * Parse + sanitise the `images` JSON blob coming from the product form.
+ * Defence-in-depth against the DB check constraint: we never send more than
+ * MAX_PRODUCT_IMAGES entries, never send malformed shapes, and always fall
+ * back to `[]` if the blob is missing / unparseable (draft-safe).
+ */
+function parseImages(raw: string | null): ProductImage[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .filter(
+      (x): x is { url: string; alt?: string } =>
+        typeof x === 'object' &&
+        x !== null &&
+        typeof (x as { url?: unknown }).url === 'string' &&
+        ((x as { url: string }).url).length > 0,
+    )
+    .slice(0, MAX_PRODUCT_IMAGES)
+    .map((x) => ({
+      url: x.url,
+      alt: typeof x.alt === 'string' ? x.alt : '',
+    }));
+}
 
 async function getMerchantId(): Promise<string> {
   const supabase = await createClient();
@@ -31,7 +62,10 @@ export async function createProduct(formData: FormData): Promise<void> {
   const description = (formData.get('description') as string | null)?.trim() || null;
   const priceMAD = parseFloat(formData.get('price') as string);
   const stock = Math.max(0, parseInt(formData.get('stock') as string) || 0);
-  const imageUrl = (formData.get('image_url') as string | null) || null;
+  // PLZ-090c — images[] is the new source of truth. image_url is kept in
+  // sync with images[0].url as a safety net (dropped in a follow-up migration).
+  const images = parseImages(formData.get('images') as string | null);
+  const imageUrl = images[0]?.url ?? null;
   const isVisible = formData.get('is_visible') === 'true';
   const discountActive = formData.get('discount_active') === 'true';
   const originalPriceRaw = formData.get('original_price');
@@ -48,6 +82,7 @@ export async function createProduct(formData: FormData): Promise<void> {
     price: Math.round(priceMAD * 100),
     stock,
     image_url: imageUrl,
+    images,
     is_visible: isVisible,
     discount_active: discountActive,
     original_price: originalPrice,
@@ -70,7 +105,8 @@ export async function updateProduct(productId: string, formData: FormData): Prom
   const description = (formData.get('description') as string | null)?.trim() || null;
   const priceMAD = parseFloat(formData.get('price') as string);
   const stock = Math.max(0, parseInt(formData.get('stock') as string) || 0);
-  const imageUrl = (formData.get('image_url') as string | null) || null;
+  const images = parseImages(formData.get('images') as string | null);
+  const imageUrl = images[0]?.url ?? null;
   const isVisible = formData.get('is_visible') === 'true';
   const discountActive = formData.get('discount_active') === 'true';
   const originalPriceRaw = formData.get('original_price');
@@ -88,6 +124,7 @@ export async function updateProduct(productId: string, formData: FormData): Prom
       price: Math.round(priceMAD * 100),
       stock,
       image_url: imageUrl,
+      images,
       is_visible: isVisible,
       discount_active: discountActive,
       original_price: originalPrice,

--- a/lib/product-images.ts
+++ b/lib/product-images.ts
@@ -67,3 +67,69 @@ export function resolveImageAlt(
   const trimmed = (image.alt ?? '').trim();
   return trimmed.length > 0 ? trimmed : getDefaultAlt(productName, index);
 }
+
+// ── PLZ-090c merchant-form mutation helpers ────────────────────────────────
+// Pure (no side effects) — safe for use in optimistic React state updates.
+// Always return a NEW array so React sees a reference change.
+
+/**
+ * Reorder helper for the drag-to-reorder gallery. Returns a new array with
+ * the image at `fromIndex` moved to `toIndex`. Out-of-bounds indexes are
+ * clamped to a no-op (returns a shallow copy) so the UI cannot corrupt the
+ * array via a stale drag event.
+ */
+export function reorderImages(
+  images: ProductImage[],
+  fromIndex: number,
+  toIndex: number,
+): ProductImage[] {
+  const next = images.slice();
+  if (
+    fromIndex < 0 || fromIndex >= next.length ||
+    toIndex < 0 || toIndex >= next.length ||
+    fromIndex === toIndex
+  ) {
+    return next;
+  }
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+/**
+ * Delete helper. Returns a new array without the image at `index`.
+ * Out-of-bounds indexes return a shallow copy (no-op).
+ */
+export function removeImageAt(images: ProductImage[], index: number): ProductImage[] {
+  if (index < 0 || index >= images.length) {
+    return images.slice();
+  }
+  const next = images.slice();
+  next.splice(index, 1);
+  return next;
+}
+
+/**
+ * Guard used by the "+" tile to know whether another upload slot should be
+ * offered. The client-side soft cap enforces the same 8-image limit as the
+ * DB check constraint (see 20260423000001_plz090a_product_images_jsonb.sql).
+ */
+export function canAddImage(images: ProductImage[]): boolean {
+  return images.length < MAX_PRODUCT_IMAGES;
+}
+
+/**
+ * Publish-time guard. Founder requirement (PLZ-090c): merchants may save a
+ * draft with 0 images but must supply at least one image before publishing.
+ *
+ * Returns a discriminated result object so callers can surface the French
+ * error message without re-deriving the copy each time.
+ */
+export function validateImagesForPublish(
+  images: ProductImage[],
+): { ok: true } | { ok: false; reason: string } {
+  if (images.length < 1) {
+    return { ok: false, reason: 'Au moins une image est requise pour publier' };
+  }
+  return { ok: true };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "plaza-platform",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/ssr": "^0.5",
@@ -592,6 +595,59 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "seed:test-merchant-pin": "node scripts/reset-test-merchant-pin.js"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.5",

--- a/tests/unit/product-images.test.ts
+++ b/tests/unit/product-images.test.ts
@@ -2,8 +2,16 @@ import {
   getProductImages,
   getDefaultAlt,
   resolveImageAlt,
+  reorderImages,
+  removeImageAt,
+  canAddImage,
+  validateImagesForPublish,
   MAX_PRODUCT_IMAGES,
 } from '@/lib/product-images'
+
+function img(url: string, alt = ''): { url: string; alt: string } {
+  return { url, alt }
+}
 
 describe('MAX_PRODUCT_IMAGES', () => {
   it('matches the DB check constraint (8)', () => {
@@ -69,5 +77,89 @@ describe('resolveImageAlt', () => {
 
   it('falls back to default when alt is whitespace-only', () => {
     expect(resolveImageAlt({ alt: '   ' }, 'Sneaker Pro', 1)).toBe('Sneaker Pro image 2')
+  })
+})
+
+describe('reorderImages', () => {
+  it('moves an image forward (first → last)', () => {
+    const input = [img('a'), img('b'), img('c')]
+    expect(reorderImages(input, 0, 2)).toEqual([img('b'), img('c'), img('a')])
+  })
+
+  it('moves an image backward (last → first)', () => {
+    const input = [img('a'), img('b'), img('c')]
+    expect(reorderImages(input, 2, 0)).toEqual([img('c'), img('a'), img('b')])
+  })
+
+  it('returns a new array (immutability)', () => {
+    const input = [img('a'), img('b')]
+    const output = reorderImages(input, 0, 1)
+    expect(output).not.toBe(input)
+    expect(input).toEqual([img('a'), img('b')]) // original untouched
+  })
+
+  it('is a no-op when from === to', () => {
+    const input = [img('a'), img('b'), img('c')]
+    expect(reorderImages(input, 1, 1)).toEqual(input)
+  })
+
+  it('clamps out-of-range indexes to a no-op copy', () => {
+    const input = [img('a'), img('b')]
+    expect(reorderImages(input, -1, 1)).toEqual(input)
+    expect(reorderImages(input, 0, 99)).toEqual(input)
+  })
+})
+
+describe('removeImageAt', () => {
+  it('removes the image at the given index', () => {
+    const input = [img('a'), img('b'), img('c')]
+    expect(removeImageAt(input, 1)).toEqual([img('a'), img('c')])
+  })
+
+  it('returns a new array (immutability)', () => {
+    const input = [img('a'), img('b')]
+    const output = removeImageAt(input, 0)
+    expect(output).not.toBe(input)
+    expect(input).toEqual([img('a'), img('b')])
+  })
+
+  it('is a no-op for out-of-range indexes', () => {
+    const input = [img('a')]
+    expect(removeImageAt(input, -1)).toEqual(input)
+    expect(removeImageAt(input, 5)).toEqual(input)
+  })
+
+  it('handles empty array', () => {
+    expect(removeImageAt([], 0)).toEqual([])
+  })
+})
+
+describe('canAddImage', () => {
+  it('returns true below the soft cap', () => {
+    expect(canAddImage([])).toBe(true)
+    expect(canAddImage(Array(MAX_PRODUCT_IMAGES - 1).fill(img('a')))).toBe(true)
+  })
+
+  it('returns false at the soft cap', () => {
+    expect(canAddImage(Array(MAX_PRODUCT_IMAGES).fill(img('a')))).toBe(false)
+  })
+})
+
+describe('validateImagesForPublish', () => {
+  it('rejects empty arrays with a French reason', () => {
+    const result = validateImagesForPublish([])
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe('Au moins une image est requise pour publier')
+    }
+  })
+
+  it('accepts a single image', () => {
+    expect(validateImagesForPublish([img('a')])).toEqual({ ok: true })
+  })
+
+  it('accepts a full gallery', () => {
+    const full = Array.from({ length: MAX_PRODUCT_IMAGES }, (_, i) => img(`u${i}`))
+    expect(validateImagesForPublish(full)).toEqual({ ok: true })
   })
 })


### PR DESCRIPTION
## Summary
Final PR of PLZ-090 sprint. Merchant dashboard now supports a multi-image product gallery (up to 8 images) with drag-to-reorder, per-image delete + alt text, and a "Photo principale" cover label on slot 1.

## Founder constraints met
- [x] Drag-to-reorder (dnd-kit + keyboard a11y via `sortableKeyboardCoordinates`)
- [x] "Photo principale" label on slot 1 + "Principale" badge + emphasized border
- [x] Per-image delete
- [x] Per-image upload progress (boolean `uploading` pattern from PLZ-080, matched to existing BoutiqueForm idiom — spinner tile + `t('uploading')` "Téléversement...")
- [x] Alt text field per image (optional, placeholder shows `{productName} image N` via `getDefaultAlt`, falls back at render time via `resolveImageAlt`)
- [x] Soft cap 8 client-side via `canAddImage` (DB `products_images_shape` check constraint is the backup)
- [x] Min >=1 image required on publish (`validateImagesForPublish`). Product form has no draft path today — every save is treated as a publish.
- [x] Reuses `lib/product-images.ts` helpers from PLZ-090b; no duplication

## Dependency added
- `@dnd-kit/core ^6.3.1` + `@dnd-kit/sortable ^10.0.0` + `@dnd-kit/utilities ^3.2.2`
- Chosen over `react-beautiful-dnd` for built-in keyboard a11y (`sortableKeyboardCoordinates` + dnd-kit's announcer) and lighter weight (~20 KB gzipped combined)
- No existing drag-reorder library in the repo — grepped `package.json` before adding

## Extended helpers (`lib/product-images.ts`)
- `reorderImages(images, from, to): ProductImage[]` — pure, returns new array, clamps out-of-range to no-op
- `removeImageAt(images, index): ProductImage[]` — pure, no-op for out-of-range
- `canAddImage(images): boolean` — soft-cap guard
- `validateImagesForPublish(images): { ok: true } | { ok: false, reason: string }` — French error message colocated with the rule

## Migration-safe
- On load: `getProductImages(product)` seeds state — prefers `images[]`, falls back to `[{ url: image_url, alt: '' }]` for pre-090a rows
- On save: server action writes BOTH `images` (new jsonb) AND `image_url = images[0]?.url ?? null` (legacy sync for one more release cycle per 090a migration note)
- `parseImages()` in actions.ts defends the DB constraint (shape validation + MAX 8 slice) before insert/update
- Zero data-loss path for products that predate PLZ-090a's backfill

## Files changed
- `lib/product-images.ts` — 4 new helpers + tests
- `tests/unit/product-images.test.ts` — 14 new tests (24 total, was 10)
- `app/dashboard/produits/_components/ProductImageUploader.tsx` — new component (~310 LOC)
- `app/dashboard/produits/ProductForm.tsx` — photoCard replaced with `<ProductImageUploader>`; publish validation calls `validateImagesForPublish`; form submit writes `images` + syncs legacy `image_url`
- `app/dashboard/produits/actions.ts` — `parseImages()` sanitiser; `createProduct` + `updateProduct` persist `images[]` and keep `image_url` in sync
- `app/dashboard/produits/ProductsClient.tsx` — mobile card list + desktop table cover image now come from `getProductImages(product)[0]?.url` (matches slot 1 of the uploader)
- `package.json` / `package-lock.json` — dnd-kit deps

## End-to-end test verified
- Merchant login (+212666666666 / 1234) -> /dashboard/produits/nouveau
- Uploaded 3 images, reordered (keyboard a11y: focus handle -> Space -> ArrowRight -> Space flipped slot 0/1), deleted slot 2, filled alt text "Hero shot test" on slot 0, saved
- Publish with 0 images -> blocked with French error "Au moins une image est requise pour publier"; stays on form URL

## DB verification (post-save)
```
id:        d00609ea-6b86-45c5-ae4a-67eabc3625fe
name_fr:   PLZ-090c Test Product
image_url: https://.../1776959238135.png         <- images[0].url (legacy sync)
images:    [
  { "url": "https://.../1776959238135.png", "alt": "Hero shot test" },
  { "url": "https://.../1776959238059.png", "alt": "" }
]
```

## Storefront round-trip
- Opened `/store/boutique-test2/produit/d00609ea-6b86-45c5-ae4a-67eabc3625fe`
- PLZ-090b ProductImageGallery renders both images in the saved order
- Merchant-entered alt "Hero shot test" carries through to the storefront `alt` attribute
- Zero storefront code changes in this PR — existing ProductImageGallery reads the new `images[]` column via the 090b path

## Dashboard list round-trip
- `/dashboard/produits` cover image for the test product = `1776959238135.png` (slot 1 after reorder)
- Pre-existing single-image products on the same page still render correctly via `image_url` fallback

## Build + tests
- `npx tsc --noEmit` — exit 0
- `npx jest tests/unit/` — 29/29 pass (was 15)
- `npm run lint` — worktree-env caveat (pre-existing plugin conflict between repo root `.eslintrc.json` and parent `.eslintrc.json`); not introduced by this PR

## Testid preservation
Preserved (unchanged):
- `merchant-product-form-photo-input` (input ref stays, now multi-file)
- `merchant-product-form-publish-btn`, `merchant-product-form-name-input`, `merchant-product-form-description-textarea`, `merchant-product-form-category-l{1,2,3}-select`, `merchant-product-form-stock-input`, `merchant-product-form-visibility-toggle-checkbox`, `merchant-product-form-price-input`, `merchant-product-form-discount-toggle-checkbox`, `merchant-product-form-original-price-input`, `merchant-product-form-delete-btn` (+ dialog/cancel/confirm)
- `merchant-products-row`, `merchant-products-delete-btn`, `merchant-products-edit-link`, `merchant-products-visibility-toggle-checkbox` (list page)

New:
- `merchant-product-form-image-uploader` (top-level uploader card)
- `merchant-product-image-uploader` (inside the component)
- `merchant-product-image-uploader-grid`
- `merchant-product-image-uploader-slot[data-index]`
- `merchant-product-image-uploader-drag-handle[data-index]`
- `merchant-product-image-uploader-delete-btn[data-index]`
- `merchant-product-image-uploader-alt-input[data-index]`
- `merchant-product-image-uploader-add-btn`
- `merchant-product-image-uploader-uploading` (in-flight upload tile)
- `merchant-product-image-uploader-cover-badge`
- `merchant-product-image-uploader-error`
- `merchant-product-form-images-error` (publish-block banner)

## Rollback
If PLZ-090c surfaces a bug: revert this PR. The merchant form falls back to the single-image path via `image_url` which is still being maintained in-sync, and the storefront's PLZ-090b gallery reads via `getProductImages` which handles both shapes.
