### PR TITLE
docs: back-button flow map (A3) + admin panel UI inspiration brief (Section D Phase 1)

### DIFF
--- a/docs/design/admin-panel-inspiration-brief.md
+++ b/docs/design/admin-panel-inspiration-brief.md
@@ -1,0 +1,227 @@
+# Admin panel — UI inspiration & direction brief
+
+Author: Antonio (product design) · Status: DRAFT — founder review gate before implementation · Date: 2026-04-23 · Scope: Section D Phase 1 of admin build-out
+
+This brief sets the visual and interaction direction for every new admin-panel screen built after PLZ-060/061. It is deliberately opinionated: admin tooling is data-dense operations software, not a consumer interface, and the visual contract should reflect that from day one. It builds on the token vocabulary Hamza already shipped in PR #83 (`.admin-scope` + `--admin-color-*` CSS variables) so no new token additions are required for Phase 1.
+
+---
+
+## 0. What's already in the codebase (anchors, not replacements)
+
+The existing admin surface has the right bones. Any new screen builds on these — don't fork.
+
+- **Shell:** `app/admin/_components/AdminShell.tsx` — 240 px dark sidebar (`#0F172A`) + white topbar + content column. Desktop-first (≥1024 px); `DesktopRequired` blocks below.
+- **Scope + tokens:** `.admin-scope` class applied at the route boundary. All color references use `var(--admin-color-*)` (see `app/globals.css:171-200`). New components MUST NOT reintroduce hex literals — pick the closest token.
+- **Table:** `app/admin/_components/DataTable.tsx` — generic, typed, supports keyboard nav (`j`/`k`/`↑`/`↓`/`Enter`), skeleton loading, empty-state slot, focus-visible left border. Extend this — do not write a second Table.
+- **Status chip:** `app/admin/_components/StatusChip.tsx` — 7 variants today (`pending`, `approved`, `rejected`, `resubmit`, `suspended`, `neutral`, `info`). Vocabulary expanded below.
+- **Filter bar:** `app/admin/_components/FilterBar.tsx` — search input + chip array pattern. Reuse it for every queue/list.
+- **Existing reference screen:** `app/admin/(shell)/drivers/pending/PendingQueueClient.tsx` is the gold standard for a queue today. Match its density and structure on new queues before inventing new patterns.
+
+Rule of thumb: if a new screen needs a pattern we don't have, describe it here first and add it to `_components/` before using it in-page.
+
+---
+
+## 1. Visual density contract
+
+Admin is **measurably tighter** than merchant or storefront. Operators scan rows, not hero sections.
+
+| Dimension | Storefront / merchant | Admin | Ratio |
+| --- | --- | --- | --- |
+| Base body text | 15–16 px | **13–14 px** | ~85 % |
+| Table-row height | 56–64 px (merchant product list) | **40–48 px** | ~75 % |
+| Page content horizontal padding | 16 px mobile / 24 px desktop | **32 px** (`px-8`) inside a `max-w-[1280px]` | — |
+| Section vertical rhythm | 24–32 px between cards | **16–24 px** | tighter |
+| Primary button height | 48–56 px | **36–40 px** (`h-9` / `h-10`) | ~75 % |
+| Chip / badge height | 22–28 px | **18–20 px** | ~80 % |
+| Color-primary usage | hero + CTAs + accents (generous) | **CTA + active-row indicator only** (reserved) | sparing |
+
+Concretely for Phase 1:
+
+- Page headers: `text-[22px] font-semibold`, one line, followed by a `text-[13px] text-[#78716C]` description, max one line. No decorative illustration, no hero gradient.
+- Table headers: 10 px vertical padding, `text-[12px] font-semibold uppercase tracking-wider`, muted (#78716C). Sticky when the table scrolls vertically.
+- Row-hover: `var(--admin-color-row-hover)` (`#F1F5F9`). Row-selected (keyboard nav): `var(--admin-color-row-selected)` (`#F5F5F4`) + 2 px left border in primary.
+- Never more than **one** primary-colored element per sub-section. If there's a primary CTA, the row-selected indicator is enough accent — don't add a second.
+
+---
+
+## 2. Table pattern
+
+Extend `DataTable.tsx`. No new table component.
+
+**Columns are first-class.** Each screen defines a typed `DataTableColumn<T>[]` with explicit `width`, `align`, and `render`. Widths are fixed px (never %) so columns don't reflow as data changes. The first column (entity identity: driver name + avatar, order number, merchant name, etc.) is always the widest and gets the focus-ring left border.
+
+**Column conventions — required for Phase 1 list screens:**
+
+- **Identity column** (always first, unset width → fills remainder): avatar/icon + bold entity name + muted secondary line (phone, email, store slug). 7-letter initials circle using `--admin-color-primary-tint`.
+- **Timestamp column:** show relative time (`Il y a 2h`, `Hier`, `Il y a 3j`) with the absolute time in a native `title` tooltip. Helper: `relativeTime(iso)` in `PendingQueueClient.tsx` — lift to a shared util.
+- **Status column:** always a `<StatusChip>`, never raw text. 110–120 px fixed width.
+- **Quantitative column** (count, delay, amount): `tabular-nums` + right-aligned. 100 px fixed. Never left-align numbers.
+- **Action column** (last): 100 px, right-aligned, `Examiner →` / `Ouvrir →` pattern. Same primary color as CTAs. Full row is clickable — the chevron is affordance only.
+
+**What we ARE adding in Phase 1:**
+
+- **Sticky column headers** (`thead` already renders a tinted row; add `sticky top-0` inside a vertical-scroll container). Critical for long queues (>30 rows).
+- **Column sort indicators.** Today the `sortable` prop exists but nothing renders — add a small up/down caret in the header; use `tabular-nums` in sorted columns.
+- **Row hover reveal.** On hover, show a tiny ghost action (⌘K, inline rejet/promote in Phase 2) at the row's right edge. Keep it subtle — chevron replaced by action cluster.
+
+**What we are explicitly NOT adding yet:**
+
+- Column resize drag handles. Nice-to-have; defer until we have a screen where operators ask for it. Premature.
+- Virtualised rows. Only worth the complexity if a list exceeds ~500 rows; we're nowhere close.
+- Per-column filter dropdowns inside the header. We use the `FilterBar` above the table — keep filter affordances in one place.
+
+---
+
+## 3. Queue pattern
+
+A queue is an ordered list of items awaiting operator action. Current: `/admin/drivers/pending`. Upcoming: `/admin/orders/stuck` (P1), `/admin/deliveries/timed-out` (P2), `/admin/support/open` (P2).
+
+Decision: **queues are rows on desktop, cards on mobile.** Queue cards are NOT used on desktop even for "high-visibility" items — density beats decoration every time for operators on a 27" screen.
+
+**Desktop queue anatomy (top to bottom):**
+1. Page header: title + count chip (`<StatusChip variant="pending">12 dossiers</StatusChip>`) + refresh button (top-right, secondary style).
+2. FilterBar (search + chip array).
+3. DataTable.
+4. Keyboard hint line beneath table: `↑↓ naviguer · Entrée ouvrir`.
+5. Optional pagination (only when count >50; until then, show all rows).
+
+**Row → detail page transition.** Clicking a row `router.push`es to a detail URL (e.g. `/admin/drivers/[id]`). No modal. Rationale: detail pages need deep-links for Slack/email handoffs between operators; modals break that.
+
+**Severity banding.** Queues that have SLAs (e.g. pending >48 h, timed-out deliveries) get a severity chip in the "delay" column: `neutral` for <24h, `pending` (amber) for 24–72h, `rejected` (red) for >72h. Apply this pattern now in the pending-drivers queue too so we don't have to retrofit later.
+
+**Empty state.** Not a marketing-style hero — an operational one. Icon (lucide `Inbox`, stroke-1.5) + bold line ("Aucun dossier en attente") + one-sentence muted explanation. Current empty state in `PendingQueueClient` is the template; reuse verbatim.
+
+**Queue card vs queue row — when to pick which.**
+- **Row:** default. Every new queue on desktop.
+- **Card (mobile only, stacked):** when the operator is on mobile and needs touch-sized targets. Mirror the row's information architecture exactly — same fields, same order — so muscle memory carries across form factors.
+- **Card on desktop:** never. There is no admin screen where a card is the right desktop primitive in Phase 1.
+
+---
+
+## 4. Status chip vocabulary
+
+Extend today's 7-variant `StatusChip` to cover the full admin surface. Colors below are locked to tokens; agents must NOT pick new hexes.
+
+| Severity | Variant token(s) | Background | Text | Use for |
+| --- | --- | --- | --- | --- |
+| **Success** | `approved` | `#F0FDF4` (tint) | `#15803D` | Approved driver, paid order, resolved ticket, active merchant, online driver |
+| **Warning** | `pending`, `resubmit` | `#FEF3C7` | `#92400E` | Pending review, SLA amber (24–72h), awaiting resubmission |
+| **Danger** | `rejected`, `suspended` | `#FEF2F2` | `#B91C1C` | Rejected, suspended, SLA red (>72h), timed-out delivery, failed payment |
+| **Neutral** | `neutral` | `#F5F5F4` | `#44403C` | Default / non-terminal states, "Hors service", inactive filters, count badges without severity |
+| **Info** | `info` | primary-tint | `#1E40AF` | System notice (read-only), "Nouveau", filter-active state, cross-links to other admin sections |
+
+**Rules:**
+
+- Each severity level has exactly one background-text pair. New semantic states reuse an existing variant — we never ship a new color pair for a new status. E.g. "dispatched" = `info` (it's an active pipeline state, not a success), "delivered" = `approved`.
+- Chips are **read-only**. They are never clickable, never act as filter toggles. Use the `FilterBar` chips for filter actions; they look different (heavier weight, primary-tint when active).
+- Never nest a chip inside a button. If a cell both needs a status and an action, put the chip in the status column and the action in the action column.
+- Icon-inside-chip is allowed for two cases only: severity-red (tiny `AlertTriangle`) and "new" info (tiny `Sparkle`). Everywhere else, text-only.
+
+---
+
+## 5. Empty / loading / error states
+
+Ops-first tone. Every state tells the operator what to do next.
+
+**Loading.**
+- Prefer skeleton rows over spinners in any table context. `DataTable` already supports `loading` + `skeletonRows`. Use 6 skeleton rows for queues (matches average fold).
+- For whole-page loads: no full-page blocker. Render the shell + skeleton content underneath. Operators should see the page shape immediately.
+- Spinners: only inline inside buttons during a mutation (e.g. "Approve" → spinner → success chip).
+
+**Empty.**
+- Title: single declarative line in 18 px semibold, reassuring tone — "Aucun dossier en attente" / "Aucune commande bloquée". Never celebratory ("🎉 All clear!"). Never apologetic ("Sorry, nothing here").
+- Subtext: one 13 px muted line telling the operator what would change this view — "Les prochaines soumissions apparaîtront ici automatiquement." / "Les commandes non prises en charge depuis 2h apparaîtront ici."
+- Icon: lucide outline, stroke-1.5, stone-400 color. Never a cartoon illustration.
+
+**Error.**
+- Inline, never toast-only. A toast disappears; an operator error needs to persist until acknowledged.
+- Danger background (`#FEF2F2`) + `AlertTriangle` + one-sentence plain French explanation + primary action ("Réessayer") + secondary action ("Voir les logs" / copy error ID).
+- Include the error ID when we have one. Operators escalate to dev via ID, not screenshots.
+- For partial-failure cases (2 of 5 rows failed to load), show the 3 that loaded + a strip at the top of the table: "2 lignes n'ont pas pu être chargées. Réessayer."
+
+---
+
+## 6. Inspiration references
+
+Real tools to borrow from. For each, annotate what to take and what to leave. These are reference points — the Phase 1 brief is not "clone these" — it's "pick the density, pick the interaction vocabulary, skip the brand".
+
+### 6.1 Linear — issues list
+- **Borrow:** row density (~40 px), keyboard-first nav, subtle row hover, inline status chips left-of-title, avatar initials in brand-tinted circles, workspace-level filter bar that stays pinned, `⌘K` command palette as the global operator shortcut.
+- **Leave:** gradient sidebar, Linear-specific shortcut hints (⌘ overlays), the swap-to-dark-mode marketing vibe, animated priority icons.
+
+### 6.2 Stripe Dashboard — Payments list
+- **Borrow:** quantitative columns with `tabular-nums` + right-align, clickable rows that push to detail pages (not modals), small "severity" dot at the start of a row for at-a-glance scanning, the pattern of "list + detail side-panel" for fast triage (defer actual side-panel until Phase 2, but design toward it).
+- **Leave:** Stripe's signature gradients, the deeply branded primary purple (we use `#1A6BFF`), the segmented control at the top (ours is a chip filter instead).
+
+### 6.3 Retool — Admin tables
+- **Borrow:** sticky headers, compact row heights, clear visual separation between header and body, right-aligned action column, the "rows are the product" mentality.
+- **Leave:** Retool's default "everything is a button" chrome, the heavy top-bar with builder tooling, multiple competing primary colors within a single view.
+
+### 6.4 Supabase Studio — Table editor
+- **Borrow:** monospaced font for IDs (`tabular-nums` + `font-mono` on UUIDs, slugs, phone numbers), minimal column-header styling, skeleton rows over spinners, row selection with keyboard, inline status chips that match our severity vocabulary.
+- **Leave:** the SQL-editor split (we're not building a query tool), the green primary (conflicts with our blue), the dark-by-default theme.
+
+### 6.5 GitHub — Issues / PR list
+- **Borrow:** the combination of bold identity line + muted metadata underneath (author, timestamp, labels), chip cluster in a dedicated column, hover state revealing secondary actions at the row's right edge, empty-state copy tone.
+- **Leave:** GitHub's dense meta-footer per row (we show less metadata), the "reaction" emoji cluster (not an admin pattern), the top tab bar with filter counts (we use the FilterBar instead).
+
+**Screenshot deliverable (follow-up).** I will drop annotated screenshots of the four reference tools into `design-exports/admin-phase1-inspiration/` in the same PR if the founder wants them — today's brief is text-only because the markdown pattern matches `design-exports/plz-090-multi-image-gallery-brief.md`'s text-dominant style and because the tokens/widths/heights above are the load-bearing part, not the mood.
+
+---
+
+## 7. Explicit NON-GOALS
+
+The admin panel is NOT a consumer surface. These are out of scope now and should be defended against in PR review.
+
+- **No hero sections.** Page header is one line of 22 px semibold + one muted subtitle. No banners, no illustrations, no background imagery.
+- **No marketing CTAs.** Admin has operational CTAs only ("Approuver", "Rejeter", "Assigner"). No "Upgrade your plan" / "Invite your team" promos even after we add multi-admin support.
+- **No decorative imagery.** The only images are: driver document previews, merchant logos in tables, order thumbnails in detail pages. No stock photos, no patterns, no gradients.
+- **No animations beyond micro-interactions.** `motion/react` is used for layout shifts only — no staggered enter animations on tables, no flourishes on page transitions. Page loads must feel instant.
+- **No dark mode in Phase 1.** The sidebar is dark; the rest is light. Dark-mode-everywhere is a Phase 3 conversation — not now.
+- **No per-user personalisation.** Every admin sees the same column layout, the same filter chips, the same sort order. Customisation adds state we don't need and makes "can you see what I see" impossible during incident response.
+- **No tooltips on idle state.** Tooltips only appear on truncated text (the timestamp → absolute-time pattern) or on icon-only buttons. We never explain what a visible label means.
+- **No cards on desktop queues.** (Re-iterated from §3.) Rows only.
+- **No toast-only error reporting.** (Re-iterated from §5.) Errors persist inline.
+- **No emoji icons.** Lucide outline only. Emoji in text copy (⚠️, 🎉) is also banned in admin — it breaks the tone.
+
+---
+
+## 8. What happens after founder approval
+
+1. PM turns each Phase-1 screen into a ticket, attaching the relevant sections of this brief as the acceptance criteria.
+2. Dev agent builds against `DataTable` / `StatusChip` / `FilterBar` — no new primitives without amending this brief first.
+3. Each PR gets one gate check from me against the density contract + status vocabulary; Anas gates for code quality. QA gates for data correctness.
+4. First screens expected: `/admin/merchants` list, `/admin/orders` list, `/admin/drivers` directory (active tab alongside pending). All three reuse the same queue skeleton.
+
+---
+
+## Appendix — token quick reference
+
+Pulled from `app/globals.css:171-200`, do not re-invent.
+
+```
+--admin-color-primary:          #1A6BFF   // CTAs, selected-row border, "Examiner" links
+--admin-color-primary-dark:     #1550CC   // button :hover on primary
+--admin-color-primary-tint:     #EFF6FF   // avatar bg, info chip bg
+--admin-color-bg:               #F1F5F9   // page background
+--admin-color-surface:          #FFFFFF   // cards, table, topbar
+--admin-color-text-primary:     #1C1917   // body titles, table cell text
+--admin-color-text-secondary:   #44403C   // secondary values
+--admin-color-text-muted:       #78716C   // subtitles, muted metadata
+--admin-color-text-faint:       #A8A29E   // placeholder, empty-state icons
+--admin-color-border:           #E7E5E4   // card + table borders
+--admin-color-border-soft:      #F5F5F4   // row dividers
+--admin-color-row-hover:        #F1F5F9   // row :hover
+--admin-color-row-selected:     #F5F5F4   // row keyboard-selected
+--admin-color-success:          #16A34A   // approved chip fg, success dot
+--admin-color-success-tint:     #F0FDF4   // approved chip bg
+--admin-color-warning:          #D97706   // pending chip fg (via chip mapping)
+--admin-color-warning-tint:     #FEF3C7   // pending chip bg
+--admin-color-error:            #DC2626   // rejected chip fg
+--admin-color-error-tint:       #FEF2F2   // rejected chip bg
+--admin-color-sidebar-bg:       #0F172A   // sidebar
+--admin-color-sidebar-fg:       #94A3B8   // sidebar label idle
+--admin-color-sidebar-active-bg:#1E3A5F   // sidebar selected
+--admin-color-sidebar-active-border: #1A6BFF
+--admin-color-sidebar-hover-bg: #1E293B
+```

--- a/docs/ux/back-button-flow.md
+++ b/docs/ux/back-button-flow.md
@@ -1,0 +1,69 @@
+# Back-button flow — customer-facing screens
+
+Author: Antonio (product design) · Status: DRAFT — founder review gate before implementation · Date: 2026-04-23
+
+Source of truth for where every back button / "Retour" CTA on the customer side should land, and what state must survive the transition. Compiled by walking every route under `app/store/[slug]/**` and `app/(track)/**`.
+
+Current state audit: every header back button in the flow today calls `router.back()`, which works for a normal forward push sequence but breaks on deep links and on any screen reached via `router.replace` / external URL (e.g. `/track/PLZ-XXXX`, the confirmation → tracking deep link, or an SMS link). The recommendations below shift us from "`router.back()` everywhere" to explicit, intent-driven targets per screen.
+
+---
+
+## Principles
+
+1. **Linear flows (OTP verification, checkout form) — back goes UP the flow, state preserved.**
+   The customer's partially-filled state (cart contents, checkout form fields, OTP entry) must never be thrown away by a back tap. Back = "let me fix the step before", not "start over". Implementation: session-scoped snapshot (what checkout already does with `plaza_pending_order`), plus explicit `router.back()` is acceptable here *because* the navigation path is strictly forward.
+
+2. **Exploratory flows (product detail, store info) — back returns to the browse context with scroll position preserved.**
+   Browsing is the default mode on the storefront. Back from a product must drop the customer on the exact tile they just opened — not at the top of the grid. Implementation: rely on the Next.js App Router's default scroll restoration on `router.back()`, which requires the origin page to remain in the browser history stack (do **not** use `router.replace` when opening a product from the grid).
+
+3. **Terminal screens (tracking, confirmation, 404) — back goes to store home, NOT into the flow that produced them.**
+   Once an order is placed, the customer should never be able to step back into `/verification` or `/commande` (checkout) — those pages are dead for that order. Back from a terminal screen exits to store home or, when the customer arrived via `/track`, to `/track`. Never to cart / checkout / OTP.
+
+---
+
+## Screen-by-screen map
+
+| Screen | Route | Back target | Preserve state? | Why |
+| --- | --- | --- | --- | --- |
+| Store home | `/store/[slug]` | (no back button — it's the root of the customer flow) | N/A | Root of browsing. Closing the tab is the intended exit. |
+| Product detail | `/store/[slug]/produit/[id]` | Store home `/store/[slug]` at the previous scroll position | Yes — scroll position on the grid, selected category chip, search query | Exploratory flow. Classic e-comm pattern: "I opened one product, let me see the next." Requires the storefront to keep scroll state in history (default Next.js App Router behaviour is fine as long as we don't `router.replace` on the grid). |
+| Cart drawer (modal over store home) | overlay on `/store/[slug]` | Closes the drawer, returns to store home underneath | Yes — cart items, category filter, scroll position | Drawer is not a page. Back button is the "X" close icon (+ swipe-down on mobile via `vaul`). Hardware back on Android should also close the drawer before leaving the page; today it exits the page — **fix needed**. |
+| Cart → checkout entry point | (CTA inside cart drawer) | — | — | N/A — this is a forward push; noted only because checkout's back target is "cart". Recommendation for Cart → Checkout: do **not** open the cart drawer back open on back from checkout. Instead return to the store-home underlay (see next row); the customer can re-open cart with one tap. Rationale: re-opening the drawer automatically fights the browser's back-gesture muscle memory. |
+| Checkout | `/store/[slug]/commande` | Store home `/store/[slug]` (NOT the cart drawer) | Yes — cart items persist in `localStorage` and `CartProvider`; form fields are ephemeral (acceptable) | Customer who backs out of checkout wants to add more items or leave. The cart is preserved in storage; customer can re-open it from the floating cart bar. **Recommend: replace `router.back()` with `router.push(/store/[slug])` to make this deterministic on deep-link entry.** |
+| OTP verification | `/store/[slug]/verification` | Checkout `/store/[slug]/commande` with all form fields + address + delivery slot re-hydrated | **Yes — critical** | Linear flow. Today `plaza_pending_order` is written before navigating to /verification but the checkout page does NOT read it on mount — so back wipes the customer's typed address. **Fix: on back to /commande, re-hydrate form state from `plaza_pending_order` sessionStorage; clear only on successful confirmation.** |
+| Confirmation | `/store/[slug]/confirmation` | Store home `/store/[slug]` | No (order is already placed) | Terminal screen. Must NOT allow back into /verification or /commande — both would show stale state and let the customer re-submit. Implementation: `router.replace(confirmation)` from /verification so the back entry in history points to /store/[slug]; or intercept back and redirect to store home. |
+| Order status / tracking (from confirmation deep-link) | `/store/[slug]/commande/[id]` | Store home `/store/[slug]` | No | Terminal. Today's header uses `router.back()` which lands the customer in /confirmation (which itself will bounce them onward, causing a brief flicker) or on /track if they came from there. **Fix: use `router.push(/store/[slug])`** — deterministic, works for SMS deep-links. |
+| Track-order lookup | `/track` | Store home of the last merchant viewed (fallback: close tab / browser back) | N/A — form is ephemeral | Today uses `router.back()`. Acceptable fallback, but note: users arriving via an SMS link have no back history → the "Retour" link in the page body (line 142) does nothing. **Fix: if `history.length <= 1`, hide the in-page Retour CTA; keep hardware back native.** |
+| Track-order result (after entering PLZ-XXXX) | redirects to `/store/[slug]/commande/[id]` | Same as "Order status / tracking" above — back to that merchant's store home | No | **Founder-flagged bug:** currently OrderStatusClient's back calls `router.back()` which sends the customer to `/track` (where they came from), which is correct for that entry path. BUT when the same URL is reached from `/confirmation`, back bounces into /confirmation. Single fix — always `router.push(/store/[slug])` — resolves both. |
+| Store info sheet | modal on `/store/[slug]` (and on some sub-pages) | Closes the sheet, back to the underlying page | Yes | Sheet uses `vaul` Drawer. Close = X button or swipe-down. Same Android hardware-back fix as cart drawer. |
+| Category / filter view | Same route `/store/[slug]` (state held in component) | No separate back — changing `selectedCategory` back to "Tous" is the customer's mental model for "undo filter" | Not applicable (no navigation) | Category chips are in-page state, not a routed view. Important: do NOT promote category to a route param (?cat=...) just to get a back target — it would spam the back stack with filter changes and make real back navigation painful. |
+| 404 / boutique not found | `notFound()` trigger on `/store/[slug]` or `/produit/[id]` | Home `/` or the Plaza root | No | There is nothing useful to go "back" to. Show a "Retour à Plaza" CTA, not a browser back. |
+| Checkout out-of-stock error banner | inline on `/store/[slug]/verification` | Back to `/store/[slug]/commande` (same as normal OTP back) + banner shown there explaining which item was removed | Yes — cart is already reconciled by the checkout's stock-revalidation effect | Today the error links to `/store/[slug]` directly, which is correct as an ESCAPE path. But the header back button should still return to /commande so the customer can pick a replacement payment method or address without re-entering everything. |
+
+---
+
+## Edge cases to cover in the implementation ticket
+
+- **Deep-link entry (SMS, copy-paste).** `router.back()` on deep-linked pages puts the user outside of Plaza. All terminal screens (`confirmation`, `commande/[id]`, `track`) must use explicit targets (`router.push`) so that "Retour" is always meaningful.
+- **Android hardware back inside a `vaul` Drawer.** Today, hardware back leaves the page with the drawer still considered "open" in state; on the next visit the drawer briefly flashes open. Fix: trap hardware back while drawer is open → close drawer only.
+- **Desktop "Retour" twin.** Desktop product detail page (the 2-col layout at lg+) currently has no back control — customer must use browser back. Add an explicit "← Boutique" breadcrumb in the desktop variant to match the mobile affordance.
+- **iOS swipe-back on the product grid.** Our current scroll-restoration works; verify after any `<Suspense>` boundary change in `StoreHomeClient`, since wrapping list rendering in Suspense resets scroll.
+- **Stale `plaza_pending_order` from a previous aborted checkout.** On mount, `/commande` should reconcile session state with the current cart slug; if the pending order is for a different slug, discard it (today this is done implicitly — make it explicit so rehydrating checkout fields on back from OTP is safe).
+
+---
+
+## Out of scope for this doc
+
+- Merchant dashboard, driver app, admin panel — they are not customer-facing.
+- Hardware gestures beyond Android back + iOS swipe (no 3-finger gestures, no keyboard shortcuts).
+- Browser tab-bar back button accessibility — covered implicitly by matching UI back-button behaviour.
+
+---
+
+## Recommended ticket slicing (for PM to decide)
+
+1. **P0 — `/track` deep-link bug (founder-called-out).** Change OrderStatusClient header back to `router.push(/store/[slug])`. One file, one line. Ships first.
+2. **P1 — Confirmation → no-going-back guard.** Use `router.replace` on navigation from /verification → /confirmation, so back from confirmation lands on store home. One-liner in `verification/page.tsx`.
+3. **P1 — Re-hydrate checkout form from `plaza_pending_order` on mount.** Small refactor in `commande/page.tsx`; makes "back from OTP" preserve the customer's typed address and delivery slot.
+4. **P2 — Drawer hardware-back trap.** Android only; touches `CartDrawer.tsx` + `StoreInfoSheet.tsx`.
+5. **P2 — Desktop product-detail breadcrumb.** UI-only; adds "← Boutique" link in the lg: variant.


### PR DESCRIPTION
## Summary

Two drafts for founder review before any implementation work. Nothing is implemented; no code changes.

- **`docs/ux/back-button-flow.md`** — intended back-button behavior for every customer-facing screen under `app/store/[slug]/**` and `app/track/**`. Principles section (linear / exploratory / terminal), per-screen table with back target + state-preservation requirements, edge cases, and proposed ticket slicing. Captures the `/track/PLZ-XXXX` back-into-`/checkout` bug as the P0 fix.
- **`docs/design/admin-panel-inspiration-brief.md`** — UI direction for admin panel build-out after PLZ-060/061. Density contract (admin ~75–85 % tighter than merchant/storefront), Table / Queue / Status-chip patterns mapped to existing `_components` primitives (`DataTable`, `StatusChip`, `FilterBar`), loading / empty / error states, five inspiration references (Linear / Stripe Dashboard / Retool / Supabase Studio / GitHub) with borrow-vs-leave annotations, and explicit NON-GOALS to defend against consumer-polish drift in review.

Both documents build on tokens already shipped in PR #83 (`.admin-scope` + `--admin-color-*`) and the design-refresh sprint close — no new tokens, no new primitives proposed for Phase 1.

## Test plan

Docs-only PR — no runtime behavior changed, no QA required.

- [ ] Founder: review `docs/ux/back-button-flow.md` — confirm the 3 principles and screen-by-screen table match intended customer behavior; confirm the proposed P0/P1/P2 ticket slicing.
- [ ] Founder: review `docs/design/admin-panel-inspiration-brief.md` — confirm density contract, status-chip vocabulary, queue pattern, and NON-GOALS are the right direction for Section D Phase 1.
- [ ] Founder merges (or redirects) via Anas; do NOT self-merge.

Reported to PM via Antonio.