### PR TITLE
fix(checkout): free-delivery threshold unit mismatch (PLZ-A2) — money bug

### DIFF
--- a/app/store/[slug]/_components/StoreHomeClient.tsx
+++ b/app/store/[slug]/_components/StoreHomeClient.tsx
@@ -161,6 +161,7 @@ export function StoreHomeClient({
         open={cartOpen}
         onClose={() => setCartOpen(false)}
         slug={slug}
+        freeThreshold={merchant.delivery_free_threshold ?? undefined}
       />
 
       <StoreInfoSheet

--- a/app/store/[slug]/_lib/deliveryUtils.ts
+++ b/app/store/[slug]/_lib/deliveryUtils.ts
@@ -1,16 +1,27 @@
-export const FREE_DELIVERY_THRESHOLD = 500; // MAD
+export const FREE_DELIVERY_THRESHOLD = 500; // MAD — platform default when merchant has no override
 export const BASE_DELIVERY_FEE = 30; // MAD
 
 /**
  * Returns the delivery fee in MAD.
- * @param subtotal - cart subtotal in MAD
- * @param threshold - free-delivery threshold in MAD (defaults to FREE_DELIVERY_THRESHOLD)
+ *
+ * @param subtotalMad    cart subtotal in MAD
+ * @param thresholdCents merchant free-delivery threshold in centimes (raw DB value).
+ *                       `null`/`undefined` falls back to FREE_DELIVERY_THRESHOLD (MAD).
+ *
+ * NOTE: the threshold column in `merchants.delivery_free_threshold` is stored in
+ * centimes like all other monetary integers. This helper normalizes to MAD
+ * internally so callers can pass the raw DB value without converting.
+ * PLZ-A2 (2026-04-24): the previous signature treated both args as MAD, which
+ * overcharged PLZ-1008 (995 MAD subtotal with a 500 MAD threshold stored as
+ * 50 000 centimes → compared 995 >= 50000 → charged 30 MAD instead of 0).
  */
 export function getDeliveryFee(
-  subtotal: number,
-  threshold: number = FREE_DELIVERY_THRESHOLD,
+  subtotalMad: number,
+  thresholdCents?: number | null,
 ): number {
-  return subtotal >= threshold ? 0 : BASE_DELIVERY_FEE;
+  const thresholdMad =
+    thresholdCents == null ? FREE_DELIVERY_THRESHOLD : thresholdCents / 100;
+  return subtotalMad >= thresholdMad ? 0 : BASE_DELIVERY_FEE;
 }
 
 // SAAD-003: generateOrderNumber() removed — order numbers are now generated

--- a/tests/unit/deliveryUtils.test.ts
+++ b/tests/unit/deliveryUtils.test.ts
@@ -1,0 +1,65 @@
+import {
+  getDeliveryFee,
+  FREE_DELIVERY_THRESHOLD,
+  BASE_DELIVERY_FEE,
+} from '@/app/store/[slug]/_lib/deliveryUtils'
+
+describe('getDeliveryFee — unit normalization (PLZ-A2 regression)', () => {
+  it('PLZ-1008 repro: subtotal 995 MAD, threshold 50 000 centimes → free', () => {
+    // Exact production case: merchant "Boutique test" had
+    // delivery_free_threshold = 50 000 centimes (500 MAD).
+    // Customer subtotal was 995 MAD. Expected fee = 0.
+    // Pre-fix (helper treated threshold as MAD) this returned 30 MAD.
+    expect(getDeliveryFee(995, 50000)).toBe(0)
+  })
+
+  it('subtotal strictly above threshold → free', () => {
+    expect(getDeliveryFee(600, 50000)).toBe(0)
+  })
+
+  it('subtotal strictly below threshold → base fee', () => {
+    expect(getDeliveryFee(200, 50000)).toBe(BASE_DELIVERY_FEE)
+  })
+
+  it('subtotal equal to threshold → free (inclusive boundary)', () => {
+    expect(getDeliveryFee(500, 50000)).toBe(0)
+  })
+})
+
+describe('getDeliveryFee — missing/edge-case thresholds', () => {
+  it('threshold undefined → falls back to platform default (500 MAD)', () => {
+    expect(getDeliveryFee(499)).toBe(BASE_DELIVERY_FEE)
+    expect(getDeliveryFee(500)).toBe(0)
+    expect(getDeliveryFee(501)).toBe(0)
+  })
+
+  it('threshold null → falls back to platform default (500 MAD)', () => {
+    expect(getDeliveryFee(499, null)).toBe(BASE_DELIVERY_FEE)
+    expect(getDeliveryFee(500, null)).toBe(0)
+  })
+
+  it('threshold 0 → always free (merchant opted for no threshold)', () => {
+    expect(getDeliveryFee(1, 0)).toBe(0)
+    expect(getDeliveryFee(0, 0)).toBe(0)
+  })
+
+  it('merchant threshold higher than platform default (20 000 MAD)', () => {
+    expect(getDeliveryFee(1000, 2_000_000)).toBe(BASE_DELIVERY_FEE)
+    expect(getDeliveryFee(20_000, 2_000_000)).toBe(0)
+  })
+
+  it('merchant threshold lower than platform default (100 MAD)', () => {
+    expect(getDeliveryFee(99, 10000)).toBe(BASE_DELIVERY_FEE)
+    expect(getDeliveryFee(100, 10000)).toBe(0)
+  })
+})
+
+describe('getDeliveryFee — exported constants stay MAD', () => {
+  it('FREE_DELIVERY_THRESHOLD is 500 MAD', () => {
+    expect(FREE_DELIVERY_THRESHOLD).toBe(500)
+  })
+
+  it('BASE_DELIVERY_FEE is 30 MAD', () => {
+    expect(BASE_DELIVERY_FEE).toBe(30)
+  })
+})


### PR DESCRIPTION
## Root cause

`getDeliveryFee(subtotal, threshold)` in `app/store/[slug]/_lib/deliveryUtils.ts` treated **both** arguments as MAD. But `merchants.delivery_free_threshold` is stored in **centimes**, like every other monetary integer on the platform. Every checkout caller passed the raw DB centimes value, so the comparison was `subtotalMAD >= thresholdCentimes` — a merchant with a 500 MAD threshold (= 50 000 centimes) would never trigger free delivery unless the subtotal itself was 50 000 MAD.

### PLZ-1008 repro (from founder's 2026-04-23 manual test)
- Merchant `Boutique test`, `delivery_free_threshold = 50000` (500 MAD)
- Customer subtotal: 995 MAD
- Pre-fix: `995 >= 50000` → `false` → charged **30 MAD**
- Post-fix: `995 >= (50000/100 = 500)` → `true` → charged **0 MAD** ✅

PM audit confirmed PLZ-1008 is the **only** affected order platform-wide (72h window + all-time). No customer refund required — founder's own test account.

## Before / after

```diff
-// threshold in MAD, defaulted to FREE_DELIVERY_THRESHOLD (500 MAD)
-export function getDeliveryFee(subtotal: number, threshold: number = FREE_DELIVERY_THRESHOLD) {
-  return subtotal >= threshold ? 0 : BASE_DELIVERY_FEE;
-}
+// subtotalMad in MAD, thresholdCents raw centimes from merchants.delivery_free_threshold
+export function getDeliveryFee(subtotalMad: number, thresholdCents?: number | null): number {
+  const thresholdMad = thresholdCents == null ? FREE_DELIVERY_THRESHOLD : thresholdCents / 100;
+  return subtotalMad >= thresholdMad ? 0 : BASE_DELIVERY_FEE;
+}
```

## Files changed (3)
- `app/store/[slug]/_lib/deliveryUtils.ts` — helper normalizes units internally; param renamed `thresholdCents`; doc comment explains the historical bug. `FREE_DELIVERY_THRESHOLD` (500 MAD) and `BASE_DELIVERY_FEE` (30 MAD) constants preserved for `StoreInfoSheet` which was already unit-aware.
- `app/store/[slug]/_components/StoreHomeClient.tsx` — wires `merchant.delivery_free_threshold ?? undefined` into `CartDrawer` (previously unwired, which silently masked the bug in the cart drawer summary by falling back to the platform default of 500 MAD).
- `tests/unit/deliveryUtils.test.ts` — **new**, 11 cases.

## No caller-side changes needed
Every caller was already passing centimes. The callers were correct; the helper was lying about the unit. Fixing the helper is the minimum change. The 3 call sites (`commande/page.tsx:201`, `verification/page.tsx:192-203`, `CartDrawer.tsx:203`) require zero edits.

## Test coverage

`tests/unit/deliveryUtils.test.ts` — **11 passing**, 0 failing locally.

- ✅ PLZ-1008 exact repro: `getDeliveryFee(995, 50000) === 0`
- ✅ Subtotal > threshold → free
- ✅ Subtotal < threshold → base fee
- ✅ Subtotal == threshold → free (inclusive `>=` boundary documented)
- ✅ Threshold `undefined` → platform default (500 MAD)
- ✅ Threshold `null` → platform default (500 MAD)
- ✅ Threshold `0` → always free (merchant opted out)
- ✅ Merchant threshold higher than default (2 000 000 centimes / 20 000 MAD)
- ✅ Merchant threshold lower than default (10 000 centimes / 100 MAD)
- ✅ Constants `FREE_DELIVERY_THRESHOLD` / `BASE_DELIVERY_FEE` unchanged (protects StoreInfoSheet)

```
Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
```

## Sibling audit (out of scope, flagged for follow-up)
- Plaza commission is computed server-side only — not in storefront call path. Clean.
- No tax logic exists in the repo (grep zero hits). No risk.
- Only delivery-fee path exhibited this unit mismatch.

## Local gates
- `npm run type-check` → clean ✅
- `npm run lint` → only pre-existing `<img>` warnings in files this PR doesn't touch ✅
- `npx jest tests/unit/deliveryUtils.test.ts` → 11/11 ✅

## Attribution
Root cause + fix design: **Hamza** (his agent session was sandbox-blocked on git/GitHub writes after completing the diagnosis — see PM memory 2026-04-24). Implementation landed by PM to unblock Sprint 1 close. Anas owns QA + merge per protocol.

## No DB touch
Per founder call, PLZ-1008 stays as-is in the DB. Internal test account; no refund.

## QA checklist for Anas
- [ ] Phase 1 — tsc, lint, CI check-runs on tip SHA (new rule — see `.agents/qa/CLAUDE.md`)
- [ ] Phase 2 — no new routes, SKIP_INTL untouched
- [ ] Phase 3 — centimes/100 conversion now correct; cart→checkout→verification path threads right
- [ ] Phase 4 — no UI change; CartDrawer summary will now show "Gratuite" correctly for merchants whose threshold ≠ 500 MAD
- [ ] Phase 5 — browser test: set Boutique test threshold to 500 MAD, add 995 MAD of cart, verify `Livraison = Gratuite` in cart drawer AND at checkout
- [ ] Phase 6 — complete a full order at subtotal > threshold → confirm `orders.delivery_fee === 0` in DB

— Othmane (PM)