### PR TITLE
feat(driver): B5 — wire delivery success page to real data

### DIFF
--- a/app/driver/livraisons/[id]/success/page.tsx
+++ b/app/driver/livraisons/[id]/success/page.tsx
@@ -1,11 +1,75 @@
+// app/driver/livraisons/[id]/success/page.tsx
+// Driver delivery success / summary screen.
+// Reads real data from the deliveries row (B5): distance_km, accepted_at→delivered_at
+// duration (falls back to estimated_duration_min), driver_earnings_mad.
+// Missing values render "—" rather than 0, so the driver is never misinformed.
+
 import { CheckCircle2 } from 'lucide-react';
 import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { getDriverProfile, getDeliverySummary } from '@/lib/db/driver';
 
-export default function SuccessPage() {
+const FALLBACK = '—';
+
+function formatDistance(km: number | null): string {
+  if (km == null || !Number.isFinite(km)) return FALLBACK;
+  return `${km.toFixed(1)} km`;
+}
+
+function formatDuration(minutes: number | null): string {
+  if (minutes == null || !Number.isFinite(minutes) || minutes < 0) return FALLBACK;
+  return `${Math.round(minutes)} min`;
+}
+
+function formatEarnings(mad: number | null): string {
+  if (mad == null || !Number.isFinite(mad)) return FALLBACK;
+  return `${Math.round(mad)} MAD`;
+}
+
+/**
+ * Prefer the actual measured duration (delivered_at - accepted_at) when both
+ * timestamps are present. Fall back to the route's estimated_duration_min
+ * otherwise, and finally to null (rendered as FALLBACK).
+ */
+function resolveDurationMinutes(
+  acceptedAt: string | null,
+  deliveredAt: string | null,
+  estimatedMin: number | null,
+): number | null {
+  if (acceptedAt && deliveredAt) {
+    const start = Date.parse(acceptedAt);
+    const end = Date.parse(deliveredAt);
+    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+      return (end - start) / 60_000;
+    }
+  }
+  return estimatedMin;
+}
+
+export default async function SuccessPage({ params }: { params: { id: string } }) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/driver/auth/phone');
+
+  const driver = await getDriverProfile(user.id);
+  if (!driver) redirect('/driver/auth/phone');
+
+  const summary = await getDeliverySummary(params.id, driver.id);
+  if (!summary) notFound();
+
+  const durationMin = resolveDurationMinutes(
+    summary.accepted_at,
+    summary.delivered_at,
+    summary.estimated_duration_min,
+  );
+
   return (
     <main className="min-h-screen flex flex-col">
-      <div className="flex-none h-[45vh] flex flex-col items-center justify-center"
-        style={{ background: 'linear-gradient(180deg, #16A34A 0%, #15803D 100%)' }}>
+      <div
+        className="flex-none h-[45vh] flex flex-col items-center justify-center"
+        style={{ background: 'linear-gradient(180deg, #16A34A 0%, #15803D 100%)' }}
+      >
         <CheckCircle2 className="w-20 h-20 text-white" strokeWidth={2.5} />
         <h1 className="text-[26px] font-bold text-white mt-3">Livraison effectuée !</h1>
         <span className="mt-2 text-white text-[13px] font-semibold bg-white/20 px-3 py-1 rounded-full">
@@ -19,16 +83,31 @@ export default function SuccessPage() {
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <span className="text-[#78716C] text-sm">Distance parcourue:</span>
-              <span className="text-sm text-[#1C1917] ml-auto">N/A</span>
+              <span
+                className="text-sm text-[#1C1917] ml-auto"
+                data-testid="driver-delivery-success-distance"
+              >
+                {formatDistance(summary.distance_km)}
+              </span>
             </div>
             <div className="flex items-center gap-2">
               <span className="text-[#78716C] text-sm">Durée:</span>
-              <span className="text-sm text-[#1C1917] ml-auto">N/A</span>
+              <span
+                className="text-sm text-[#1C1917] ml-auto"
+                data-testid="driver-delivery-success-duration"
+              >
+                {formatDuration(durationMin)}
+              </span>
             </div>
             <div className="border-t border-gray-100 my-2" />
             <div className="flex items-center justify-between">
               <span className="text-sm text-green-600">Gains:</span>
-              <span className="text-base font-bold text-green-600">Calculé lundi</span>
+              <span
+                className="text-base font-bold text-green-600"
+                data-testid="driver-delivery-success-earnings"
+              >
+                {formatEarnings(summary.driver_earnings_mad)}
+              </span>
             </div>
           </div>
         </div>

--- a/lib/db/driver.ts
+++ b/lib/db/driver.ts
@@ -179,6 +179,37 @@ export async function getDeliveryById(
   return data ? normaliseDelivery(data) : null;
 }
 
+// ─── Fetch delivery summary for success page ──────────────────────────────
+
+export type DeliverySummary = {
+  id: string;
+  distance_km: number | null;
+  estimated_duration_min: number | null;
+  driver_earnings_mad: number | null;
+  accepted_at: string | null;
+  delivered_at: string | null;
+};
+
+/**
+ * Fetch the minimal set of fields needed to render the delivery success
+ * summary. Returns null if the delivery does not exist or does not belong
+ * to the given driver — callers should render notFound() in that case.
+ */
+export async function getDeliverySummary(
+  deliveryId: string,
+  driverId: string,
+): Promise<DeliverySummary | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('deliveries')
+    .select('id, distance_km, estimated_duration_min, driver_earnings_mad, accepted_at, delivered_at')
+    .eq('id', deliveryId)
+    .eq('driver_id', driverId)
+    .maybeSingle<DeliverySummary>();
+  if (error) throw new Error(`getDeliverySummary: ${error.message}`);
+  return data ?? null;
+}
+
 // ─── Fetch completed deliveries for history ───────────────────────────────
 
 export type HistoryDelivery = {


### PR DESCRIPTION
## Scope (B5 — Sprint 2)

Replaces hardcoded `N/A` placeholders on the driver delivery success screen with real values from the `deliveries` row.

### Data source mapping

| Display field | Source | Fallback |
|---|---|---|
| Distance parcourue | `deliveries.distance_km` | `—` if null / non-finite |
| Durée | `delivered_at - accepted_at` if both timestamps present, else `estimated_duration_min` | `—` if neither available / negative diff |
| Gains | `deliveries.driver_earnings_mad` | `—` if null / non-finite |

Computed duration is preferred over the route's estimate so the driver sees their actual time on the road. If only one of the timestamps is present (delivery not yet finalized), we fall back gracefully.

### Files changed

- `app/driver/livraisons/[id]/success/page.tsx` — wired to real data with `'—'` fallbacks; added `data-testid` attributes for QA
- `lib/db/driver.ts` — new `getDeliverySummary(deliveryId, driverId)` helper, scoped to the minimal field set, enforces driver ownership via `.eq('driver_id', driverId).maybeSingle()`

### Behaviour

- Distance: `"7.3 km"` (1 decimal)
- Duration: `"42 min"` (rounded)
- Earnings: `"45 MAD"` (rounded)
- Any null / NaN / negative-diff field renders `—` rather than `0` so the driver is never misinformed
- Unauthorized delivery (wrong driver_id) → `notFound()` (consistent with existing patterns in `lib/db/driver.ts`)

### Quality gates

- [x] `tsc --noEmit` → exit 0
- [x] `next lint` → exit 0 (only pre-existing `<img>` warnings on unrelated storefront files)
- [x] No new dependencies
- [x] Graceful null/edge-case handling on every real-data field
- [ ] Phase 5 browser test — **deferred to Anas / founder manual**, see "PM-direct context" below

### PM-direct context

Hamza subagent dispatch (`agent-a6fbb70d`) stalled at 600s watchdog on the `tsc --noEmit` step before producing any commits. Per the founder-approved cluster-stall sequential-dispatch protocol (2026-04-25), PM completed the last-mile mechanics (tsc/lint/commit/push/PR) directly. Same pattern as the A2 fix `f531550` from PR #96.

### Test checklist for QA

1. Open a delivered `deliveries` row in DB with all 5 fields populated → success page shows real values
2. Open one with `distance_km = NULL` → renders `—`
3. Open one where `accepted_at < delivered_at` → duration = computed actual (not estimated)
4. Open one where `accepted_at = NULL` but `estimated_duration_min` set → duration = estimate
5. Open one where both timestamps and estimate are NULL → duration = `—`
6. Open one with another driver's delivery as the wrong driver → 404
7. Earnings: `driver_earnings_mad = 0` → renders `0 MAD` (a real zero is valid, only null/non-finite falls back)

### Tracking

Closes Sprint 2 / B5. Hamza-original-dispatch worktree `agent-a6fbb70d` produced no usable output before stall — see PM memory log entry for 2026-04-24 evening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>