### PR TITLE
fix(storefront): hide global footer on linear checkout pages

### DIFF
--- a/app/store/[slug]/_components/ConditionalStoreFooter.tsx
+++ b/app/store/[slug]/_components/ConditionalStoreFooter.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { StoreFooter } from './StoreFooter';
+
+const LINEAR_FLOW_SEGMENTS = new Set(['commande', 'verification', 'confirmation']);
+
+export function ConditionalStoreFooter() {
+  const pathname = usePathname();
+  const lastSegment = pathname.split('/').filter(Boolean).pop();
+
+  if (lastSegment && LINEAR_FLOW_SEGMENTS.has(lastSegment)) {
+    return null;
+  }
+
+  return <StoreFooter />;
+}

--- a/app/store/[slug]/layout.tsx
+++ b/app/store/[slug]/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 import { getMerchantBySlug } from './actions';
 import { CartProvider } from './_components/CartProvider';
-import { StoreFooter } from './_components/StoreFooter';
+import { ConditionalStoreFooter } from './_components/ConditionalStoreFooter';
 
 type Props = {
   children: ReactNode;
@@ -24,7 +24,9 @@ export default async function StoreLayout({ children, params }: Props) {
   // ProductDetailClient, etc.) so the `onInfoClick` / `onCartClick` handlers
   // are wired to that page's local sheet state. Linear checkout / verification
   // / confirmation flows intentionally omit the tab bar (they use their own
-  // back buttons + CTAs).
+  // back buttons + CTAs). The global StoreFooter is hidden on those same
+  // linear flow pages by ConditionalStoreFooter so the fixed-bottom CTA can
+  // pin to the viewport without stacking against the footer.
   return (
     <CartProvider slug={slug}>
       <div
@@ -32,7 +34,7 @@ export default async function StoreLayout({ children, params }: Props) {
         className="storefront-scope"
       >
         {children}
-        <StoreFooter />
+        <ConditionalStoreFooter />
       </div>
     </CartProvider>
   );


### PR DESCRIPTION
## Why

Founder spot-check 2026-04-28 flagged that the "Confirmer la commande" CTA on `/store/[slug]/commande` was rendering **below** the global storefront footer instead of pinned to the viewport bottom. This blocked all checkout testing.

### Root cause

`app/store/[slug]/layout.tsx` renders `<StoreFooter />` unconditionally after `{children}`. The CTA on the checkout page uses `position: fixed bottom-0` — but on long forms the footer pushes into the viewport above it visually, making the CTA unreachable.

This contradicts the existing intent already captured in a layout comment:
> "Linear checkout / verification / confirmation flows intentionally omit the tab bar (they use their own back buttons + CTAs)."

The tab bar was already excluded from those flows; the footer was the missing half of that intent.

## What changed

- New client component `app/store/[slug]/_components/ConditionalStoreFooter.tsx` reads `usePathname()` and skips rendering on the linear flow segments (`commande`, `verification`, `confirmation`).
- `app/store/[slug]/layout.tsx` swaps `<StoreFooter />` for `<ConditionalStoreFooter />`.
- Order detail page `commande/[id]` keeps the footer (last segment is the orderId, not `commande`).

## Test plan

- [ ] `/store/<slug>` (home) — footer renders
- [ ] `/store/<slug>/produit/<id>` — footer renders
- [ ] `/store/<slug>/commande` — footer hidden, "Confirmer la commande" CTA pinned to viewport bottom
- [ ] `/store/<slug>/verification` — footer hidden
- [ ] `/store/<slug>/confirmation` — footer hidden
- [ ] `/store/<slug>/commande/<orderId>` (order detail) — footer renders

## Verification

- `tsc --noEmit` clean
- `next lint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)