### PR TITLE
chore(pm): Sprint 2 closure docs — schema convention + ops inventory seed

### DIFF
--- a/.agents/pm/memory.md
+++ b/.agents/pm/memory.md
@@ -355,3 +355,108 @@ After A2 merges (final Sprint 1 PR), dispatch Sprint 2: B3 pickup confirmation +
 
 ### Process learning — github MCP vs curl
 Enterprise policy blocks grepping `.env.local` in this session's permission set. All PR/CI operations in this session ran through `mcp__github__*` tools successfully (get_pull_request_status, merge_pull_request, create_issue, add_issue_comment). `gh` CLI still not installed. One limitation: github MCP has no check-runs endpoint — combined status API returns Vercel statuses but not GitHub Actions. When Actions check-run detail is needed, must escalate to founder for alternate access path. Updated user-level feedback memory accordingly.
+
+---
+
+## Session close — 2026-04-24 (evening) — TAG: infra-unstable session
+
+> **Session tag for next-day PM:** This session is marked **infra-unstable**. 4 subagent stalls across 4 dispatches in ~8h (Hamza A2 sandbox-blocked → PM-direct; Hamza B3+B4 stream idle timeout; Hamza B5 600s watchdog; Youssef ConnectionRefused proxy retry loop). Default to **sequential dispatch + narrow scope + PM-direct fallback** per `feedback_cluster_stall_sequential_dispatch.md` until a session restart confirms infra has stabilized. Do not resume parallel dispatch on the next session without a quick stability probe (single small dispatch first, observe outcome).
+
+### Sprint 1 fully closed
+- PR #92 (Antonio docs): MERGED — `35cbed0`
+- PR #93 (A1 i18n) MERGED with E2E flake override — `cd65f57`
+- PR #94 (B2 driver CTAs) MERGED with same flake override — `8369f80`
+- **PR #96 (A2 money-bug fix) MERGED with founder override** — `f531550`. Override comment posted: 11 unit tests cover PLZ-1008 repro + edges, Phase 5 deferred to founder manual spot-check (within 24h) due to known Mapbox/Playwright watchdog issue. Static gates + CI green on tip SHA `0286eb8`.
+- PR #97 (QA CI-gate rule + PM session log): MERGED — `b4484f6`. CI-gate now permanent on `.agents/qa/CLAUDE.md` Phase 1.
+- PR #98 (Saad CLAUDE.md with R1–R4 rules): MERGED — `58a54ba`. Saad persona codified.
+
+### Issue #99 filed — Anas watchdog infrastructure fix
+P1 tech-debt, labelled `infrastructure`/`qa`/`tech-debt`. Tracks the recurring 600s watchdog stalls on Mapbox/Playwright flows. Owner: Youssef-adjacent. Acceptance: Anas subagent runs full Phase 5 on checkout-with-map and driver-app flows without watchdog trip. Until fixed, the watchdog escalation rule (in `feedback_watchdog_escalation_in_briefs.md` user memory) is embedded in every dispatch brief.
+
+### Sprint 2 — partial close (B5 landed PM-direct, B3 dispatched, B4 queued)
+First parallel dispatch attempt failed entirely (3-of-3 stalls):
+- **Hamza B3+B4** (`worktree-agent-abebfae7`) — Stream idle timeout / partial response after 50 tool calls. Worktree had only `lib/db/driver.ts` modified, no commits. **Re-dispatched as B3 alone** with narrow-scope rules (40-call hard cap, 30-call early-stop trigger, no retries).
+- **Hamza B5** (`worktree-agent-a6fbb70d`) — 600s watchdog stall on `tsc --noEmit`. Worktree empty. **Landed via PM-direct as PR #100** (merged `1695cc4`) with founder override; manual spot-check within 24h.
+- **Youssef schema consult** (`adf9a6b1...`) — ConnectionRefused + retry loop. **Parked** until B3 + B4 land (founder directive). Fallback options if next attempt also stalls: PM runs schema analysis directly via Supabase Management API, or backlog ticket parked until post-admin-panel sprint.
+
+After B5 landed, switched to **narrow-scope sequential dispatch**: Hamza B3 alone (`feat/driver-pickup-confirmation-b3`) running with 40-call cap, single-feature scope (pickup screen + code verify + photo upload + support CTAs + failure-CTA stub only). B4 queued — do not dispatch until B3 lands.
+
+### Resilience rules added today (now permanent protocol)
+1. **Stream watchdog** (Mapbox/Playwright compile, silent `browser_wait_for`) → falls under issue #99; agent briefs include the option-(a) escalation rule; founder accepts deferred Phase 5 trade-off.
+2. **ConnectionRefused + retry loop** (proxy / API connectivity from agent sandbox) → DO NOT auto-retry. Parking the task is safer than burning 10 retries that all fail the same way.
+3. **Cluster-stall sequential rule** (>1 agent failure in <2h) → switch to sequential + narrow scope + PM-direct fallback. Resume parallel only after session restart confirms stability. See `feedback_cluster_stall_sequential_dispatch.md`.
+4. **PM-direct landing** is acceptable attribution when an agent is sandbox-blocked or stalls on last-mile mechanics. Same precedent as A2 fix `f531550` and B5 fix `1695cc4`.
+
+### What's next (founder-owned + PM-owned items)
+- Founder manual spot-check PR #96 + PR #100 on localhost (24h, founder-owned).
+- B3 PR landing (Hamza dispatched, awaiting completion or stall).
+- B4 dispatch (queued after B3 lands).
+- Youssef schema consult re-dispatch (after B3 + B4 land, per founder).
+- Item 3 (`back-button-flow.md` review → A3 gate) is founder-owned, separate.
+
+### Today's process learnings logged to user memory
+- `feedback_bundle_docs_with_code.md` — bundle session-learning docs with the related code PR, not separate chore PRs.
+- `feedback_watchdog_escalation_in_briefs.md` — embed the stop-and-switch-to-option-a rule in every Mapbox/driver dispatch brief.
+- `feedback_cluster_stall_sequential_dispatch.md` — on cluster-stall days, sequential + narrow + PM-direct.
+- `feedback_anas_merge.md` — rewritten: GitHub MCP tools for all PR/CI ops; no `.env.local` grep; `gh` CLI not installed; check-runs gap documented.
+
+---
+
+## Sprint 2 closure — 2026-04-27/28 — TAG: infra-unstable session (still applies)
+
+> **Session tag for next-day PM:** Infra-unstable session continues to apply. 5 subagent stalls across 5 dispatches in ~10h wall-clock (Hamza A2 sandbox-blocked; Hamza B3+B4 stream idle; Hamza B5 600s watchdog; Hamza B3-narrow commit-blocked; Hamza B4-narrow commit-blocked; Youssef ConnectionRefused). PM-direct landed 4 of 5 PRs from this session's code work. Default tomorrow's first dispatch to a small stability probe (e.g. Saad post-Sprint-2 retest at narrow scope) before resuming any parallel work.
+
+### Sprint 2 — fully closed, driver lifecycle end-to-end shippable
+- **PR #100 (B5 — success page real data)** MERGED with founder override — `1695cc4`. PM-direct land after Hamza B5 watchdog stall. `lib/db/driver.ts` `getDeliverySummary` + driver-ownership enforcement; computed duration prefers `delivered_at - accepted_at` with `estimated_duration_min` fallback; `'—'` placeholder for missing values.
+- **PR #101 (B3 — pickup confirmation + collection page)** MERGED with founder override — `add37876`. Hamza dispatched narrow-scope (40-call cap, 30-call early-stop), code complete, commit blocked at sandbox layer → PM-direct commit + push + PR. `confirmCollectionAction` validates against `delivery.merchant_pickup_code` (text on deliveries row, authoritative per PLZ-058) — no longer reads `delivery.order.merchant_pickup_code` (integer). 16 new i18n keys under `driver.collect.*`. Support CTA + failure-CTA stub wired to `/driver/livraisons/[id]/issue`.
+- **PR #103 (B4 — delivery failure form i18n + validation)** MERGED with founder override — `9c8fcc4`. Same Hamza narrow-scope-then-commit-blocker pattern as B3. `/driver/livraisons/[id]/issue` route already existed from PLZ-057 — Hamza filled the gaps: `driver.issue.*` namespace (35 keys × 2 locales), 6-value enum whitelist (`client_absent | client_refuse | wrong_address | damaged | payment_issue | other`), 500-char cap, "other requires notes" guard, ARIA `radiogroup` wiring.
+
+### Founder-ratified naming + enum precedents (now in conventions.md)
+- **`issue_*` columns kept** (not renamed to `failure_*` per brief). Rule locked: "When an existing schema convention exists, agents follow it; only PM can authorize a rename, and renames need a real reason beyond word choice." Added to `.agents/shared/conventions.md` as new "Schema naming — never rename live columns to match brief wording" section. Origin event referenced: PR #103.
+- **6-value `issue_type` enum kept** (includes `payment_issue`, brief had only 5). The brief was incomplete, not the schema; preserving the live enum constraint was correct.
+
+### Legacy data finding — backfill applied + Sprint 3 ticket filed
+- Audit found 5 `deliveries.merchant_pickup_code IS NULL` rows: 1 in-flight (`accepted`, test fixture `TEST-DRIVER-001` / `d1342df2-3365-4e53-80d4-1d8b60dcc6da`) + 2 `delivered` + 2 `failed`.
+- In-flight row backfilled in-place to `'123456'` via Management API UPDATE before dispatching B4. Verified post-update: zero in-flight NULLs.
+- 4 terminal NULL rows tracked in **issue #102** (P3 / data-hygiene / tech-debt). Plan: bundle backfill migration with Youssef's deferred schema consult (`orders.merchant_pickup_code` int vs `deliveries.merchant_pickup_code` text — the deeper inconsistency).
+- This stuck row also seeded an admin-panel ops gap: `TEST-DRIVER-001` sat in `accepted` for 12 days with no operator alert. Logged to `docs/admin/ops-inventory-seed.md` as the first entry — "Stuck deliveries — non-terminal states with no recent state transition" — with proposed view, per-state stuck thresholds, and Slack alert plan. Antonio + PM build on this during Phase 1 admin-panel ops inventory.
+
+### Issue #99 still open (Anas watchdog infrastructure)
+P1 tech-debt remains the gating reason for accepting deferred Phase 5 on every Mapbox/driver-flow PR this session. Until #99 is resolved, the watchdog escalation rule in `feedback_watchdog_escalation_in_briefs.md` continues to be embedded in every dispatch brief.
+
+### What's parked for tomorrow's clean session (founder directive — DO NOT dispatch tonight)
+- **Saad post-Sprint-2 retest** — first dispatch tomorrow as the stability probe. If clean → re-enable parallel dispatch.
+- **Youssef schema consult** — second dispatch tomorrow. Schema unification is research-only and benefits from a stable agent run; today's infra hostility makes it likely to ConnectionRefused again.
+- **A3 implementation (back-button flow)** — gated on founder reading `back-button-flow.md` and replying with the gate decision.
+- **Admin panel Phase 1 ops inventory in earnest** — PM + Antonio. Seeded today (`docs/admin/ops-inventory-seed.md`); promotion to Phase 1 sprint tickets happens during planning.
+- **Sprint 3 polish** as capacity allows.
+
+### Founder-owned items tonight (post-merge spot-checks)
+- PR #96 (A2 money-bug fix) on localhost
+- PR #100 (B5) + #101 (B3) + #103 (B4) end-to-end as one driver lifecycle pass on localhost
+- Read `back-button-flow.md` → A3 gate decision
+
+### Resilience protocol now permanent in user memory
+1. **Stream watchdog** (Mapbox/Playwright compile, silent `browser_wait_for`) → option-(a) escalation embedded in every dispatch brief; founder accepts deferred Phase 5 trade-off.
+2. **ConnectionRefused + retry loop** → DO NOT auto-retry; park the task.
+3. **Cluster-stall sequential rule** (>1 agent failure in <2h) → sequential + narrow + PM-direct fallback. Resume parallel only after a stability probe on the next session.
+4. **PM-direct landing** is acceptable attribution when an agent is sandbox-blocked or stalls on last-mile mechanics. Precedent: A2 `f531550`, B5 `1695cc4`, B3 `add37876`, B4 `9c8fcc4`.
+
+### Stopping point
+Sprint 2 fully closed. Awaiting founder spot-checks + A3 gate decision. Tomorrow's session opens with Saad retest as the stability probe.
+
+---
+
+## Session — 2026-04-28 (start) — TAG REMOVED: infra recovered
+
+### Stability probe — CLEAN
+Saad-persona probe (`a750abc17d75e0211`) ran in ~30s with 4/10 tool calls. No stalls, no retries triggered, watchdog did not trip, ToolSearch loaded Playwright schemas cleanly. Persona file loaded fine. Local dev server was not running so the navigate returned `ERR_CONNECTION_REFUSED` and landed on Chrome's error page — that is a valid probe outcome since the probe tested *infrastructure*, not app uptime.
+
+### Operating defaults today
+- **Infra-unstable tag REMOVED** — yesterday's session-close tag no longer applies.
+- **Parallel dispatch re-enabled** as default.
+- **Fail-fast hand-back rule** kept regardless (good hygiene). 30-call early-stop / 40-call hard cap continues to be embedded in dispatch briefs.
+- **No retries on stream watchdog or ConnectionRefused** still applies (issue #99 not yet resolved; the resilience rules in user memory remain permanent).
+
+### Network blip during PM working time
+Founder noted network was briefly down during this session's start; came back online before any subagent work was in flight. No impact on the probe (already returned). Logged as a single point-in-time observation, not a pattern.

--- a/.agents/shared/conventions.md
+++ b/.agents/shared/conventions.md
@@ -209,6 +209,26 @@ refactor(dashboard): extract revenue chart into separate component
 
 ---
 
+## Schema naming — never rename live columns to match brief wording
+
+When a brief specifies one column name and the existing DB schema uses a different one, **follow the existing schema, not the brief**.
+
+### Rule
+- Existing live columns are the source of truth
+- Briefs reflect a writer's word choice, not a schema requirement
+- Renames are migration cost (alter table, RLS policies, type regen, every consuming query) with zero user-facing benefit
+- Only the PM agent can authorize a rename — and the rename needs a real reason beyond word choice (e.g. ambiguity, conflict with reserved word, factually wrong domain term)
+
+### How to apply
+- If you spot a brief/schema mismatch: implement against the schema, flag the mismatch in the PR body for PM review
+- Do not stop the dispatch to ask — keep moving, surface the gap in the handoff
+- Do not invent shadow columns to satisfy the brief if the schema already covers it (e.g. `failed_at` when `status='failed' + created_at` is sufficient)
+
+### Origin
+PR #103 (B4 delivery failure form): brief used `failure_reason / failure_note / failure_photo_url / failed_at`, but PLZ-057 had already shipped `issue_type / issue_notes / issue_photo_url` + `status='failed'`. Hamza correctly preserved the live convention. Founder ratified — locked here so future agents default correctly without burning cycles asking.
+
+---
+
 ## What to do when conventions conflict with speed
 
 At MVP stage, if following a convention would block shipping for more than a day, flag it to the PM agent. The PM agent escalates to the founder for a judgment call. Never silently skip a convention — always flag it explicitly.

--- a/docs/admin/ops-inventory-seed.md
+++ b/docs/admin/ops-inventory-seed.md
@@ -1,0 +1,66 @@
+# Admin Panel — Ops Inventory (seed)
+
+This document seeds the operational-monitoring inventory for the admin panel. It captures the dashboards, alerts, and oversight surfaces that the Plaza ops team needs to run the platform day-to-day. It is the working starting point for **Phase 1 admin-panel ops inventory** (Antonio + PM).
+
+Each entry is a candidate observability surface, not a committed deliverable. PM and Antonio prioritise during Phase 1 planning; some will land as cards on the existing admin home, others as dedicated views, others as scheduled alerts.
+
+---
+
+## How to use this document
+
+- **Add an entry** when an incident, audit, or operational gap reveals that ops has no visibility into a category of data. Capture the original triggering event so future PMs can judge the entry's load-bearing weight.
+- **Promote an entry** to a build ticket once it's been included in a Phase 1 sprint — link the ticket here.
+- **Retire an entry** if the underlying gap has been closed by a different surface (e.g. a Supabase scheduled function alert replaces a manual admin view).
+
+Entries are grouped by data category, not by priority. Priority is assigned during Phase 1 planning.
+
+---
+
+## 1. Stuck deliveries — non-terminal states with no recent state transition
+
+**Status:** seed entry — Phase 1 candidate, not yet ticketed
+**Triggering event:** 2026-04-27 — fixture `TEST-DRIVER-001` (`deliveries.id = d1342df2-3365-4e53-80d4-1d8b60dcc6da`) sat in `accepted` status for 12 days with no operator alert. Discovered only because the B3 dispatch (PR #101) audit surfaced it as a NULL `merchant_pickup_code` row blocking the new runtime path.
+
+### What's missing
+
+Ops has no view that answers "which deliveries are non-terminal but haven't moved in N minutes?" There's no dashboard, no alert, no scheduled email. The only way to find a stuck delivery today is a manual SQL query against the Management API.
+
+### Proposed surface
+
+- **Admin panel view:** "Stuck deliveries" — table of rows where `status NOT IN ('delivered','failed','cancelled')` AND `updated_at < NOW() - INTERVAL '30 minutes'`.
+- **Columns:** delivery id, status, time-since-last-transition, driver name (if assigned), merchant name, customer phone, "open in admin" link.
+- **Actions:** force-cancel (with reason note), reassign to driver, contact driver/customer.
+- **Default sort:** longest-stuck first.
+
+### Threshold suggestions (to validate during Phase 1)
+
+| State | Stuck threshold | Reasoning |
+|---|---|---|
+| `pending` (no driver assigned) | 5 min | Dispatch should match within seconds; 5 min = real backlog |
+| `assigned` (offered to driver) | 2 min | Driver has 60s to accept; 2 min = stuck offer |
+| `accepted` (driver en route to merchant) | 30 min | Most pickups complete within 20 min; 30 min = wandering driver or real-world block |
+| `picked_up` (en route to customer) | 45 min | Generous to cover Casa traffic; tighten after we have data |
+| `at_customer` (arrived, no confirmation) | 10 min | Driver should confirm or fail within minutes |
+
+### Alerting
+
+In addition to the visual dashboard, push a Slack alert to ops when ANY delivery crosses its state-specific threshold. Alert content includes the delivery ID, the time-stuck, the assigned driver's last-known location, and a deep link to the admin row.
+
+### Open questions for Phase 1 planning
+
+- Do we want per-merchant thresholds (high-value merchants alert sooner)?
+- Do we auto-cancel after some hard upper bound (e.g. 4h `accepted` with no movement) or always wait for human review?
+- Where do test fixtures sit in this view? Should a `is_test_fixture` column hide them from the alert path while keeping them visible in the dashboard?
+
+---
+
+## (Add new entries below as gaps surface during ops review)
+
+---
+
+## Cross-references
+
+- `.agents/pm/memory.md` — Sprint 2 closure (2026-04-27/28) for the original triggering audit
+- Issue #102 — `merchant_pickup_code` legacy NULL rows (related data-hygiene work)
+- `.agents/admin/CLAUDE.md` — admin agent operating notes (when created)
+- Antonio's `back-button-flow.md` — admin UI map (Phase 1 reference)


### PR DESCRIPTION
## Summary

Sprint 2 closure deliverables bundled together (docs-only, no production code):

- **`.agents/shared/conventions.md`** — adds `Schema naming — never rename live columns to match brief wording` rule, ratified by the founder during PR #103 review.
- **`.agents/pm/memory.md`** — Sprint 2 closure entry covering PRs #100/#101/#103, founder-ratified precedents, and the 4-row legacy backfill plan tracked in issue #102.
- **`docs/admin/ops-inventory-seed.md`** — new seed doc for Phase 1 admin-panel ops inventory; first entry is the `stuck-deliveries` monitor surfaced by the TEST-DRIVER-001 12-day stuck row.

## Why

Founder explicitly approved each item as part of Sprint 2 closure and asked that the schema-naming rule be locked in conventions.md so future agents don't burn cycles re-asking. Bundling these into a single chore PR keeps the closure paper trail in git rather than scattered across stashes.

## Test plan

- [ ] Read each doc on the PR diff view for clarity
- [ ] Confirm conventions.md rule is unambiguous for future agents
- [ ] Confirm pm/memory.md entry captures the right load-bearing details

🤖 Generated with [Claude Code](https://claude.com/claude-code)